### PR TITLE
Implement FemtoFormatter trait

### DIFF
--- a/rust_extension/src/formatter.rs
+++ b/rust_extension/src/formatter.rs
@@ -1,0 +1,11 @@
+pub trait FemtoFormatter: Send + Sync {
+    fn format(&self, record: &crate::log_record::FemtoLogRecord) -> String;
+}
+
+pub struct DefaultFormatter;
+
+impl FemtoFormatter for DefaultFormatter {
+    fn format(&self, record: &crate::log_record::FemtoLogRecord) -> String {
+        format!("{}: {} - {}", record.logger, record.level, record.message)
+    }
+}

--- a/rust_extension/src/formatter.rs
+++ b/rust_extension/src/formatter.rs
@@ -1,11 +1,19 @@
+use crate::log_record::FemtoLogRecord;
+
+/// Trait for formatting log records into strings.
+///
+/// Implementors must be thread-safe (`Send + Sync`) so formatters can be
+/// shared across threads in a logging system.
 pub trait FemtoFormatter: Send + Sync {
-    fn format(&self, record: &crate::log_record::FemtoLogRecord) -> String;
+    /// Format a log record into a string representation.
+    fn format(&self, record: &FemtoLogRecord) -> String;
 }
 
+#[derive(Copy, Clone, Debug)]
 pub struct DefaultFormatter;
 
 impl FemtoFormatter for DefaultFormatter {
-    fn format(&self, record: &crate::log_record::FemtoLogRecord) -> String {
+    fn format(&self, record: &FemtoLogRecord) -> String {
         format!("{}: {} - {}", record.logger, record.level, record.message)
     }
 }

--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -1,8 +1,10 @@
 use pyo3::prelude::*;
 
+mod formatter;
 mod log_record;
 mod logger;
 
+pub use formatter::{DefaultFormatter, FemtoFormatter};
 pub use log_record::FemtoLogRecord;
 pub use logger::FemtoLogger;
 

--- a/rust_extension/src/log_record.rs
+++ b/rust_extension/src/log_record.rs
@@ -6,6 +6,8 @@ use std::fmt;
 
 #[derive(Clone, Debug)]
 pub struct FemtoLogRecord {
+    /// Name of the logger that created this record.
+    pub logger: String,
     /// The log level as a string (e.g. "INFO" or "ERROR").
     pub level: String,
     /// The log message content.
@@ -13,9 +15,10 @@ pub struct FemtoLogRecord {
 }
 
 impl FemtoLogRecord {
-    /// Construct a new log record from `level` and `message` arguments.
-    pub fn new(level: &str, message: &str) -> Self {
+    /// Construct a new log record from logger `name`, `level`, and `message`.
+    pub fn new(logger: &str, level: &str, message: &str) -> Self {
         Self {
+            logger: logger.to_owned(),
             level: level.to_owned(),
             message: message.to_owned(),
         }

--- a/rust_extension/src/logger.rs
+++ b/rust_extension/src/logger.rs
@@ -5,7 +5,10 @@ use pyo3::prelude::*;
 use crossbeam_channel::{bounded, Receiver, Sender};
 use std::thread::{self, JoinHandle};
 
-use crate::{formatter::{DefaultFormatter, FemtoFormatter}, log_record::FemtoLogRecord};
+use crate::{
+    formatter::{DefaultFormatter, FemtoFormatter},
+    log_record::FemtoLogRecord,
+};
 use std::sync::Arc;
 
 const DEFAULT_CHANNEL_CAPACITY: usize = 1024;

--- a/rust_extension/src/logger.rs
+++ b/rust_extension/src/logger.rs
@@ -46,7 +46,7 @@ impl FemtoLogger {
     /// name with the level and message.
     #[pyo3(text_signature = "(self, level, message)")]
     pub fn log(&self, level: &str, message: &str) -> String {
-        let record = FemtoLogRecord::new(level, message);
+        let record = FemtoLogRecord::new(&self.name, level, message);
         let msg = format!("{}: {}", self.name, record);
         if let Some(tx) = &self.tx {
             if tx.send(record).is_err() {

--- a/rust_extension/src/logger.rs
+++ b/rust_extension/src/logger.rs
@@ -5,7 +5,8 @@ use pyo3::prelude::*;
 use crossbeam_channel::{bounded, Receiver, Sender};
 use std::thread::{self, JoinHandle};
 
-use crate::log_record::FemtoLogRecord;
+use crate::{formatter::{DefaultFormatter, FemtoFormatter}, log_record::FemtoLogRecord};
+use std::sync::Arc;
 
 const DEFAULT_CHANNEL_CAPACITY: usize = 1024;
 
@@ -14,6 +15,7 @@ const DEFAULT_CHANNEL_CAPACITY: usize = 1024;
 pub struct FemtoLogger {
     /// Identifier used to distinguish log messages from different loggers.
     name: String,
+    formatter: Arc<dyn FemtoFormatter>,
     tx: Option<Sender<FemtoLogRecord>>,
     handle: Option<JoinHandle<()>>,
 }
@@ -28,13 +30,20 @@ impl FemtoLogger {
         // producers outpace the consumer thread.
         let (tx, rx): (Sender<FemtoLogRecord>, Receiver<FemtoLogRecord>) =
             bounded(DEFAULT_CHANNEL_CAPACITY);
+
+        // Default to a simple formatter mirroring Python's "name: level - message" format.
+        let formatter: Arc<dyn FemtoFormatter> = Arc::new(DefaultFormatter);
+        let thread_formatter = Arc::clone(&formatter);
+
         let handle = thread::spawn(move || {
             for record in rx {
-                println!("{}", record);
+                println!("{}", thread_formatter.format(&record));
             }
         });
+
         Self {
             name,
+            formatter,
             tx: Some(tx),
             handle: Some(handle),
         }
@@ -47,7 +56,7 @@ impl FemtoLogger {
     #[pyo3(text_signature = "(self, level, message)")]
     pub fn log(&self, level: &str, message: &str) -> String {
         let record = FemtoLogRecord::new(&self.name, level, message);
-        let msg = format!("{}: {}", self.name, record);
+        let msg = self.formatter.format(&record);
         if let Some(tx) = &self.tx {
             if tx.send(record).is_err() {
                 eprintln!("Warning: failed to send log record to background thread");

--- a/rust_extension/tests/formatter_tests.rs
+++ b/rust_extension/tests/formatter_tests.rs
@@ -1,0 +1,18 @@
+use _femtologging_rs::{DefaultFormatter, FemtoFormatter, FemtoLogRecord};
+use rstest::rstest;
+
+#[rstest]
+#[case("core", "INFO", "hello", "core: INFO - hello")]
+#[case("sys", "ERROR", "fail", "sys: ERROR - fail")]
+#[case("", "INFO", "", ": INFO - ")]
+#[case("core", "WARN", "⚠", "core: WARN - ⚠")]
+fn default_formatter_formats(
+    #[case] logger: &str,
+    #[case] level: &str,
+    #[case] message: &str,
+    #[case] expected: &str,
+) {
+    let record = FemtoLogRecord::new(logger, level, message);
+    let formatter = DefaultFormatter;
+    assert_eq!(formatter.format(&record), expected);
+}


### PR DESCRIPTION
## Summary
- define FemtoFormatter and DefaultFormatter
- extend FemtoLogRecord with logger field
- update FemtoLogger to build records with logger name
- add unit tests for default formatter

## Testing
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test --manifest-path rust_extension/Cargo.toml`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --manifest-path rust_extension/Cargo.toml -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_685e93eb360483229a707195679bef29

## Summary by Sourcery

Introduce a formatting extension point by defining the FemtoFormatter trait and a DefaultFormatter, update log records to carry logger names, and ensure formatting logic is covered by unit tests.

New Features:
- Add FemtoFormatter trait for customizable log record formatting
- Implement DefaultFormatter as the default formatting strategy

Enhancements:
- Extend FemtoLogRecord to include the originating logger's name
- Modify FemtoLogger to supply its name when constructing log records

Tests:
- Add unit tests to verify DefaultFormatter output for various record scenarios