### PR TITLE
Add docs about picologging features

### DIFF
--- a/docs/core_features.md
+++ b/docs/core_features.md
@@ -1,0 +1,50 @@
+# Picologging Core Features
+
+This document summarizes the key features of the `picologging` library.
+Items are ordered by priority for the Rust port.
+
+## 1. Logging API Compatibility
+
+- Drop‑in replacement for the standard `logging` module
+- Functions include `getLogger`, `basicConfig`, and common level helpers
+- Supports standard log levels and hierarchical names
+
+## 2. Core Data Structures
+
+- **Logger** manages levels and handlers
+- **LogRecord** represents a log event
+- **Handler** defines an output destination
+- **Formatter** and **FormatStyle** shape messages
+- **Filterer** performs basic record filtering
+- **Manager** maintains the logger tree
+
+## 3. Built‑in Handlers
+
+- **StreamHandler** and **FileHandler** for basic output
+- **RotatingFileHandler** and **TimedRotatingFileHandler** for rotation
+- **WatchedFileHandler** for logrotate‑style changes
+- **QueueHandler** and **QueueListener** for async logging
+- **BufferingHandler** and **MemoryHandler** for in‑memory buffering
+- **SocketHandler** for network logging
+
+## 4. Configuration Helpers
+
+- `basicConfig` convenience function
+- `dictConfig` (without the `incremental` option)
+- Formatting styles: percent, `str.format`, and `string.Template`
+
+## 5. Limitations
+
+- Custom log levels and log record factories are not supported
+- `LogRecord` always captures process and thread IDs
+- Some advanced features are omitted to boost speed
+
+## Prioritization for Rust Port
+
+1. **Logging API Compatibility** – essential drop‑in behavior
+2. **Core Data Structures** – backbone of the system
+3. **StreamHandler** and **FileHandler** – basic output paths
+4. **Formatter** and styles – human‑readable logs
+5. **Rotating** and **TimedRotating** handlers – common operations
+6. **Queue** and **Buffering** handlers – high‑throughput support
+7. **SocketHandler** and **WatchedFileHandler** – lower priority

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap: Port picologging to Rust/PyO3
 
-- [ ] Review picologging codebase and isolate core logging features
+- [x] Review picologging codebase and isolate core logging features
 - [ ] Evaluate dependencies and identify Rust equivalents
 - [ ] Design Rust crate layout and expose PyO3 bindings
 - [ ] Implement basic logger in Rust with matching Python API


### PR DESCRIPTION
## Summary
- describe picologging's core logging features and Rust port priorities
- check off the roadmap item for reviewing the picologging codebase

## Testing
- `markdownlint docs/core_features.md`
- `nixie docs/core_features.md`
- `markdownlint docs/roadmap.md`
- `nixie docs/roadmap.md`


------
https://chatgpt.com/codex/tasks/task_e_68498eea4d0083228e197d208a9e5455