### PR TITLE
Add roadmap to port picologging

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,14 @@
+# Roadmap: Port picologging to Rust/PyO3
+
+- [ ] Review picologging codebase and isolate core logging features
+- [ ] Evaluate dependencies and identify Rust equivalents
+- [ ] Design Rust crate layout and expose PyO3 bindings
+- [ ] Implement basic logger in Rust with matching Python API
+- [ ] Integrate Rust extension into Python packaging workflow
+- [ ] Port formatting and handler components to Rust
+- [ ] Add concurrency support and thread safety guarantees
+- [ ] Benchmark against picologging and optimize hot paths
+- [ ] Provide unit and integration tests for all features
+- [ ] Set up continuous integration for Rust and Python tests
+- [ ] Write migration guide for existing picologging users
+- [ ] Publish femtologging package and update documentation


### PR DESCRIPTION
## Summary
- outline steps to port picologging to Rust/PyO3

## Testing
- `markdownlint docs/roadmap.md`
- `nixie docs/roadmap.md`


------
https://chatgpt.com/codex/tasks/task_e_68498d946a0083228f1aeda3d4771314