### PR TITLE
Fix logger shutdown handling

### DIFF
--- a/docs/configuration-design-roadmap.md
+++ b/docs/configuration-design-roadmap.md
@@ -11,7 +11,6 @@ safety (especially in Rust), and discoverability.
 The Rust configuration will expose a `ConfigBuilder` struct, allowing for a
 programmatic and type-safe setup of the logging system.
 
-
 ```rust
 // In femtologging::config::ConfigBuilder
 pub struct ConfigBuilder {

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -1,15 +1,18 @@
 # Rust Extension
 
-This project includes a small Rust extension built with
-[PyO3](https://pyo3.rs/). Initially, it exposed only a trivial `hello()`
-function and the `FemtoLogger` class. It has since grown to provide the core
-handler implementations as well:
+This project bundles a Rust extension built with
+[PyO3](https://pyo3.rs/). It started as a small experiment exposing a trivial
+`hello()` function and a basic `FemtoLogger`. The extension now implements the
+core logging components:
 
 - `FemtoStreamHandler` writes log records to `stdout` or `stderr` on a
   background thread.
 - `FemtoFileHandler` persists records to a file, also using a dedicated worker
   thread. It now provides `flush()` and `close()` to deterministically manage
   that thread.
+- `FemtoLogger` spawns a background thread for experimentation. When dropped it
+  sends a shutdown command over a `crossbeam-channel` so the thread exits even
+  if additional `Sender` clones remain.
 
 Packaging is handled by [maturin](https://maturin.rs/). The `[tool.maturin]`
 section in `pyproject.toml` declares the extension module as


### PR DESCRIPTION
## Summary
- send an explicit shutdown command to FemtoLogger's worker thread
- document new drop behaviour in the Rust extension guide
- verify drop doesn't block with a unit test
- add test for sends after drop failing

## Testing
- `make check-fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68659fc567f88322a5313d0445d62f3e