### PR TITLE
Refine default log formatting

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -18,9 +18,10 @@ formatting and handler components from Python to Rust. It complements the
 
 ## FemtoFormatter Trait
 
-`FemtoFormatter` defines how a `FemtoLogRecord` becomes a string. A
-simple default formatter mirrors the current Python behaviour by
-combining the logger name, level, and message:
+`FemtoFormatter` defines how a `FemtoLogRecord` becomes a string. The
+default implementation is intentionally simple and follows a common
+"logger [LEVEL] message" convention:
+
 ```rust
 pub trait FemtoFormatter: Send + Sync {
     fn format(&self, record: &FemtoLogRecord) -> String;
@@ -30,7 +31,7 @@ pub struct DefaultFormatter;
 
 impl FemtoFormatter for DefaultFormatter {
     fn format(&self, record: &FemtoLogRecord) -> String {
-        format!("{}: {} - {}", record.logger, record.level, record.message)
+        format!("{} [{}] {}", record.logger, record.level, record.message)
     }
 }
 ```

--- a/femtologging/pure.py
+++ b/femtologging/pure.py
@@ -9,7 +9,7 @@ class FemtoLogger:
 
     def log(self, level: str, message: str) -> str:
         """Return the formatted log message."""
-        return f"{self.name}: {level} - {message}"
+        return f"{self.name} [{level}] {message}"
 
 
 def hello() -> str:

--- a/rust_extension/src/formatter.rs
+++ b/rust_extension/src/formatter.rs
@@ -14,6 +14,6 @@ pub struct DefaultFormatter;
 
 impl FemtoFormatter for DefaultFormatter {
     fn format(&self, record: &FemtoLogRecord) -> String {
-        format!("{}: {} - {}", record.logger, record.level, record.message)
+        format!("{} [{}] {}", record.logger, record.level, record.message)
     }
 }

--- a/rust_extension/src/logger.rs
+++ b/rust_extension/src/logger.rs
@@ -34,7 +34,7 @@ impl FemtoLogger {
         let (tx, rx): (Sender<FemtoLogRecord>, Receiver<FemtoLogRecord>) =
             bounded(DEFAULT_CHANNEL_CAPACITY);
 
-        // Default to a simple formatter mirroring Python's "name: level - message" format.
+        // Default to a simple formatter using the "name [LEVEL] message" style.
         let formatter: Arc<dyn FemtoFormatter> = Arc::new(DefaultFormatter);
         let thread_formatter = Arc::clone(&formatter);
 

--- a/rust_extension/tests/formatter_tests.rs
+++ b/rust_extension/tests/formatter_tests.rs
@@ -2,10 +2,10 @@ use _femtologging_rs::{DefaultFormatter, FemtoFormatter, FemtoLogRecord};
 use rstest::rstest;
 
 #[rstest]
-#[case("core", "INFO", "hello", "core: INFO - hello")]
-#[case("sys", "ERROR", "fail", "sys: ERROR - fail")]
-#[case("", "INFO", "", ": INFO - ")]
-#[case("core", "WARN", "⚠", "core: WARN - ⚠")]
+#[case("core", "INFO", "hello", "core [INFO] hello")]
+#[case("sys", "ERROR", "fail", "sys [ERROR] fail")]
+#[case("", "INFO", "", " [INFO] ")]
+#[case("core", "WARN", "⚠", "core [WARN] ⚠")]
 fn default_formatter_formats(
     #[case] logger: &str,
     #[case] level: &str,

--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -2,10 +2,10 @@ use _femtologging_rs::FemtoLogger;
 use rstest::rstest;
 
 #[rstest]
-#[case("core", "INFO", "hello", "core: INFO - hello")]
-#[case("sys", "ERROR", "fail", "sys: ERROR - fail")]
-#[case("", "INFO", "", ": INFO - ")]
-#[case("core", "WARN", "⚠", "core: WARN - ⚠")]
+#[case("core", "INFO", "hello", "core [INFO] hello")]
+#[case("sys", "ERROR", "fail", "sys [ERROR] fail")]
+#[case("", "INFO", "", " [INFO] ")]
+#[case("core", "WARN", "⚠", "core [WARN] ⚠")]
 fn log_formats_message(
     #[case] name: &str,
     #[case] level: &str,

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -9,23 +9,23 @@ from femtologging import FemtoLogger
 @pytest.mark.parametrize(
     "name, level, message, expected",
     [
-        ("core", "INFO", "hello", "core: INFO - hello"),
-        ("sys", "ERROR", "fail", "sys: ERROR - fail"),
+        ("core", "INFO", "hello", "core [INFO] hello"),
+        ("sys", "ERROR", "fail", "sys [ERROR] fail"),
         # Edge cases:
-        ("", "INFO", "empty name", ": INFO - empty name"),
-        ("core", "", "empty level", "core:  - empty level"),
-        ("core", "INFO", "", "core: INFO - "),
-        ("", "", "", ":  - "),
+        ("", "INFO", "empty name", " [INFO] empty name"),
+        ("core", "", "empty level", "core [] empty level"),
+        ("core", "INFO", "", "core [INFO] "),
+        ("", "", "", " [] "),
         # Non-ASCII characters
-        ("核", "信息", "你好", "核: 信息 - 你好"),
-        ("core", "INFO", "¡Hola!", "core: INFO - ¡Hola!"),
-        ("система", "ОШИБКА", "не удалось", "система: ОШИБКА - не удалось"),
+        ("核", "信息", "你好", "核 [信息] 你好"),
+        ("core", "INFO", "¡Hola!", "core [INFO] ¡Hola!"),
+        ("система", "ОШИБКА", "не удалось", "система [ОШИБКА] не удалось"),
         # Very long strings
         (
             "n" * 1000,
             "L" * 1000,
             "m" * 1000,
-            f"{'n' * 1000}: {'L' * 1000} - {'m' * 1000}",
+            f"{'n' * 1000} [{'L' * 1000}] {'m' * 1000}",
         ),
     ],
 )


### PR DESCRIPTION
## Summary
- clarify default formatting style in docs
- adopt `name [LEVEL] message` convention in Python and Rust
- update tests for new format

## Testing
- `ruff format --check`
- `ruff check`
- `pyright`
- `pytest -q`
- `cargo fmt --manifest-path rust_extension/Cargo.toml`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --manifest-path rust_extension/Cargo.toml -- -D warnings`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test --manifest-path rust_extension/Cargo.toml`
- `markdownlint docs/formatters-and-handlers-rust-port.md`
- `nixie docs/formatters-and-handlers-rust-port.md`


------
https://chatgpt.com/codex/tasks/task_e_685f17bf38b48322ab08d5b07c1d11a7