### PR TITLE
Update roadmap for hierarchical loggers

### DIFF
--- a/docs/configuration-design-roadmap.md
+++ b/docs/configuration-design-roadmap.md
@@ -11,7 +11,6 @@ safety (especially in Rust), and discoverability.
 The Rust configuration will expose a `ConfigBuilder` struct, allowing for a
 programmatic and type-safe setup of the logging system.
 
-
 ```rust
 // In femtologging::config::ConfigBuilder
 pub struct ConfigBuilder {

--- a/docs/configuration-roadmap.md
+++ b/docs/configuration-roadmap.md
@@ -14,10 +14,13 @@ expanded with specifics for the configuration design.
 - [ ] **Implement** `femtologging::handlers::FileHandlerBuilder` **and**
   `femtologging::handlers::StreamHandlerBuilder` **in Rust, implementing**
   `HandlerBuilderTrait`**.**
+
 - [ ] **Enable multiple handler IDs to be attached to a single logger in the
   builder API.**
+
 - [ ] **Store handlers in an `Arc` so that several loggers can share one
   instance safely.**
+
 - [ ] **Introduce a `Manager` registry with dotted-name hierarchy support and a
   root logger configuration.**
 

--- a/docs/configuration-roadmap.md
+++ b/docs/configuration-roadmap.md
@@ -14,6 +14,12 @@ expanded with specifics for the configuration design.
 - [ ] **Implement** `femtologging::handlers::FileHandlerBuilder` **and**
   `femtologging::handlers::StreamHandlerBuilder` **in Rust, implementing**
   `HandlerBuilderTrait`**.**
+- [ ] **Enable multiple handler IDs to be attached to a single logger in the
+  builder API.**
+- [ ] **Store handlers in an `Arc` so that several loggers can share one
+  instance safely.**
+- [ ] **Introduce a `Manager` registry with dotted-name hierarchy support and a
+  root logger configuration.**
 
 - [ ] **Expose a mirroring** `femtologging.ConfigBuilder` **in Python via**
   `PyO3` **bindings.**

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -31,6 +31,9 @@ libraries. Use the links below to explore each topic.
   - Summarizes picologging's key features prioritized for the Rust port.
 - [formatters-and-handlers-rust-port.md](./formatters-and-handlers-rust-port.md)
   - Design for moving formatter and handler logic to Rust with thread safety.
+- [logger-hierarchy-and-multi-handler.md](./logger-hierarchy-and-multi-handler.md)
+  - Describes how loggers share handlers and inherit configuration via dotted
+    names.
 - [rust-extension.md](./rust-extension.md)
   - Describes the small PyO3-based Rust extension shipped in the project.
 - [rust-multithreaded-logging-framework-for-python-design.md](./rust-multithreaded-logging-framework-for-python-design.md)

--- a/docs/logger-hierarchy-and-multi-handler.md
+++ b/docs/logger-hierarchy-and-multi-handler.md
@@ -2,8 +2,8 @@
 
 This note outlines the work required to add flexible logger/handler wiring to
 `femtologging`. The current prototype assumes each logger owns exactly one
-handler and that handlers are not shared. To match the capabilities of CPython's
-`logging`, the following features must be implemented:
+handler and that handlers are not shared. To match the capabilities of
+CPython's `logging`, the following features must be implemented:
 
 - multiple handlers per logger
 - multiple loggers targeting the same handler safely
@@ -24,7 +24,8 @@ handler and that handlers are not shared. To match the capabilities of CPython's
 3. **Support handler sharing**
    - Wrap handlers in `Arc` so they can be referenced by multiple loggers.
    - Ensure the internal MPSC sender is cloned for each logger.
-   - Document that handlers must be `Send + Sync`.
+   - Document that handlers must be `Send + Sync + 'static` and stored as
+     `Arc<dyn FemtoHandlerTrait + Send + Sync + 'static>`.
 
 4. **Implement propagation across the hierarchy**
    - Each logger gains a `propagate` flag (default `True`).
@@ -42,7 +43,7 @@ handler and that handlers are not shared. To match the capabilities of CPython's
 
 - Unit tests should verify that records are emitted once per handler even when
   shared between loggers.
-- Behavioural tests must cover propagation rules, ensuring child loggers inherit
-  levels and handlers from their parents unless explicitly overridden.
+- Behavioural tests must cover propagation rules to ensure child loggers
+  inherit levels and handlers from their parents unless explicitly overridden.
 - Concurrency tests should create several loggers writing to the same file
   handler from multiple threads and assert no data loss.

--- a/docs/logger-hierarchy-and-multi-handler.md
+++ b/docs/logger-hierarchy-and-multi-handler.md
@@ -2,8 +2,8 @@
 
 This note outlines the work required to add flexible logger/handler wiring to
 `femtologging`. The current prototype assumes each logger owns exactly one
-handler and that handlers are not shared. To match the capabilities of
-CPython's `logging`, the following features must be implemented:
+handler and that handlers are not shared. To match the capabilities of CPython's
+`logging`, the following features must be implemented:
 
 - multiple handlers per logger
 - multiple loggers targeting the same handler safely
@@ -12,38 +12,47 @@ CPython's `logging`, the following features must be implemented:
 ## Steps to Implement
 
 1. **Introduce a Manager registry**
+
    - Maintain a global `Manager` struct storing all loggers by name.
    - Each logger records its parent based on dotted name segments.
    - The root logger is created on first use and acts as the top of the tree.
 
 2. **Allow multiple handlers per logger**
+
    - Change `FemtoLogger` to hold a `Vec<Arc<dyn FemtoHandlerTrait>>`.
    - Expose `add_handler()` and `remove_handler()` APIs.
    - Update logging macros to dispatch each record to every configured handler.
 
 3. **Support handler sharing**
+
    - Wrap handlers in `Arc` so they can be referenced by multiple loggers.
    - Ensure the internal MPSC sender is cloned for each logger.
    - Document that handlers must be `Send + Sync + 'static` and stored as
      `Arc<dyn FemtoHandlerTrait + Send + Sync + 'static>`.
 
 4. **Implement propagation across the hierarchy**
+
    - Each logger gains a `propagate` flag (default `True`).
    - When a logger handles a record, it first passes it to its own handlers,
      then forwards it to the parent logger if `propagate` is enabled.
    - Effective log level is computed by walking up the hierarchy.
 
 5. **Provide configuration helpers**
+
    - Extend the builder API to attach multiple handler IDs per logger.
    - Allow handlers defined once to be referenced from several loggers.
-   - Implement a `get_logger(name)` function in Python that mirrors
-     CPython's semantics and returns existing instances from the registry.
+   - Implement a `get_logger(name)` function in Python that mirrors CPython's
+     semantics and returns existing instances from the registry.
 
 ## Testing Considerations
 
 - Unit tests should verify that records are emitted once per handler even when
   shared between loggers.
-- Behavioural tests must cover propagation rules to ensure child loggers
-  inherit levels and handlers from their parents unless explicitly overridden.
+- Behavioural tests must cover propagation rules to ensure child loggers inherit
+  levels and handlers from their parents unless explicitly overridden.
 - Concurrency tests should create several loggers writing to the same file
-  handler from multiple threads and assert no data loss.
+  handler from multiple threads. They must assert that each log record is
+  written exactly once with no data loss. Ordering between threads is not
+  guaranteed, but records emitted by a single logger should appear in the order
+  they were produced. Tests must also check for duplicate records when a handler
+  is shared across threads.

--- a/docs/logger-hierarchy-and-multi-handler.md
+++ b/docs/logger-hierarchy-and-multi-handler.md
@@ -1,0 +1,48 @@
+# Logger Hierarchy and Handler Relationships
+
+This note outlines the work required to add flexible logger/handler wiring to
+`femtologging`. The current prototype assumes each logger owns exactly one
+handler and that handlers are not shared. To match the capabilities of CPython's
+`logging`, the following features must be implemented:
+
+- multiple handlers per logger
+- multiple loggers targeting the same handler safely
+- hierarchical logger configuration using dotted names with propagation
+
+## Steps to Implement
+
+1. **Introduce a Manager registry**
+   - Maintain a global `Manager` struct storing all loggers by name.
+   - Each logger records its parent based on dotted name segments.
+   - The root logger is created on first use and acts as the top of the tree.
+
+2. **Allow multiple handlers per logger**
+   - Change `FemtoLogger` to hold a `Vec<Arc<dyn FemtoHandlerTrait>>`.
+   - Expose `add_handler()` and `remove_handler()` APIs.
+   - Update logging macros to dispatch each record to every configured handler.
+
+3. **Support handler sharing**
+   - Wrap handlers in `Arc` so they can be referenced by multiple loggers.
+   - Ensure the internal MPSC sender is cloned for each logger.
+   - Document that handlers must be `Send + Sync`.
+
+4. **Implement propagation across the hierarchy**
+   - Each logger gains a `propagate` flag (default `True`).
+   - When a logger handles a record, it first passes it to its own handlers,
+     then forwards it to the parent logger if `propagate` is enabled.
+   - Effective log level is computed by walking up the hierarchy.
+
+5. **Provide configuration helpers**
+   - Extend the builder API to attach multiple handler IDs per logger.
+   - Allow handlers defined once to be referenced from several loggers.
+   - Implement a `get_logger(name)` function in Python that mirrors
+     CPython's semantics and returns existing instances from the registry.
+
+## Testing Considerations
+
+- Unit tests should verify that records are emitted once per handler even when
+  shared between loggers.
+- Behavioural tests must cover propagation rules, ensuring child loggers inherit
+  levels and handlers from their parents unless explicitly overridden.
+- Concurrency tests should create several loggers writing to the same file
+  handler from multiple threads and assert no data loss.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,7 +34,7 @@ that design.
 - [ ] Route records to all configured handlers.
 - [ ] Support attaching multiple handlers to a single logger.
 - [ ] Allow a handler instance to be shared by multiple loggers safely.
-- [ ] Build a `Manager` registry so `get_logger(name)` returns existing
+- [ ] Build a `Manager` registry, so `get_logger(name)` returns existing
   loggers and establishes parent relationships based on dotted names.
 - [ ] Implement `propagate` behaviour so loggers inherit configuration from
   their parents up to the root logger.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,8 +34,8 @@ that design.
 - [ ] Route records to all configured handlers.
 - [ ] Support attaching multiple handlers to a single logger.
 - [ ] Allow a handler instance to be shared by multiple loggers safely.
-- [ ] Build a `Manager` registry, so `get_logger(name)` returns existing
-  loggers and establishes parent relationships based on dotted names.
+- [ ] Build a `Manager` registry, so `get_logger(name)` returns existing loggers
+  and establishes parent relationships based on dotted names.
 - [ ] Implement `propagate` behaviour so loggers inherit configuration from
   their parents up to the root logger.
 - [x] Implement the `FemtoFormatter` trait with a default formatter.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,7 +31,13 @@ that design.
   - [ ] Add a `FemtoLevel` enum and per‑logger level checks.
   - [ ] Provide `debug!`, `info!`, `warn!`, and `error!` macros that capture
     source location.
-  - [ ] Route records to all configured handlers.
+- [ ] Route records to all configured handlers.
+- [ ] Support attaching multiple handlers to a single logger.
+- [ ] Allow a handler instance to be shared by multiple loggers safely.
+- [ ] Build a `Manager` registry so `get_logger(name)` returns existing
+  loggers and establishes parent relationships based on dotted names.
+- [ ] Implement `propagate` behaviour so loggers inherit configuration from
+  their parents up to the root logger.
 - [x] Implement the `FemtoFormatter` trait with a default formatter.
 - [x] Select and integrate an MPSC channel for producer‑consumer queues.
 - [x] Create `FemtoStreamHandler` and `FemtoFileHandler`, each running in a


### PR DESCRIPTION
## Summary
- document multi-handler and hierarchical logger design
- extend configuration and implementation roadmaps with tasks for shared handlers

## Testing
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_6865f69398e88322b5d8b5e359ca3bcb

## Summary by Sourcery

Document multi-handler and hierarchical logger design and update implementation and configuration roadmaps with tasks for handler sharing, Manager registry, and propagation behaviour.

Documentation:
- Add a new design note outlining logger hierarchy, multi-handler support, handler sharing via Arc, and propagation semantics
- Extend implementation and configuration roadmaps with tasks for multiple handlers per logger, shared handler instances, Manager registry with dotted-name hierarchy, and propagate behaviour