### PR TITLE
Fix Maturin config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires = ["maturin>=1.5"]
 build-backend = "maturin"
 [tool.maturin]
 manifest-path = "rust_extension/Cargo.toml"
-python-source = "rust_pkg"
-module-name = "rust_pkg._rust_pkg_rs"
+python-source = "femtologging"
+module-name = "femtologging._femtologging_rs"
 python-packages = ["femtologging"]
 


### PR DESCRIPTION
## Summary
- point Maturin at the correct package name so the Rust extension builds

## Testing
- `ruff check`
- `ruff format --check`
- `pyright`
- `cargo fmt --manifest-path rust_extension/Cargo.toml -- --check`
- `cargo clippy --manifest-path rust_extension/Cargo.toml -- -D warnings`
- `cargo test --manifest-path rust_extension/Cargo.toml`
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_68498af984c08322a032e68f3900807a