### PR TITLE
Add configurable overflow handling to FemtoFileHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,15 @@ This variant includes a small Rust extension built with [PyO3](https://pyo3.rs/)
 and packaged using [maturin](https://maturin.rs/). Ensure the
 [Rust tool‑chain](https://www.rust-lang.org/tools/install) is installed, then
 run `pip install .` or `make build` to compile the extension.
+
+## Usage
+
+```python
+from femtologging import FemtoFileHandler
+
+handler = FemtoFileHandler.with_capacity_flush_timeout(
+    "app.log", capacity=32, flush_interval=1, timeout_ms=200
+)
+handler.handle("core", "INFO", "hello")
+handler.close()
+```

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -65,7 +65,13 @@ pub struct FemtoHandler;
 
 Implementations should forward the record to an internal queue with `try_send`
 so the caller never blocks. If the queue is full, the record is silently dropped
-and a warning is written to `stderr`.
+and a warning is written to `stderr`. Advanced use cases can specify an overflow
+policy when constructing a handler:
+
+- **Drop** – current default; new records are discarded when the queue is full.
+- **Block** – the call blocks until space becomes available.
+- **Timeout** – wait for a fixed duration before giving up and dropping the
+  record.
 
 ### StreamHandler
 

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -68,7 +68,7 @@ so the caller never blocks. If the queue is full, the record is silently dropped
 and a warning is written to `stderr`. Advanced use cases can specify an overflow
 policy when constructing a handler:
 
-- **Drop** – current default; new records are discarded when the queue is full.
+- **Drop** – current default; records are discarded when the queue is full.
 - **Block** – the call blocks until space becomes available.
 - **Timeout** – wait for a fixed duration before giving up and dropping the
   record.

--- a/rust_extension/Cargo.toml
+++ b/rust_extension/Cargo.toml
@@ -12,9 +12,13 @@ pyo3 = { version = "0.21.2", features = ["extension-module"] }
 crossbeam-channel = "0.5.15"
 log = "0.4"
 
+[features]
+test-util = []
+
 [dev-dependencies]
 rstest = "0.25"
 tempfile = "^3.20.0"
 proptest = "1.0.0"
 loom = "0.7.2"
 itertools = "0.10"
+_femtologging_rs = { path = ".", package = "femtologging_rs", features = ["test-util"] }

--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -8,7 +8,7 @@ mod log_record;
 mod logger;
 mod stream_handler;
 
-pub use file_handler::{FemtoFileHandler, OverflowPolicy};
+pub use file_handler::{FemtoFileHandler, HandlerConfig, OverflowPolicy, TestConfig};
 pub use formatter::{DefaultFormatter, FemtoFormatter};
 pub use handler::{FemtoHandler, FemtoHandlerTrait};
 pub use level::FemtoLevel;

--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -8,7 +8,7 @@ mod log_record;
 mod logger;
 mod stream_handler;
 
-pub use file_handler::FemtoFileHandler;
+pub use file_handler::{FemtoFileHandler, OverflowPolicy};
 pub use formatter::{DefaultFormatter, FemtoFormatter};
 pub use handler::{FemtoHandler, FemtoHandlerTrait};
 pub use level::FemtoLevel;

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -130,6 +130,7 @@ def test_blocking_policy_basic(tmp_path: Path) -> None:
 
 
 def test_blocking_policy_over_capacity(tmp_path: Path) -> None:
+    """Verify blocking behaviour when capacity is exceeded."""
     path = tmp_path / "block_over.log"
     handler = FemtoFileHandler.with_capacity_flush_blocking(str(path), 2, 1)
     handler.handle("core", "INFO", "first")
@@ -145,7 +146,7 @@ def test_timeout_policy_basic(tmp_path: Path) -> None:
     """Test basic functionality of timeout policy in FemtoFileHandler."""
     path = tmp_path / "timeout.log"
     handler = FemtoFileHandler.with_capacity_flush_timeout(
-        str(path), 1, 1, timeout_ms=10
+        str(path), 1, 1, timeout_ms=500
     )
     handler.handle("core", "INFO", "first")
     handler.close()
@@ -153,9 +154,10 @@ def test_timeout_policy_basic(tmp_path: Path) -> None:
 
 
 def test_timeout_policy_over_capacity(tmp_path: Path) -> None:
+    """Ensure timeout policy flushes when over capacity."""
     path = tmp_path / "timeout_over.log"
     handler = FemtoFileHandler.with_capacity_flush_timeout(
-        str(path), 2, 1, timeout_ms=100
+        str(path), 2, 1, timeout_ms=1000
     )
     handler.handle("core", "INFO", "first")
     handler.handle("core", "INFO", "second")

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -118,3 +118,21 @@ def test_file_handler_flush_interval_one(
     with file_handler_factory(path, 8, 1) as handler:
         handler.handle("core", "INFO", "message")
     assert path.read_text() == "core [INFO] message\n"
+
+
+def test_blocking_policy_basic(tmp_path: Path) -> None:
+    path = tmp_path / "block.log"
+    handler = FemtoFileHandler.with_capacity_flush_blocking(str(path), 1, 1)
+    handler.handle("core", "INFO", "first")
+    handler.close()
+    assert path.read_text() == "core [INFO] first\n"
+
+
+def test_timeout_policy_basic(tmp_path: Path) -> None:
+    path = tmp_path / "timeout.log"
+    handler = FemtoFileHandler.with_capacity_flush_timeout(
+        str(path), 1, 1, timeout_ms=10
+    )
+    handler.handle("core", "INFO", "first")
+    handler.close()
+    assert path.read_text() == "core [INFO] first\n"

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -128,6 +128,18 @@ def test_blocking_policy_basic(tmp_path: Path) -> None:
     assert path.read_text() == "core [INFO] first\n"
 
 
+def test_blocking_policy_over_capacity(tmp_path: Path) -> None:
+    path = tmp_path / "block_over.log"
+    handler = FemtoFileHandler.with_capacity_flush_blocking(str(path), 2, 1)
+    handler.handle("core", "INFO", "first")
+    handler.handle("core", "INFO", "second")
+    handler.handle("core", "INFO", "third")
+    handler.close()
+    assert (
+        path.read_text() == "core [INFO] first\ncore [INFO] second\ncore [INFO] third\n"
+    )
+
+
 def test_timeout_policy_basic(tmp_path: Path) -> None:
     path = tmp_path / "timeout.log"
     handler = FemtoFileHandler.with_capacity_flush_timeout(
@@ -136,3 +148,17 @@ def test_timeout_policy_basic(tmp_path: Path) -> None:
     handler.handle("core", "INFO", "first")
     handler.close()
     assert path.read_text() == "core [INFO] first\n"
+
+
+def test_timeout_policy_over_capacity(tmp_path: Path) -> None:
+    path = tmp_path / "timeout_over.log"
+    handler = FemtoFileHandler.with_capacity_flush_timeout(
+        str(path), 2, 1, timeout_ms=100
+    )
+    handler.handle("core", "INFO", "first")
+    handler.handle("core", "INFO", "second")
+    handler.handle("core", "INFO", "third")
+    handler.close()
+    assert (
+        path.read_text() == "core [INFO] first\ncore [INFO] second\ncore [INFO] third\n"
+    )

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -121,6 +121,7 @@ def test_file_handler_flush_interval_one(
 
 
 def test_blocking_policy_basic(tmp_path: Path) -> None:
+    """Verify flushing and writing when using the blocking policy."""
     path = tmp_path / "block.log"
     handler = FemtoFileHandler.with_capacity_flush_blocking(str(path), 1, 1)
     handler.handle("core", "INFO", "first")
@@ -141,6 +142,7 @@ def test_blocking_policy_over_capacity(tmp_path: Path) -> None:
 
 
 def test_timeout_policy_basic(tmp_path: Path) -> None:
+    """Test basic functionality of timeout policy in FemtoFileHandler."""
     path = tmp_path / "timeout.log"
     handler = FemtoFileHandler.with_capacity_flush_timeout(
         str(path), 1, 1, timeout_ms=10


### PR DESCRIPTION
## Summary
Introduce configurable overflow policies for the FemtoFileHandler queue, expose them to Python and tests, and add documentation and usage examples.

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686a978ac0348322846a35a49593f7c2

## Summary by Sourcery

Introduce configurable overflow policies for the FemtoFileHandler queue, expose them to Python and tests, and add documentation and usage examples.

New Features:
- Add OverflowPolicy enum to control how the handler behaves when its queue is full
- Expose new Python constructors for blocking and timeout overflow behaviors
- Provide a test-only with_writer_for_test constructor for injecting custom writers and policies
- Include a usage example of with_capacity_flush_timeout in the README

Enhancements:
- Centralize queue and flush behavior into a new with_capacity_flush_policy method
- Export OverflowPolicy in the library’s public API

Documentation:
- Document overflow policies and usage example in README and handler documentation

Tests:
- Add Rust tests for blocking and timeout policies using the test writer
- Add Python tests for blocking and timeout overflow behaviors

## Summary by Sourcery

Enable configurable overflow handling for FemtoFileHandler queue by introducing OverflowPolicy with Drop, Block, and Timeout options, centralizing handler setup into HandlerConfig and spawn_worker, exposing policy-aware constructors in both Rust and Python, adding test utilities and coverage, and updating documentation and Cargo configuration.

New Features:
- Introduce OverflowPolicy enum to control Drop, Block, or Timeout behavior when the queue is full
- Add HandlerConfig and TestConfig structs for configurable file handler setup and test injection
- Expose Python constructors for blocking and timeout-based capacity and flush policies
- Provide a test-only with_writer_for_test constructor for injecting custom writers and policies
- Export OverflowPolicy, HandlerConfig, and TestConfig in the public Rust API

Enhancements:
- Centralize handler construction and background worker logic into create_with_policy, with_capacity_flush_policy, and spawn_worker methods

Build:
- Add "test-util" feature and update Cargo.toml dev-dependencies for test support

Documentation:
- Update README with usage examples for timeout-based overflow handling
- Extend handler documentation to describe configurable overflow policies

Tests:
- Add Rust unit tests covering blocking and timeout overflow policies using TestConfig
- Add Python integration tests for blocking and timeout policies under various capacity and flush scenarios