### PR TITLE
Implement parameterized tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 Example package generated from this Copier template.
 
-This variant includes a small Rust extension.
+This variant includes a small Rust extension built with [PyO3](https://pyo3.rs/)
+and packaged using [maturin](https://maturin.rs/). Run `pip install .` or
+`make build` to compile the extension.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Example package generated from this Copier template.
 
-This variant includes a small Rust extension built with [PyO3](https://pyo3.rs/)
-and packaged using [maturin](https://maturin.rs/). Run `pip install .` or
-`make build` to compile the extension.
+This variant includes a small Rust extension built with
+[PyO3](https://pyo3.rs/) and packaged using
+[maturin](https://maturin.rs/). Ensure the
+[Rust tool‑chain](https://www.rust-lang.org/tools/install) is installed, then
+run `pip install .` or `make build` to compile the extension.

--- a/docs/dependency-analysis.md
+++ b/docs/dependency-analysis.md
@@ -21,8 +21,10 @@ implementation:
   replaces the C++ extension used by picologging.
 - **crossbeam-channel** (v0.5.15) is recommended as the baseline synchronous
   multi-producer, single-consumer queue for handler threads. Alternatives like
-  `flume` or `tokio::sync::mpsc` may be benchmarked later. Version 0.5.15 avoids
-  the double-free vulnerability disclosed in RUSTSEC-2025-0024.
+`flume` or `tokio::sync::mpsc` may be benchmarked later. Version 0.5.15 avoids
+the double-free vulnerability disclosed in RUSTSEC-2025-0024. The current
+implementation uses a bounded channel with a capacity of 1024 messages so that
+log producers cannot exhaust memory if the consumer thread stalls.
 - **rstest** is used as a development dependency to provide concise test
   fixtures and parameterized tests.
 - **serde** will power any structured data serialization needed for network

--- a/docs/dependency-analysis.md
+++ b/docs/dependency-analysis.md
@@ -5,31 +5,31 @@ This note tracks third-party libraries required for the Rust port of
 
 ## Python project
 
-The current Python package has no runtime dependencies. Development
-tools are `pytest`, `ruff` and `pyright` as configured in
-`pyproject.toml`. Static type checking uses the `ty` CLI. A
-`Makefile` in the project root wraps these tools with convenient
-targets (`fmt`, `check-fmt`, `lint`, `test`, `build` and `release`).
-The `tools` target ensures commands like `ruff` and `ty` are present.
+The current Python package has no runtime dependencies. Development tools are
+`pytest`, `ruff` and `pyright` as configured in `pyproject.toml`. Static type
+checking uses the `ty` CLI. A `Makefile` in the project root wraps these tools
+with convenient targets (`fmt`, `check-fmt`, `lint`, `test`, `build` and
+`release`). The `tools` target ensures commands like `ruff` and `ty` are
+present.
 
 ## Rust ecosystem
 
-The design document discusses several crates that map to parts of the
-CPython implementation:
+The design document discusses several crates that map to parts of the CPython
+implementation:
 
-- **PyO3** provides bindings so the Rust library can be imported from
-  Python. It replaces the C++ extension used by picologging.
+- **PyO3** provides bindings so the Rust library can be imported from Python. It
+  replaces the C++ extension used by picologging.
 - **crossbeam-channel** (v0.5.15) is recommended as the baseline synchronous
-  multi-producer, single-consumer queue for handler threads. Alternatives
-  like `flume` or `tokio::sync::mpsc` may be benchmarked later. Version
-  0.5.15 avoids the double-free vulnerability disclosed in
-  RUSTSEC-2025-0024.
-- **serde** will power any structured data serialization needed for
-  network handlers or configuration files. This crate is not yet listed in
-  `Cargo.toml` because serialization features are planned for a later phase.
-- **chrono** or `time` will supply timestamp utilities for
-  `FemtoLogRecord`. These dependencies will be added once timestamp
-  formatting is implemented.
+  multi-producer, single-consumer queue for handler threads. Alternatives like
+  `flume` or `tokio::sync::mpsc` may be benchmarked later. Version 0.5.15 avoids
+  the double-free vulnerability disclosed in RUSTSEC-2025-0024.
+- **rstest** is used as a development dependency to provide concise test
+  fixtures and parameterized tests.
+- **serde** will power any structured data serialization needed for network
+  handlers or configuration files. This crate is not yet listed in `Cargo.toml`
+  because serialization features are planned for a later phase.
+- **chrono** or `time` will supply timestamp utilities for `FemtoLogRecord`.
+  These dependencies will be added once timestamp formatting is implemented.
 
 These choices prioritize crates with strong community adoption and good
 performance characteristics.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,8 +12,8 @@ that design.
 - [x] Review picologging codebase and isolate core logging features
 - [x] Evaluate dependencies and identify Rust equivalents
 - [x] Design Rust crate layout and expose PyO3 bindings
-- [ ] Implement basic logger in Rust with matching Python API
-- [ ] Integrate Rust extension into Python packaging workflow
+- [x] Implement basic logger in Rust with matching Python API
+- [x] Integrate Rust extension into Python packaging workflow
 - [ ] Port formatting and handler components to Rust
 - [ ] Add concurrency support and thread safety guarantees
 - [ ] Benchmark against picologging and optimise hot paths

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -1,5 +1,7 @@
 # Rust Extension
 
 This variant includes a small Rust extension built with
-[PyO3](https://pyo3.rs/). The extension exposes a `hello()` function implemented
-in Rust.
+[PyO3](https://pyo3.rs/). The extension exposes a `hello()` function and the
+`FemtoLogger` class implemented in Rust. Packaging is handled by
+[maturin](https://maturin.rs/), which is configured via `pyproject.toml` so that
+`pip install .` builds the extension automatically.

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -5,3 +5,5 @@ This variant includes a small Rust extension built with
 `FemtoLogger` class implemented in Rust. Packaging is handled by
 [maturin](https://maturin.rs/), which is configured via `pyproject.toml` so that
 `pip install .` builds the extension automatically.
+Windows users may need the MSVC build tools installed or to run maturin with
+`--compatibility windows`.

--- a/docs/rust-multithreaded-logging-framework-for-python-design.md
+++ b/docs/rust-multithreaded-logging-framework-for-python-design.md
@@ -255,6 +255,10 @@ instance, `crossbeam-channel` is a popular choice, but alternatives like `flume`
 claim higher performance in some scenarios and offer asynchronous capabilities
 8, while `thingbuf` focuses on lock-free MPSC channels built on a lock-free
 queue.7 The selection directly impacts throughput and latency.
+For the early experimental release, `femtologging` defaults to a bounded
+`crossbeam-channel` with a capacity of 1024 records. This guards against
+unbounded memory growth when producers outpace the consumer thread. Later
+versions may expose the channel type and capacity as configuration options.
 
 ## 4. Leveraging Rust's Strengths
 

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -13,6 +13,9 @@ document provides a comprehensive exploration of `rstest`, from fundamental
 concepts to advanced techniques, enabling Rust developers to write cleaner, more
 expressive, and robust tests.
 
+`femtologging` uses `rstest` extensively for its logger tests, enabling concise
+fixtures and parameterized cases without manual setup code.
+
 ## I. Introduction to `rstest` and Test Fixtures in Rust
 
 ### A. What are Test Fixtures and Why Use Them?
@@ -1182,13 +1185,13 @@ The following table summarizes key differences:
 **Table 1:** `rstest` **vs. Standard Rust** `#[test]` **for Fixture Management
 and Parameterization**
 
-| Feature | Standard `#[test]` Approach | `rstest` Approach |
-|---------|-----------------------------|------------------|
-| **Fixture Injection** | Manual calls to setup functions within each test. | Fixture name as argument in `#[rstest]` function; fixture defined with `#[fixture]`. |
-| **Parameterized Tests (Specific Cases)** | Loop inside one test or multiple distinct `#[test]` functions. | `#[case(...)]` attributes on `#[rstest]` function. |
-| **Parameterized Tests (Value Combinations)** | Nested loops inside one test or complex manual generation. | `#[values(...)]` attributes on arguments of `#[rstest]` function. |
-| **Async Fixture Setup** | Manual `async` block and `.await` calls inside test. | `async fn` fixtures with `#[future]` and `#[awt]` for ergonomic `.await`ing. |
-| **Reusing Parameter Sets** | Manual duplication of cases or custom helper macros. | `rstest_reuse` crate with `#[template]` and `#[apply]` attributes. |
+| Feature                                      | Standard `#[test]` Approach                                    | `rstest` Approach                                                                    |
+| -------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Fixture Injection**                        | Manual calls to setup functions within each test.              | Fixture name as argument in `#[rstest]` function; fixture defined with `#[fixture]`. |
+| **Parameterized Tests (Specific Cases)**     | Loop inside one test or multiple distinct `#[test]` functions. | `#[case(...)]` attributes on `#[rstest]` function.                                   |
+| **Parameterized Tests (Value Combinations)** | Nested loops inside one test or complex manual generation.     | `#[values(...)]` attributes on arguments of `#[rstest]` function.                    |
+| **Async Fixture Setup**                      | Manual `async` block and `.await` calls inside test.           | `async fn` fixtures with `#[future]` and `#[awt]` for ergonomic `.await`ing.         |
+| **Reusing Parameter Sets**                   | Manual duplication of cases or custom helper macros.           | `rstest_reuse` crate with `#[template]` and `#[apply]` attributes.                   |
 
 This comparison highlights how `rstest`'s attribute-based, declarative approach
 streamlines common testing patterns, reducing manual effort and improving the
@@ -1321,22 +1324,21 @@ resources are recommended:
   community experiences with `rstest`.19
 
 The following table provides a quick reference to some of the key attributes
-provided by `rstest`:
-**Table 2: Key** `rstest` **Attributes Quick Reference**
+provided by `rstest`: **Table 2: Key** `rstest` **Attributes Quick Reference**
 
-| Attribute | Core Purpose |
-|-----------|--------------|
-| `#[rstest]` | Marks a function as an `rstest` test; enables fixture injection and parameterization. |
-| `#[fixture]` | Defines a function that provides a test fixture (setup data or services). |
-| `#[case(...)]` | Defines a single parameterized test case with specific input values. |
-| `#[values(...)]` | Defines a list of values for an argument, generating tests for each value or combination. |
-| `#[once]` | Marks a fixture to be initialized only once and shared across tests. |
-| `#[future]` | Simplifies async argument types by removing `impl Future` boilerplate. |
-| `#[awt]` | Automatically `.await`s future arguments in async tests. |
-| `#[from(original_name)]` | Allows renaming an injected fixture argument in the test function. |
-| `#[with(...)]` | Overrides default arguments of a fixture for a specific test. |
-| `#[default(...)]` | Provides default values for arguments within a fixture function. |
-| `#[timeout(...)]` | Sets a timeout for an asynchronous test. |
+| Attribute                       | Core Purpose                                                                              |
+| ------------------------------- | ----------------------------------------------------------------------------------------- |
+| `#[rstest]`                     | Marks a function as an `rstest` test; enables fixture injection and parameterization.     |
+| `#[fixture]`                    | Defines a function that provides a test fixture (setup data or services).                 |
+| `#[case(...)]`                  | Defines a single parameterized test case with specific input values.                      |
+| `#[values(...)]`                | Defines a list of values for an argument, generating tests for each value or combination. |
+| `#[once]`                       | Marks a fixture to be initialized only once and shared across tests.                      |
+| `#[future]`                     | Simplifies async argument types by removing `impl Future` boilerplate.                    |
+| `#[awt]`                        | Automatically `.await`s future arguments in async tests.                                  |
+| `#[from(original_name)]`        | Allows renaming an injected fixture argument in the test function.                        |
+| `#[with(...)]`                  | Overrides default arguments of a fixture for a specific test.                             |
+| `#[default(...)]`               | Provides default values for arguments within a fixture function.                          |
+| `#[timeout(...)]`               | Sets a timeout for an asynchronous test.                                                  |
 | `#[files("glob_pattern", ...)]` | Injects file paths (or contents, with `mode=`) matching a glob pattern as test arguments. |
 
 By mastering `rstest`, Rust developers can significantly elevate the quality and

--- a/femtologging/__init__.py
+++ b/femtologging/__init__.py
@@ -7,7 +7,8 @@ PACKAGE_NAME = "femtologging"
 try:  # pragma: no cover - Rust optional
     rust = __import__(f"_{PACKAGE_NAME}_rs")
     hello = rust.hello  # type: ignore[attr-defined]
+    FemtoLogger = rust.FemtoLogger  # type: ignore[attr-defined]
 except ModuleNotFoundError:  # pragma: no cover - Python fallback
-    from .pure import hello
+    from .pure import FemtoLogger, hello
 
-__all__ = ["hello"]
+__all__ = ["FemtoLogger", "hello"]

--- a/femtologging/pure.py
+++ b/femtologging/pure.py
@@ -1,6 +1,19 @@
 from __future__ import annotations
 
 
+class FemtoLogger:
+    """Simplistic Python implementation used when the Rust module is missing."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def log(self, level: str, message: str) -> str:
+        return f"{self.name}: {level} - {message}"
+
+
 def hello() -> str:
     """Return a friendly greeting from Python."""
     return "hello from Python"
+
+
+__all__ = ["FemtoLogger", "hello"]

--- a/femtologging/pure.py
+++ b/femtologging/pure.py
@@ -8,6 +8,7 @@ class FemtoLogger:
         self.name = name
 
     def log(self, level: str, message: str) -> str:
+        """Return the formatted log message."""
         return f"{self.name}: {level} - {message}"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dev = ["pytest", "ruff", "pyright"]
 
 [tool.pyright]
 pythonVersion = "3.13"
-strict = true
+typeCheckingMode = "strict"
 include = ["femtologging"]
 
 [tool.ruff]

--- a/rust_extension/Cargo.lock
+++ b/rust_extension/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,7 +50,109 @@ version = "0.1.0"
 dependencies = [
  "crossbeam-channel",
  "pyo3",
+ "rstest",
 ]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "heck"
@@ -70,6 +181,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memoffset"
@@ -108,6 +225,18 @@ dependencies = [
  "smallvec",
  "windows-targets",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-atomic"
@@ -206,10 +335,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
+name = "slab"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"

--- a/rust_extension/Cargo.toml
+++ b/rust_extension/Cargo.toml
@@ -10,3 +10,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 pyo3 = { version = "0.20", features = ["extension-module"] }
 crossbeam-channel = "0.5.15"
+
+[dev-dependencies]
+rstest = "0.18"

--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -3,7 +3,8 @@ use pyo3::prelude::*;
 mod log_record;
 mod logger;
 
-use logger::FemtoLogger;
+pub use log_record::FemtoLogRecord;
+pub use logger::FemtoLogger;
 
 #[pyfunction]
 fn hello() -> &'static str {

--- a/rust_extension/src/logger.rs
+++ b/rust_extension/src/logger.rs
@@ -13,7 +13,6 @@ pub struct FemtoLogger {
     /// Identifier used to distinguish log messages from different loggers.
     name: String,
     tx: Option<Sender<FemtoLogRecord>>,
-    #[allow(dead_code)]
     handle: Option<JoinHandle<()>>,
 }
 
@@ -45,7 +44,9 @@ impl FemtoLogger {
         let record = FemtoLogRecord::new(level, message);
         let msg = format!("{}: {}", self.name, record);
         if let Some(tx) = &self.tx {
-            let _ = tx.send(record);
+            if tx.send(record).is_err() {
+                eprintln!("Warning: failed to send log record to background thread");
+            }
         }
         msg
     }

--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -4,6 +4,8 @@ use rstest::rstest;
 #[rstest]
 #[case("core", "INFO", "hello", "core: INFO - hello")]
 #[case("sys", "ERROR", "fail", "sys: ERROR - fail")]
+#[case("", "INFO", "", ": INFO - ")]
+#[case("core", "WARN", "⚠", "core: WARN - ⚠")]
 fn log_formats_message(
     #[case] name: &str,
     #[case] level: &str,

--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -1,0 +1,15 @@
+use _femtologging_rs::FemtoLogger;
+use rstest::rstest;
+
+#[rstest]
+#[case("core", "INFO", "hello", "core: INFO - hello")]
+#[case("sys", "ERROR", "fail", "sys: ERROR - fail")]
+fn log_formats_message(
+    #[case] name: &str,
+    #[case] level: &str,
+    #[case] message: &str,
+    #[case] expected: &str,
+) {
+    let logger = FemtoLogger::new(name.to_string());
+    assert_eq!(logger.log(level, message), expected);
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+# Add project root to sys.path so femtologging can be imported without hacks.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -11,6 +11,22 @@ from femtologging import FemtoLogger
     [
         ("core", "INFO", "hello", "core: INFO - hello"),
         ("sys", "ERROR", "fail", "sys: ERROR - fail"),
+        # Edge cases:
+        ("", "INFO", "empty name", ": INFO - empty name"),
+        ("core", "", "empty level", "core:  - empty level"),
+        ("core", "INFO", "", "core: INFO - "),
+        ("", "", "", ":  - "),
+        # Non-ASCII characters
+        ("核", "信息", "你好", "核: 信息 - 你好"),
+        ("core", "INFO", "¡Hola!", "core: INFO - ¡Hola!"),
+        ("система", "ОШИБКА", "не удалось", "система: ОШИБКА - не удалось"),
+        # Very long strings
+        (
+            "n" * 1000,
+            "L" * 1000,
+            "m" * 1000,
+            f'{"n"*1000}: {"L"*1000} - {"m"*1000}',
+        ),
     ],
 )
 def test_log_formats_message(

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,12 +1,9 @@
+"""Tests for :class:`FemtoLogger`."""
+
 from __future__ import annotations
 
-from pathlib import Path
-import sys
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
-from femtologging import FemtoLogger
 import pytest
+from femtologging import FemtoLogger
 
 
 @pytest.mark.parametrize(

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from femtologging import FemtoLogger
+import pytest
+
+
+@pytest.mark.parametrize(
+    "name, level, message, expected",
+    [
+        ("core", "INFO", "hello", "core: INFO - hello"),
+        ("sys", "ERROR", "fail", "sys: ERROR - fail"),
+    ],
+)
+def test_log_formats_message(
+    name: str, level: str, message: str, expected: str
+) -> None:
+    logger = FemtoLogger(name)
+    assert logger.log(level, message) == expected


### PR DESCRIPTION
## Summary
- parameterize the Rust logger test with rstest
- parameterize the Python logger test with pytest

## Testing
- `ruff check femtologging tests`
- `pyright`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --manifest-path rust_extension/Cargo.toml -- -D warnings`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test --manifest-path rust_extension/Cargo.toml`
- `pytest -q`
- `find docs -name '*.md' -not -path './target/*' -print0 | xargs -0 markdownlint`

------
https://chatgpt.com/codex/tasks/task_e_685c56f26dd88322bfe7972bfd72c898

## Summary by Sourcery

Implement a background-threaded FemtoLogger in Rust using a bounded crossbeam channel, expose it via PyO3 with a matching pure-Python fallback, parameterize log-formatting tests in both Rust (rstest) and Python (pytest), and update documentation and packaging accordingly.

New Features:
- Introduce asynchronous, crossbeam-channel-based logging in Rust FemtoLogger with bounded buffer and background thread management
- Expose FemtoLogger in the Python extension and add a pure-Python fallback implementation

Enhancements:
- Add parameterized tests for FemtoLogger.log using rstest in Rust and pytest in Python
- Update documentation to cover rstest usage, channel capacity rationale, and packaging via maturin

Build:
- Add rstest as a dev dependency in Cargo.toml
- Configure PyO3 extension packaging via maturin in pyproject.toml

Documentation:
- Revise multiple docs (rust-testing-with-rstest-fixtures, dependency-analysis, rust-extension, README, roadmap) to reflect new logger behavior, testing approach, and packaging

Tests:
- Add Rust parameterized tests for log formatting in rust_extension/tests/logger_tests.rs
- Add Python parameterized tests in tests/test_logger.py

Chores:
- Mark Rust logger implementation and packaging steps as complete in the roadmap