### PR TITLE
Add non-ASCII and long string logger tests

### DIFF
--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -6,6 +6,7 @@ use rstest::rstest;
 #[case("sys", "ERROR", "fail", "sys [ERROR] fail")]
 #[case("", "INFO", "", " [INFO] ")]
 #[case("core", "WARN", "⚠", "core [WARN] ⚠")]
+#[case("i18n", "INFO", "こんにちは世界", "i18n [INFO] こんにちは世界")]
 fn log_formats_message(
     #[case] name: &str,
     #[case] level: &str,
@@ -14,4 +15,12 @@ fn log_formats_message(
 ) {
     let logger = FemtoLogger::new(name.to_string());
     assert_eq!(logger.log(level, message), expected);
+}
+
+#[test]
+fn log_formats_very_long_message() {
+    let long_msg = "x".repeat(1024);
+    let logger = FemtoLogger::new("long".to_string());
+    let expected = format!("long [INFO] {}", long_msg);
+    assert_eq!(logger.log("INFO", &long_msg), expected);
 }


### PR DESCRIPTION
## Summary
- add a non-ASCII case to `log_formats_message`
- check formatting of a very long log message

## Testing
- `cargo fmt --all -- --check`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy -- -D warnings`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685f1eff0ee4832290d3aa936681ff12

## Summary by Sourcery

Add new tests for `FemtoLogger` to validate formatting of non-ASCII and very long messages

Tests:
- Add a non-ASCII test case to `log_formats_message` to verify formatting of international strings
- Add `log_formats_very_long_message` test to ensure the logger handles messages up to 1024 characters correctly