### PR TITLE
Implement multi-handler loom tests

### DIFF
--- a/docs/logger-hierarchy-and-multi-handler.md
+++ b/docs/logger-hierarchy-and-multi-handler.md
@@ -9,6 +9,7 @@ is implementing hierarchical configuration using dotted names with propagation.
 - [x] multiple handlers per logger
 - [x] multiple loggers targeting the same handler safely
 - hierarchical logger configuration using dotted names with propagation
+- add_handler is currently only exposed in Rust; Python APIs will follow
 
 ## Steps to Implement
 

--- a/docs/logger-hierarchy-and-multi-handler.md
+++ b/docs/logger-hierarchy-and-multi-handler.md
@@ -1,12 +1,13 @@
 # Logger Hierarchy and Handler Relationships
 
-This note outlines the work required to add flexible logger/handler wiring to
-`femtologging`. The current prototype assumes each logger owns exactly one
-handler and that handlers are not shared. To match the capabilities of CPython's
-`logging`, the following features must be implemented:
+This note outlines the remaining work to add flexible logger/handler wiring to
+`femtologging`. The prototype originally assumed each logger owned a single
+handler and that handlers were not shared. The codebase now supports multiple
+handlers per logger and safely sharing a handler between loggers. The next step
+is implementing hierarchical configuration using dotted names with propagation.
 
-- multiple handlers per logger
-- multiple loggers targeting the same handler safely
+- [x] multiple handlers per logger
+- [x] multiple loggers targeting the same handler safely
 - hierarchical logger configuration using dotted names with propagation
 
 ## Steps to Implement

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,9 +31,9 @@ that design.
   - [x] Add a `FemtoLevel` enum and per‑logger level checks.
   - [ ] Provide `debug!`, `info!`, `warn!`, and `error!` macros that capture
     source location.
-- [ ] Route records to all configured handlers.
-- [ ] Support attaching multiple handlers to a single logger.
-- [ ] Allow a handler instance to be shared by multiple loggers safely.
+  - [x] Route records to all configured handlers.
+  - [x] Support attaching multiple handlers to a single logger.
+  - [x] Allow a handler instance to be shared by multiple loggers safely.
 - [ ] Build a `Manager` registry, so `get_logger(name)` returns existing loggers
   and establishes parent relationships based on dotted names.
 - [ ] Implement `propagate` behaviour so loggers inherit configuration from

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -28,3 +28,10 @@ key‑value pairs. Use `FemtoLogRecord::new` for default metadata or
 messages below that threshold. The `set_level()` method updates the logger's
 minimum level from Python or Rust code. The `log()` method returns the formatted
 string or `None` when a message is filtered out.
+
+`FemtoLogger` can now dispatch a record to multiple handlers. Handlers implement
+`FemtoHandlerTrait` and run their I/O on worker threads. A logger holds a
+`Vec<Arc<dyn FemtoHandlerTrait>>`; calling `add_handler()` stores another
+handler reference. When `log()` creates a `FemtoLogRecord`, it sends a clone to
+each configured handler, ensuring thread‑safe routing via the handlers' MPSC
+queues.

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -36,7 +36,7 @@ handler reference. When `log()` creates a `FemtoLogRecord`, it sends a clone to
 each configured handler, ensuring thread‑safe routing via the handlers' MPSC
 queues.
 
-Currently `add_handler()` is only available from Rust code. Python users still
+Currently, `add_handler()` is only available from Rust code. Python users still
 create a logger with a single default handler. Support for attaching additional
 handlers from Python will be added once the trait objects can be safely
 transferred across the FFI boundary.

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -35,3 +35,8 @@ string or `None` when a message is filtered out.
 handler reference. When `log()` creates a `FemtoLogRecord`, it sends a clone to
 each configured handler, ensuring thread‑safe routing via the handlers' MPSC
 queues.
+
+Currently `add_handler()` is only available from Rust code. Python users still
+create a logger with a single default handler. Support for attaching additional
+handlers from Python will be added once the trait objects can be safely
+transferred across the FFI boundary.

--- a/rust_extension/tests/heavy/loom_topologies.rs
+++ b/rust_extension/tests/heavy/loom_topologies.rs
@@ -8,7 +8,7 @@ use loom::thread;
 use std::io::{self, Write};
 
 use _femtologging_rs::{
-    DefaultFormatter, FemtoLogger, FemtoHandlerTrait, FemtoStreamHandler, FemtoLogRecord,
+    DefaultFormatter, FemtoLogger, FemtoHandlerTrait, FemtoStreamHandler,
 };
 
 #[derive(Clone)]

--- a/rust_extension/tests/heavy/loom_topologies.rs
+++ b/rust_extension/tests/heavy/loom_topologies.rs
@@ -1,0 +1,156 @@
+//! Concurrency tests for various logger/handler topologies.
+//!
+//! These tests leverage `loom` to explore possible thread interleavings
+//! and ensure log records are routed correctly without duplication.
+
+use loom::sync::{Arc, Mutex};
+use loom::thread;
+use std::io::{self, Write};
+
+use _femtologging_rs::{
+    DefaultFormatter, FemtoLogger, FemtoHandlerTrait, FemtoStreamHandler, FemtoLogRecord,
+};
+
+#[derive(Clone)]
+struct LoomBuf(Arc<Mutex<Vec<u8>>>);
+
+impl Write for LoomBuf {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0
+            .lock()
+            .expect("Failed to lock LoomBuf for write")
+            .write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0
+            .lock()
+            .expect("Failed to lock LoomBuf for flush")
+            .flush()
+    }
+}
+
+fn read_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
+    let data = buffer
+        .lock()
+        .expect("Failed to lock buffer for read")
+        .clone();
+    String::from_utf8(data).expect("Buffer contains invalid UTF-8")
+}
+
+#[test]
+#[ignore]
+fn loom_single_logger_multi_handlers() {
+    loom::model(|| {
+        let buf1 = Arc::new(Mutex::new(Vec::new()));
+        let buf2 = Arc::new(Mutex::new(Vec::new()));
+        let h1 = Arc::new(FemtoStreamHandler::new(
+            LoomBuf(Arc::clone(&buf1)),
+            DefaultFormatter,
+        ));
+        let h2 = Arc::new(FemtoStreamHandler::new(
+            LoomBuf(Arc::clone(&buf2)),
+            DefaultFormatter,
+        ));
+        let mut logger = FemtoLogger::new("core".to_string());
+        logger.add_handler(h1.clone() as Arc<dyn FemtoHandlerTrait>);
+        logger.add_handler(h2.clone() as Arc<dyn FemtoHandlerTrait>);
+        let logger = Arc::new(logger);
+        let l = Arc::clone(&logger);
+        let t = thread::spawn(move || {
+            l.log("INFO", "one");
+        });
+        logger.log("INFO", "two");
+        t.join().expect("Thread panicked");
+        drop(logger);
+        drop(h1);
+        drop(h2);
+        let mut lines1: Vec<_> = read_output(&buf1).lines().collect();
+        let mut lines2: Vec<_> = read_output(&buf2).lines().collect();
+        lines1.sort();
+        lines2.sort();
+        assert_eq!(lines1, ["core [INFO] one", "core [INFO] two"]);
+        assert_eq!(lines2, ["core [INFO] one", "core [INFO] two"]);
+    });
+}
+
+#[test]
+#[ignore]
+fn loom_shared_handler_multi_loggers() {
+    loom::model(|| {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let handler = Arc::new(FemtoStreamHandler::new(
+            LoomBuf(Arc::clone(&buffer)),
+            DefaultFormatter,
+        ));
+        let mut l1 = FemtoLogger::new("a".to_string());
+        let mut l2 = FemtoLogger::new("b".to_string());
+        l1.add_handler(handler.clone() as Arc<dyn FemtoHandlerTrait>);
+        l2.add_handler(handler.clone() as Arc<dyn FemtoHandlerTrait>);
+        let l1 = Arc::new(l1);
+        let l2 = Arc::new(l2);
+        let t = thread::spawn({
+            let l1 = Arc::clone(&l1);
+            move || {
+                l1.log("INFO", "one");
+            }
+        });
+        l2.log("INFO", "two");
+        t.join().expect("Thread panicked");
+        drop(l1);
+        drop(l2);
+        drop(handler);
+        let mut lines: Vec<_> = read_output(&buffer).lines().collect();
+        lines.sort();
+        assert_eq!(lines, ["a [INFO] one", "b [INFO] two"]);
+    });
+}
+
+#[test]
+#[ignore]
+fn loom_multiple_loggers_multiple_handlers() {
+    loom::model(|| {
+        let shared_buf = Arc::new(Mutex::new(Vec::new()));
+        let buf1 = Arc::new(Mutex::new(Vec::new()));
+        let buf2 = Arc::new(Mutex::new(Vec::new()));
+        let shared_handler = Arc::new(FemtoStreamHandler::new(
+            LoomBuf(Arc::clone(&shared_buf)),
+            DefaultFormatter,
+        ));
+        let h1 = Arc::new(FemtoStreamHandler::new(
+            LoomBuf(Arc::clone(&buf1)),
+            DefaultFormatter,
+        ));
+        let h2 = Arc::new(FemtoStreamHandler::new(
+            LoomBuf(Arc::clone(&buf2)),
+            DefaultFormatter,
+        ));
+        let mut l1 = FemtoLogger::new("l1".to_string());
+        l1.add_handler(shared_handler.clone() as Arc<dyn FemtoHandlerTrait>);
+        l1.add_handler(h1.clone() as Arc<dyn FemtoHandlerTrait>);
+        let mut l2 = FemtoLogger::new("l2".to_string());
+        l2.add_handler(shared_handler.clone() as Arc<dyn FemtoHandlerTrait>);
+        l2.add_handler(h2.clone() as Arc<dyn FemtoHandlerTrait>);
+        let l1 = Arc::new(l1);
+        let l2 = Arc::new(l2);
+        let t = thread::spawn({
+            let l1 = Arc::clone(&l1);
+            move || {
+                l1.log("INFO", "one");
+            }
+        });
+        l2.log("INFO", "two");
+        t.join().expect("Thread panicked");
+        drop(l1);
+        drop(l2);
+        drop(shared_handler);
+        drop(h1);
+        drop(h2);
+        let mut shared_lines: Vec<_> = read_output(&shared_buf).lines().collect();
+        shared_lines.sort();
+        assert_eq!(shared_lines, ["l1 [INFO] one", "l2 [INFO] two"]);
+        assert_eq!(read_output(&buf1), "l1 [INFO] one\n");
+        assert_eq!(read_output(&buf2), "l2 [INFO] two\n");
+    });
+}
+


### PR DESCRIPTION
## Summary
- update docs on logger/handler progress
- add loom tests covering logger and handler permutations

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6869be0b953c8322bf794eff92cd93d5

## Summary by Sourcery

Enable multi-handler support by replacing the single-handler queue with a handler list, and add unit and loom tests to validate multi-handler and shared-handler behaviors.

New Features:
- Allow attaching multiple handlers to a single logger
- Support sharing the same handler instance across multiple loggers

Enhancements:
- Remove the background channel and thread in favor of directly invoking handlers
- Update documentation and roadmap to reflect multi-handler and shared-handler support

Documentation:
- Update logger-hierarchy-and-multi-handler, rust-extension, and roadmap documentation with multi-handler details

Tests:
- Add unit tests for multi-handler routing and shared-handler scenarios
- Add loom-based concurrency tests for various logger/handler topologies