### PR TITLE
Add explicit shutdown controls for FemtoFileHandler

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -102,6 +102,10 @@ Rotation variants (`FemtoRotatingFileHandler`,
 `FemtoTimedRotatingFileHandler`) build on this by performing rotation
 logic inside their consumer threads.
 
+`FemtoFileHandler` exposes `flush()` and `close()` methods so callers can
+drain pending records and stop the background thread explicitly. Dropping
+the handler still performs this cleanup if the methods aren't invoked.
+
 All handlers spawn their consumer threads on creation and expose a
 `snd: Sender<FemtoLogRecord>` to the logger. The logger clones this
 sender when created, ensuring log messages are dispatched without

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -8,7 +8,8 @@ core handler implementations as well:
 - `FemtoStreamHandler` writes log records to `stdout` or `stderr` on a
   background thread.
 - `FemtoFileHandler` persists records to a file, also using a dedicated
-  worker thread.
+  worker thread. It now provides `flush()` and `close()` to deterministically
+  manage that thread.
 
 Packaging is handled by [maturin](https://maturin.rs/). The
 `[tool.maturin]` section in `pyproject.toml` declares the extension module as

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -50,6 +50,8 @@ def test_file_handler_concurrent_usage(tmp_path: Path) -> None:
 
 
 def test_file_handler_flush(tmp_path: Path) -> None:
+    """Test that ``flush()`` writes pending records immediately."""
+
     path = tmp_path / "flush.log"
     handler = FemtoFileHandler(str(path))
 

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import gc
 from pathlib import Path
 import threading
 
@@ -14,8 +13,8 @@ def test_file_handler_writes_to_file(tmp_path: Path) -> None:
     path = tmp_path / "out.log"
     handler = FemtoFileHandler(str(path))
     handler.handle("core", "INFO", "hello")
-    del handler
-    gc.collect()
+    assert handler.flush() is True
+    handler.close()
     assert path.read_text() == "core [INFO] hello\n"
 
 
@@ -25,8 +24,7 @@ def test_file_handler_multiple_records(tmp_path: Path) -> None:
     handler.handle("core", "INFO", "first")
     handler.handle("core", "WARN", "second")
     handler.handle("core", "ERROR", "third")
-    del handler
-    gc.collect()
+    handler.close()
     assert (
         path.read_text()
         == "core [INFO] first\ncore [WARN] second\ncore [ERROR] third\n"
@@ -45,11 +43,22 @@ def test_file_handler_concurrent_usage(tmp_path: Path) -> None:
         t.start()
     for t in threads:
         t.join()
-    del handler
-    gc.collect()
+    handler.close()
     data = path.read_text()
     for i in range(10):
         assert f"core [INFO] msg{i}" in data
+
+
+def test_file_handler_flush(tmp_path: Path) -> None:
+    path = tmp_path / "flush.log"
+    handler = FemtoFileHandler(str(path))
+    handler.handle("core", "INFO", "one")
+    assert handler.flush() is True
+    assert path.read_text() == "core [INFO] one\n"
+    handler.handle("core", "INFO", "two")
+    assert handler.flush() is True
+    assert path.read_text() == "core [INFO] one\ncore [INFO] two\n"
+    handler.close()
 
 
 def test_file_handler_open_failure(tmp_path: Path) -> None:

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -52,11 +52,14 @@ def test_file_handler_concurrent_usage(tmp_path: Path) -> None:
 def test_file_handler_flush(tmp_path: Path) -> None:
     path = tmp_path / "flush.log"
     handler = FemtoFileHandler(str(path))
-    handler.handle("core", "INFO", "one")
-    assert handler.flush() is True
+
+    def send(msg: str) -> None:
+        handler.handle("core", "INFO", msg)
+        assert handler.flush() is True
+
+    send("one")
     assert path.read_text() == "core [INFO] one\n"
-    handler.handle("core", "INFO", "two")
-    assert handler.flush() is True
+    send("two")
     assert path.read_text() == "core [INFO] one\ncore [INFO] two\n"
     handler.close()
 


### PR DESCRIPTION
## Summary
- add `flush` and `close` methods to `FemtoFileHandler`
- update drop impl to use new close helper
- test the new functionality
- document the additional API in design docs

## Testing
- `ruff format femtologging tests`
- `ruff check femtologging tests`
- `pyright`
- `cargo fmt --manifest-path rust_extension/Cargo.toml`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --manifest-path rust_extension/Cargo.toml -- -D warnings`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test --manifest-path rust_extension/Cargo.toml`
- `markdownlint docs/formatters-and-handlers-rust-port.md docs/rust-extension.md`
- `nixie docs/formatters-and-handlers-rust-port.md docs/rust-extension.md`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68614aa7cf408322a75654bcce154ccb

## Summary by Sourcery

Introduce explicit shutdown controls to FemtoFileHandler by adding flush and close methods, refactor the internal channel to use a FileCommand enum for record and flush operations, and update tests and documentation to use and describe the new API.

New Features:
- Expose flush() and close() methods on FemtoFileHandler for deterministic draining and thread shutdown.

Enhancements:
- Use a FileCommand enum for unified record and flush commands over the internal channel.
- Refactor the background thread loop to handle flush commands with acknowledgment.
- Simplify Drop implementation to delegate shutdown logic to the new close() helper.

Documentation:
- Document the new flush() and close() methods in both the design and rust-extension documentation.

Tests:
- Update tests to invoke flush and close explicitly instead of relying on destructor behavior.
- Add a new test to verify flush functionality writes pending records immediately.