### PR TITLE
Implement metadata in FemtoLogRecord

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,8 +26,8 @@ that design.
 
 - [ ] Define the `FemtoLogRecord` structure and implement core `FemtoLogger`
   logic, including efficient level checking and logging macros.
-  - [ ] Expand `FemtoLogRecord` with timestamp and source location. Thread info
-    and structured key‑values should also be stored.
+  - [x] Expand `FemtoLogRecord` with timestamp and source location. Thread info
+    and structured key‑values are stored on each record.
   - [ ] Add a `FemtoLevel` enum and per‑logger level checks.
   - [ ] Provide `debug!`, `info!`, `warn!`, and `error!` macros that capture
     source location.

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -16,3 +16,7 @@ section in `pyproject.toml` declares the extension module as
 `femtologging._femtologging_rs`, so running `pip install .` automatically builds
 the Rust code. Windows users may need the MSVC build tools installed or may need
 to run maturin with `--compatibility windows`.
+
+`FemtoLogRecord` now captures additional metadata when created. Each record
+stores a timestamp, source file and line, module path, thread ID, thread name if
+available, and a map of structured key‑value pairs.

--- a/rust_extension/src/log_record.rs
+++ b/rust_extension/src/log_record.rs
@@ -1,8 +1,13 @@
-/// Represents a single log event with level and message data.
+use std::collections::BTreeMap;
+/// Represents a single log event with associated metadata.
 ///
-/// This struct is intentionally minimal for now. Additional fields such as a
-/// timestamp may be added as functionality grows.
+/// `FemtoLogRecord` captures not only the textual message but also contextual
+/// information about where and when the log was created. This data can later be
+/// used by formatters and handlers. The structure remains simple so that
+/// creating a record on the logging hot path is cheap.
 use std::fmt;
+use std::thread::{self, ThreadId};
+use std::time::SystemTime;
 
 #[derive(Clone, Debug)]
 pub struct FemtoLogRecord {
@@ -12,6 +17,20 @@ pub struct FemtoLogRecord {
     pub level: String,
     /// The log message content.
     pub message: String,
+    /// Rust module path where the log call originated.
+    pub module_path: String,
+    /// Source file name for the log call.
+    pub filename: String,
+    /// Line number in the source file.
+    pub line_number: u32,
+    /// Time the record was created.
+    pub timestamp: SystemTime,
+    /// ID of the thread that created the record.
+    pub thread_id: ThreadId,
+    /// Name of the thread that created the record (if any).
+    pub thread_name: Option<String>,
+    /// Structured key-value pairs attached to the record.
+    pub key_values: BTreeMap<String, String>,
 }
 
 impl FemtoLogRecord {
@@ -21,6 +40,37 @@ impl FemtoLogRecord {
             logger: logger.to_owned(),
             level: level.to_owned(),
             message: message.to_owned(),
+            module_path: String::new(),
+            filename: String::new(),
+            line_number: 0,
+            timestamp: SystemTime::now(),
+            thread_id: thread::current().id(),
+            thread_name: thread::current().name().map(|n| n.to_string()),
+            key_values: BTreeMap::new(),
+        }
+    }
+
+    /// Construct a log record with explicit source location and key-values.
+    pub fn with_metadata(
+        logger: &str,
+        level: &str,
+        message: &str,
+        module_path: &str,
+        filename: &str,
+        line_number: u32,
+        key_values: BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            logger: logger.to_owned(),
+            level: level.to_owned(),
+            message: message.to_owned(),
+            module_path: module_path.to_owned(),
+            filename: filename.to_owned(),
+            line_number,
+            timestamp: SystemTime::now(),
+            thread_id: thread::current().id(),
+            thread_name: thread::current().name().map(|n| n.to_string()),
+            key_values,
         }
     }
 }

--- a/rust_extension/tests/log_record_tests.rs
+++ b/rust_extension/tests/log_record_tests.rs
@@ -1,0 +1,42 @@
+use _femtologging_rs::FemtoLogRecord;
+use std::collections::BTreeMap;
+use std::thread;
+use std::time::SystemTime;
+
+#[test]
+fn new_populates_metadata() {
+    let before = SystemTime::now();
+    let record = FemtoLogRecord::new("core", "INFO", "hello");
+    assert_eq!(record.logger, "core");
+    assert_eq!(record.level, "INFO");
+    assert_eq!(record.message, "hello");
+    assert!(record.timestamp >= before && record.timestamp <= SystemTime::now());
+    assert_eq!(record.module_path, "");
+    assert_eq!(record.filename, "");
+    assert_eq!(record.line_number, 0);
+    assert_eq!(record.thread_id, thread::current().id());
+    assert_eq!(
+        record.thread_name,
+        thread::current().name().map(|s| s.to_string())
+    );
+    assert!(record.key_values.is_empty());
+}
+
+#[test]
+fn with_metadata_sets_fields() {
+    let mut kvs = BTreeMap::new();
+    kvs.insert("user".to_string(), "alice".to_string());
+    let record = FemtoLogRecord::with_metadata(
+        "core",
+        "ERROR",
+        "fail",
+        "mod::path",
+        "file.rs",
+        42,
+        kvs.clone(),
+    );
+    assert_eq!(record.module_path, "mod::path");
+    assert_eq!(record.filename, "file.rs");
+    assert_eq!(record.line_number, 42);
+    assert_eq!(record.key_values, kvs);
+}


### PR DESCRIPTION
## Summary
- expand `FemtoLogRecord` with timestamp, source and thread info, and structured key-values
- document metadata storage in roadmap and rust extension docs
- add constructor with metadata and tests for new behaviour

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68673ffee32c8322bf7aa74f6bb171ec