### PR TITLE
Parameterize long message logger test

### DIFF
--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -17,10 +17,14 @@ fn log_formats_message(
     assert_eq!(logger.log(level, message), expected);
 }
 
-#[test]
-fn log_formats_very_long_message() {
-    let long_msg = "x".repeat(1024);
+#[rstest]
+#[case(0)]
+#[case(1024)]
+#[case(65536)]
+#[case(1_048_576)]
+fn log_formats_long_messages(#[case] length: usize) {
+    let msg = "x".repeat(length);
     let logger = FemtoLogger::new("long".to_string());
-    let expected = format!("long [INFO] {}", long_msg);
-    assert_eq!(logger.log("INFO", &long_msg), expected);
+    let expected = format!("long [INFO] {}", msg);
+    assert_eq!(logger.log("INFO", &msg), expected);
 }


### PR DESCRIPTION
## Summary
- parameterize the logger test for long messages
- cover multiple message lengths with rstest

## Testing
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --manifest-path rust_extension/Cargo.toml -- -D warnings`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test --manifest-path rust_extension/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_685f393215b08322b86b211dd80c5ebb

## Summary by Sourcery

Parameterize the long message logger test using rstest to cover multiple message lengths in a single, data-driven test

Enhancements:
- Replace fixed-length long message test with a parameterized rstest

Tests:
- Add rstest cases for message lengths 0, 1024, 65536, and 1_048_576 to validate logger formatting across sizes