### PR TITLE
Fix CI workflow syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Install tools
+        run: |
+          uv tool install ruff
+          uv tool install ty
       - name: Check format
         run: make check-fmt
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: make check-fmt
       - name: Lint
         run: make lint
-      - name Typecheck
+      - name: Typecheck
         run: make typecheck
       - name: Test
         run: make test

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -1,25 +1,27 @@
 # Development Workflow
 
-This project uses a `Makefile` to keep routine development tasks
-consistent across Python and Rust code.
+This project uses a `Makefile` to keep routine development tasks consistent
+across Python and Rust code.
 
 ## Commands
 
 - `make fmt` – format Python, Rust and Markdown sources.
 - `make check-fmt` – verify formatting without modifying files.
-- `make lint` – run `ruff check` and
-  `cargo clippy` with `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`.
-- `make typecheck` – run `ty check --extra-search-path=/root/.pyenv/versions/3.13.3/lib/python3.13/site-packages`.
+- `make lint` – run `ruff check` and `cargo clippy` with
+  `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`.
+- `make typecheck` – run
+  `ty check --extra-search-path=/root/.pyenv/versions/3.13.3/lib/python3.13/site-packages`.
   This target depends on `make build`.
 - `make build` – compile the Rust extension by running `pip install -e .`.
 - `make release` – build the extension with optimizations.
 - `make clean` – remove build artifacts.
-- `make tools` – verify required commands like `ruff` and `ty` are installed.
-- `make test` – run formatting checks, clippy, cargo tests and pytest.
-  This target depends on `make build`.
+- `make tools` – verify required commands like `ruff` and `ty` are installed. In
+  CI these tools are installed with `uv tool install` before formatting checks
+  run.
+- `make test` – run formatting checks, clippy, cargo tests and pytest. This
+  target depends on `make build`.
 - `make markdownlint` – lint Markdown files.
 - `make nixie` – validate Mermaid diagrams embedded in Markdown.
 - `make help` – list available targets.
 
-These targets ensure style, type safety and correctness across the
-project.
+These targets ensure style, type safety and correctness across the project.


### PR DESCRIPTION
## Summary
- fix YAML syntax for the CI workflow

## Testing
- `make check-fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6861ad619ff8832284ad5590092b514c

## Summary by Sourcery

CI:
- Add missing colon to the Typecheck step in the CI workflow to correct YAML syntax.