### PR TITLE
Implement FemtoHandler and StreamHandler

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -54,7 +54,7 @@ pub trait FemtoHandler: Send + Sync {
 ```
 
 Implementations should forward the record to an internal queue with
-`try_send` so the caller never blocks. If the queue is full the record is
+`try_send` so the caller never blocks. If the queue is full, the record is
 silently dropped and a warning is written to `stderr`.
 
 ### StreamHandler
@@ -70,7 +70,7 @@ capacity when needed.
 
 Dropping a handler closes its channel and waits briefly for the worker
 thread to finish flushing. If the thread does not exit within one
-second a warning is printed and the drop continues, preventing
+second, a warning is printed and the drop continues, preventing
 deadlocks during shutdown.
 
 #### Sequence Diagram

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -68,6 +68,11 @@ The default bounded queue size is 1024 records, but
 `FemtoStreamHandler::with_capacity` lets callers configure a custom
 capacity when needed.
 
+Dropping a handler closes its channel and waits briefly for the worker
+thread to finish flushing. If the thread does not exit within one
+second a warning is printed and the drop continues, preventing
+deadlocks during shutdown.
+
 #### Sequence Diagram
 
 ```mermaid

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -48,10 +48,14 @@ thread. Application code holds the sender cloned from the channel.
 Handlers implement a common trait:
 
 ```rust
-pub trait FemtoHandler: Send {
+pub trait FemtoHandler: Send + Sync {
     fn handle(&self, record: FemtoLogRecord);
 }
 ```
+
+Implementations should forward the record to an internal queue with
+`try_send` so the caller never blocks. If the queue is full the record is
+silently dropped and a warning is written to `stderr`.
 
 ### StreamHandler
 

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -48,9 +48,13 @@ thread. Application code holds the sender cloned from the channel.
 Handlers implement a common trait:
 
 ```rust
-pub trait FemtoHandler: Send + Sync {
+pub trait FemtoHandlerTrait: Send + Sync {
     fn handle(&self, record: FemtoLogRecord);
 }
+
+/// Base Python-exposed class. Methods are no-ops by default.
+#[pyclass(name = "FemtoHandler", subclass)]
+pub struct FemtoHandler;
 ```
 
 Implementations should forward the record to an internal queue with

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -60,6 +60,9 @@ The consumer thread receives `FemtoLogRecord` values, formats them using
 its `FemtoFormatter`, and writes via a mutex‑protected `Write` object to
 avoid interleaving. This mirrors the locking described in
 [`concurrency-models-in-high-performance-logging.md`](./concurrency-models-in-high-performance-logging.md#1-the-picologging-concurrency-model-a-hybrid-approach).
+The default bounded queue size is 1024 records, but
+`FemtoStreamHandler::with_capacity` lets callers configure a custom
+capacity when needed.
 
 #### Sequence Diagram
 

--- a/femtologging/__init__.py
+++ b/femtologging/__init__.py
@@ -8,8 +8,9 @@ try:  # pragma: no cover - Rust optional
     rust = __import__(f"_{PACKAGE_NAME}_rs")
     hello = rust.hello  # type: ignore[attr-defined]
     FemtoLogger = rust.FemtoLogger  # type: ignore[attr-defined]
+    FemtoHandler = rust.FemtoHandler  # type: ignore[attr-defined]
     FemtoStreamHandler = rust.FemtoStreamHandler  # type: ignore[attr-defined]
 except ModuleNotFoundError:  # pragma: no cover - Python fallback
-    from .pure import FemtoLogger, FemtoStreamHandler, hello
+    from .pure import FemtoHandler, FemtoLogger, FemtoStreamHandler, hello
 
-__all__ = ["FemtoLogger", "FemtoStreamHandler", "hello"]
+__all__ = ["FemtoHandler", "FemtoLogger", "FemtoStreamHandler", "hello"]

--- a/femtologging/__init__.py
+++ b/femtologging/__init__.py
@@ -10,6 +10,6 @@ try:  # pragma: no cover - Rust optional
     FemtoLogger = rust.FemtoLogger  # type: ignore[attr-defined]
     FemtoStreamHandler = rust.FemtoStreamHandler  # type: ignore[attr-defined]
 except ModuleNotFoundError:  # pragma: no cover - Python fallback
-    from .pure import FemtoLogger, hello
+    from .pure import FemtoLogger, FemtoStreamHandler, hello
 
 __all__ = ["FemtoLogger", "FemtoStreamHandler", "hello"]

--- a/femtologging/__init__.py
+++ b/femtologging/__init__.py
@@ -8,7 +8,8 @@ try:  # pragma: no cover - Rust optional
     rust = __import__(f"_{PACKAGE_NAME}_rs")
     hello = rust.hello  # type: ignore[attr-defined]
     FemtoLogger = rust.FemtoLogger  # type: ignore[attr-defined]
+    FemtoStreamHandler = rust.FemtoStreamHandler  # type: ignore[attr-defined]
 except ModuleNotFoundError:  # pragma: no cover - Python fallback
     from .pure import FemtoLogger, hello
 
-__all__ = ["FemtoLogger", "hello"]
+__all__ = ["FemtoLogger", "FemtoStreamHandler", "hello"]

--- a/femtologging/pure.py
+++ b/femtologging/pure.py
@@ -24,4 +24,11 @@ class FemtoStreamHandler:
         pass
 
 
-__all__ = ["FemtoLogger", "FemtoStreamHandler", "hello"]
+class FemtoHandler:
+    """Base class placeholder when the Rust extension is missing."""
+
+    def handle(self, _record: object) -> None:  # pragma: no cover - stub
+        pass
+
+
+__all__ = ["FemtoHandler", "FemtoLogger", "FemtoStreamHandler", "hello"]

--- a/femtologging/pure.py
+++ b/femtologging/pure.py
@@ -17,4 +17,11 @@ def hello() -> str:
     return "hello from Python"
 
 
-__all__ = ["FemtoLogger", "hello"]
+class FemtoStreamHandler:
+    """Placeholder used when the Rust extension is unavailable."""
+
+    def __init__(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+
+__all__ = ["FemtoLogger", "FemtoStreamHandler", "hello"]

--- a/rust_extension/Cargo.lock
+++ b/rust_extension/Cargo.lock
@@ -255,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -273,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/rust_extension/Cargo.toml
+++ b/rust_extension/Cargo.toml
@@ -8,7 +8,7 @@ name = "_femtologging_rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3 = { version = "0.20", features = ["extension-module"] }
+pyo3 = { version = "0.21.2", features = ["extension-module"] }
 crossbeam-channel = "0.5.15"
 
 [dev-dependencies]

--- a/rust_extension/src/handler.rs
+++ b/rust_extension/src/handler.rs
@@ -1,11 +1,29 @@
 use crate::log_record::FemtoLogRecord;
+use pyo3::prelude::*;
 
 /// Trait implemented by all log handlers.
 ///
 /// `FemtoHandler` is `Send + Sync` so it can be safely called from multiple
 /// threads by reference. Each implementation forwards the record to its own
 /// consumer thread without blocking the caller.
-pub trait FemtoHandler: Send + Sync {
+pub trait FemtoHandlerTrait: Send + Sync {
     /// Dispatch a log record for handling.
     fn handle(&self, record: FemtoLogRecord);
+}
+
+/// Base Python class for handlers. Methods do nothing by default.
+#[pyclass(name = "FemtoHandler", subclass)]
+#[derive(Default)]
+pub struct FemtoHandler;
+
+#[pymethods]
+impl FemtoHandler {
+    #[new]
+    fn py_new() -> Self {
+        Self
+    }
+}
+
+impl FemtoHandlerTrait for FemtoHandler {
+    fn handle(&self, _record: FemtoLogRecord) {}
 }

--- a/rust_extension/src/handler.rs
+++ b/rust_extension/src/handler.rs
@@ -2,10 +2,10 @@ use crate::log_record::FemtoLogRecord;
 
 /// Trait implemented by all log handlers.
 ///
-/// `FemtoHandler` is `Send` so it can be invoked from multiple threads.
-/// Each implementation forwards the record to its own consumer thread
-/// without blocking the caller.
-pub trait FemtoHandler: Send {
+/// `FemtoHandler` is `Send + Sync` so it can be safely called from multiple
+/// threads by reference. Each implementation forwards the record to its own
+/// consumer thread without blocking the caller.
+pub trait FemtoHandler: Send + Sync {
     /// Dispatch a log record for handling.
     fn handle(&self, record: FemtoLogRecord);
 }

--- a/rust_extension/src/handler.rs
+++ b/rust_extension/src/handler.rs
@@ -1,0 +1,11 @@
+use crate::log_record::FemtoLogRecord;
+
+/// Trait implemented by all log handlers.
+///
+/// `FemtoHandler` is `Send` so it can be invoked from multiple threads.
+/// Each implementation forwards the record to its own consumer thread
+/// without blocking the caller.
+pub trait FemtoHandler: Send {
+    /// Dispatch a log record for handling.
+    fn handle(&self, record: FemtoLogRecord);
+}

--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -1,12 +1,16 @@
 use pyo3::prelude::*;
 
 mod formatter;
+mod handler;
 mod log_record;
 mod logger;
+mod stream_handler;
 
 pub use formatter::{DefaultFormatter, FemtoFormatter};
+pub use handler::FemtoHandler;
 pub use log_record::FemtoLogRecord;
 pub use logger::FemtoLogger;
+pub use stream_handler::FemtoStreamHandler;
 
 #[pyfunction]
 fn hello() -> &'static str {

--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -18,7 +18,7 @@ fn hello() -> &'static str {
 }
 
 #[pymodule]
-fn _femtologging_rs(_py: Python, m: &PyModule) -> PyResult<()> {
+fn _femtologging_rs(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<FemtoLogger>()?;
     m.add_function(wrap_pyfunction!(hello, m)?)?;
     Ok(())

--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -7,7 +7,7 @@ mod logger;
 mod stream_handler;
 
 pub use formatter::{DefaultFormatter, FemtoFormatter};
-pub use handler::FemtoHandler;
+pub use handler::{FemtoHandler, FemtoHandlerTrait};
 pub use log_record::FemtoLogRecord;
 pub use logger::FemtoLogger;
 pub use stream_handler::FemtoStreamHandler;
@@ -21,6 +21,7 @@ fn hello() -> &'static str {
 #[pymodule]
 fn _femtologging_rs(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<FemtoLogger>()?;
+    m.add_class::<FemtoHandler>()?;
     m.add_class::<FemtoStreamHandler>()?;
     m.add_function(wrap_pyfunction!(hello, m)?)?;
     Ok(())

--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -17,9 +17,11 @@ fn hello() -> &'static str {
     "hello from Rust"
 }
 
+#[allow(deprecated)]
 #[pymodule]
-fn _femtologging_rs(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn _femtologging_rs(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<FemtoLogger>()?;
+    m.add_class::<FemtoStreamHandler>()?;
     m.add_function(wrap_pyfunction!(hello, m)?)?;
     Ok(())
 }

--- a/rust_extension/src/stream_handler.rs
+++ b/rust_extension/src/stream_handler.rs
@@ -8,7 +8,7 @@ use std::{
 use crossbeam_channel::{bounded, Sender};
 use pyo3::prelude::*;
 
-use crate::handler::FemtoHandler;
+use crate::handler::FemtoHandlerTrait;
 use crate::{
     formatter::{DefaultFormatter, FemtoFormatter},
     log_record::FemtoLogRecord,
@@ -95,7 +95,7 @@ impl FemtoStreamHandler {
     }
 }
 
-impl FemtoHandler for FemtoStreamHandler {
+impl FemtoHandlerTrait for FemtoStreamHandler {
     fn handle(&self, record: FemtoLogRecord) {
         if self.tx.try_send(record).is_err() {
             eprintln!("FemtoStreamHandler: queue full or shutting down, dropping record");

--- a/rust_extension/src/stream_handler.rs
+++ b/rust_extension/src/stream_handler.rs
@@ -1,0 +1,86 @@
+use std::{
+    io::{self, Write},
+    sync::{Arc, Mutex},
+    thread::{self, JoinHandle},
+};
+
+use crossbeam_channel::{bounded, Sender};
+
+use crate::handler::FemtoHandler;
+use crate::{
+    formatter::{DefaultFormatter, FemtoFormatter},
+    log_record::FemtoLogRecord,
+};
+
+const DEFAULT_CHANNEL_CAPACITY: usize = 1024;
+
+/// Handler that writes formatted log records to an `io::Write` stream.
+///
+/// Each instance owns a background thread which receives records via a
+/// channel and writes them to the provided stream. The stream is protected
+/// by a `Mutex` to avoid interleaved writes when shared across threads.
+pub struct FemtoStreamHandler {
+    tx: Option<Sender<FemtoLogRecord>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl FemtoStreamHandler {
+    /// Create a new handler writing to `stdout` with a `DefaultFormatter`.
+    pub fn stdout() -> Self {
+        Self::new(
+            Arc::new(Mutex::new(io::stdout())),
+            Arc::new(DefaultFormatter),
+        )
+    }
+
+    /// Create a new handler writing to `stderr` with a `DefaultFormatter`.
+    pub fn stderr() -> Self {
+        Self::new(
+            Arc::new(Mutex::new(io::stderr())),
+            Arc::new(DefaultFormatter),
+        )
+    }
+
+    /// Create a new handler from an arbitrary writer and formatter.
+    pub fn new<W>(writer: Arc<Mutex<W>>, formatter: Arc<dyn FemtoFormatter>) -> Self
+    where
+        W: Write + Send + 'static,
+    {
+        let (tx, rx) = bounded(DEFAULT_CHANNEL_CAPACITY);
+        let thread_writer = Arc::clone(&writer);
+        let thread_formatter = formatter;
+
+        let handle = thread::spawn(move || {
+            for record in rx {
+                let msg = thread_formatter.format(&record);
+                if let Ok(mut w) = thread_writer.lock() {
+                    let _ = writeln!(w, "{}", msg);
+                    let _ = w.flush();
+                }
+            }
+        });
+
+        Self {
+            tx: Some(tx),
+            handle: Some(handle),
+        }
+    }
+}
+
+impl FemtoHandler for FemtoStreamHandler {
+    fn handle(&self, record: FemtoLogRecord) {
+        if let Some(tx) = &self.tx {
+            let _ = tx.send(record);
+        }
+    }
+}
+
+impl Drop for FemtoStreamHandler {
+    fn drop(&mut self) {
+        // Dropping the sender signals the consumer thread to finish.
+        self.tx.take();
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}

--- a/rust_extension/tests/stream_handler_tests.rs
+++ b/rust_extension/tests/stream_handler_tests.rs
@@ -1,0 +1,15 @@
+use std::sync::{Arc, Mutex};
+
+use _femtologging_rs::{DefaultFormatter, FemtoHandler, FemtoLogRecord, FemtoStreamHandler};
+use rstest::rstest;
+
+#[rstest]
+fn stream_handler_writes_to_buffer() {
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let handler = FemtoStreamHandler::new(Arc::clone(&buffer), Arc::new(DefaultFormatter));
+    handler.handle(FemtoLogRecord::new("core", "INFO", "hello"));
+    drop(handler); // ensure thread completes
+
+    let output = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
+    assert_eq!(output, "core: INFO - hello\n");
+}

--- a/rust_extension/tests/stream_handler_tests.rs
+++ b/rust_extension/tests/stream_handler_tests.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, Mutex};
+use std::thread;
 
 use _femtologging_rs::{DefaultFormatter, FemtoHandler, FemtoLogRecord, FemtoStreamHandler};
 use rstest::rstest;
@@ -32,8 +33,6 @@ fn stream_handler_multiple_records() {
 
 #[rstest]
 fn stream_handler_concurrent_usage() {
-    use std::thread;
-
     let buffer = Arc::new(Mutex::new(Vec::new()));
     let handler = Arc::new(FemtoStreamHandler::new(
         Arc::clone(&buffer),

--- a/rust_extension/tests/stream_handler_tests.rs
+++ b/rust_extension/tests/stream_handler_tests.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use _femtologging_rs::{DefaultFormatter, FemtoHandler, FemtoLogRecord, FemtoStreamHandler};
+use _femtologging_rs::{DefaultFormatter, FemtoHandlerTrait, FemtoLogRecord, FemtoStreamHandler};
 use rstest::rstest;
 
 #[derive(Clone)]
@@ -74,7 +74,7 @@ fn stream_handler_concurrent_usage() {
 #[rstest]
 fn stream_handler_trait_object_usage() {
     let buffer = Arc::new(Mutex::new(Vec::new()));
-    let handler: Box<dyn FemtoHandler> = Box::new(FemtoStreamHandler::new(
+    let handler: Box<dyn FemtoHandlerTrait> = Box::new(FemtoStreamHandler::new(
         SharedBuf(Arc::clone(&buffer)),
         DefaultFormatter,
     ));


### PR DESCRIPTION
## Summary
- add new `FemtoHandler` trait
- implement `FemtoStreamHandler` running in a background thread
- expose new API from the library
- test handler output with `rstest`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685f0261883483229b09672a673710b5

## Summary by Sourcery

Add a new asynchronous handler trait and a stream-based handler implementation, integrate them into the Python extension, update documentation and configuration options, and include comprehensive tests

New Features:
- Introduce FemtoHandler trait for asynchronous log dispatching
- Implement FemtoStreamHandler to stream formatted log records on a background thread with configurable queue capacity

Enhancements:
- Expose FemtoHandler and FemtoStreamHandler in the Python extension API
- Provide convenience constructors for stdout and stderr and allow custom buffer capacity

Build:
- Bump pyo3 dependency to version 0.21.2

Documentation:
- Add documentation on default channel capacity and include a sequence diagram for FemtoStreamHandler

Tests:
- Add rstest-based tests for FemtoStreamHandler covering single and multiple records, concurrency, and poisoned mutex handling