### PR TITLE
Use uv in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ tools:
 	$(call ensure_tool,mdformat-all)
 	$(call ensure_tool,$(CARGO))
 	$(call ensure_tool,rustfmt)
+	$(call ensure_tool,uv)
 	$(call ensure_tool,ruff)
 	$(call ensure_tool,ty)
 

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ NIXIE ?= nixie
 all: release ## Build the release artifact
 
 build: ## Build debug artifact
-        uv venv
-	PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 uv sync
+	uv venv
+	PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 uv sync --group dev
 
 release: ## Build release artifact
 	PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 $(CARGO) build $(BUILD_JOBS) --manifest-path $(RUST_MANIFEST) --release

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ NIXIE ?= nixie
 all: release ## Build the release artifact
 
 build: ## Build debug artifact
-	PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 pip install -e .
+        uv venv
+	PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 uv sync
 
 release: ## Build release artifact
 	PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 $(CARGO) build $(BUILD_JOBS) --manifest-path $(RUST_MANIFEST) --release
@@ -53,10 +54,10 @@ test: build ## Run tests
 	cargo fmt --manifest-path $(RUST_MANIFEST) -- --check
 	PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --manifest-path $(RUST_MANIFEST) -- -D warnings
 	PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test --manifest-path $(RUST_MANIFEST)
-	pytest -q
+	uv run pytest -q
 
 typecheck: build ## Static type analysis
-	ty check --extra-search-path=/root/.pyenv/versions/3.13.3/lib/python3.13/site-packages
+	ty check
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 license = { text = "MIT" }
 dependencies = []
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = ["pytest", "ruff", "pyright"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = { text = "MIT" }
 dependencies = []
 
 [dependency-groups]
-dev = ["pytest", "ruff", "pyright"]
+dev = ["pytest"]
 
 [tool.ruff]
 line-length = 88

--- a/rust_extension/src/file_handler.rs
+++ b/rust_extension/src/file_handler.rs
@@ -145,7 +145,9 @@ impl FemtoFileHandler {
                             warn!("FemtoFileHandler write error");
                         } else {
                             writes += 1;
-                            if flush_interval != 0 && writes % flush_interval == 0 && file.flush().is_err()
+                            if flush_interval != 0
+                                && writes % flush_interval == 0
+                                && file.flush().is_err()
                             {
                                 warn!("FemtoFileHandler flush error");
                             }


### PR DESCRIPTION
## Summary by Sourcery

Adopt uv for Python virtual environment management and command execution across build, test, and typecheck targets

Enhancements:
- Create and synchronize Python virtual environment via uv in the build target instead of direct pip install
- Run pytest through uv to ensure tests execute in the managed virtual environment
- Simplify typecheck command by removing hardcoded search paths and relying on uv-managed environment