### PR TITLE
Implement logger registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ This variant includes a small Rust extension built with [PyO3](https://pyo3.rs/)
 and packaged using [maturin](https://maturin.rs/). Ensure the
 [Rust tool‑chain](https://www.rust-lang.org/tools/install) is installed, then
 run `pip install .` or `make build` to compile the extension.
+
+```python
+from femtologging import get_logger
+
+log = get_logger("demo")
+log.log("INFO", "hello from femtologging")
+```

--- a/docs/configuration-roadmap.md
+++ b/docs/configuration-roadmap.md
@@ -21,7 +21,7 @@ expanded with specifics for the configuration design.
 - [ ] **Store handlers in an `Arc` so that several loggers can share one
   instance safely.**
 
-- [ ] **Introduce a `Manager` registry with dotted-name hierarchy support and a
+- [x] **Introduce a `Manager` registry with dotted-name hierarchy support and a
   root logger configuration.**
 
 - [ ] **Expose a mirroring** `femtologging.ConfigBuilder` **in Python via**

--- a/docs/logging-sequence-diagrams.md
+++ b/docs/logging-sequence-diagrams.md
@@ -35,6 +35,25 @@ sequenceDiagram
     LoggingMod  --> Client: Logger
 ```
 
+## `Manager.get_logger()` – femtologging
+
+```mermaid
+sequenceDiagram
+    participant PythonAPI as Python API
+    participant Manager
+    participant FemtoLogger
+
+    PythonAPI->>Manager: get_logger(py, name)
+    alt logger exists
+        Manager-->>PythonAPI: return existing FemtoLogger
+    else logger does not exist
+        Manager->>Manager: determine parent (dotted-name logic)
+        Manager->>FemtoLogger: FemtoLogger::with_parent(name, parent)
+        Manager->>Manager: store logger in registry
+        Manager-->>PythonAPI: return new FemtoLogger
+    end
+```
+
 ______________________________________________________________________
 
 ## 2 `basicConfig(...)` – one-shot root logger configuration

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,7 +34,7 @@ that design.
   - [x] Route records to all configured handlers.
   - [x] Support attaching multiple handlers to a single logger.
   - [x] Allow a handler instance to be shared by multiple loggers safely.
-- [ ] Build a `Manager` registry, so `get_logger(name)` returns existing loggers
+- [x] Build a `Manager` registry, so `get_logger(name)` returns existing loggers
   and establishes parent relationships based on dotted names.
 - [ ] Implement `propagate` behaviour so loggers inherit configuration from
   their parents up to the root logger.

--- a/femtologging/__init__.py
+++ b/femtologging/__init__.py
@@ -7,6 +7,7 @@ PACKAGE_NAME = "femtologging"
 rust = __import__(f"_{PACKAGE_NAME}_rs")
 hello = rust.hello  # type: ignore[attr-defined]
 FemtoLogger = rust.FemtoLogger  # type: ignore[attr-defined]
+get_logger = rust.get_logger  # type: ignore[attr-defined]
 FemtoHandler = rust.FemtoHandler  # type: ignore[attr-defined]
 FemtoStreamHandler = rust.FemtoStreamHandler  # type: ignore[attr-defined]
 FemtoFileHandler = rust.FemtoFileHandler  # type: ignore[attr-defined]
@@ -14,6 +15,7 @@ FemtoFileHandler = rust.FemtoFileHandler  # type: ignore[attr-defined]
 __all__ = [
     "FemtoHandler",
     "FemtoLogger",
+    "get_logger",
     "FemtoStreamHandler",
     "FemtoFileHandler",
     "hello",

--- a/femtologging/__init__.py
+++ b/femtologging/__init__.py
@@ -8,6 +8,7 @@ rust = __import__(f"_{PACKAGE_NAME}_rs")
 hello = rust.hello  # type: ignore[attr-defined]
 FemtoLogger = rust.FemtoLogger  # type: ignore[attr-defined]
 get_logger = rust.get_logger  # type: ignore[attr-defined]
+reset_manager = rust.reset_manager_py  # type: ignore[attr-defined]
 FemtoHandler = rust.FemtoHandler  # type: ignore[attr-defined]
 FemtoStreamHandler = rust.FemtoStreamHandler  # type: ignore[attr-defined]
 FemtoFileHandler = rust.FemtoFileHandler  # type: ignore[attr-defined]
@@ -16,6 +17,7 @@ __all__ = [
     "FemtoHandler",
     "FemtoLogger",
     "get_logger",
+    "reset_manager",
     "FemtoStreamHandler",
     "FemtoFileHandler",
     "hello",

--- a/rust_extension/Cargo.lock
+++ b/rust_extension/Cargo.lock
@@ -104,6 +104,8 @@ dependencies = [
  "itertools",
  "log",
  "loom",
+ "once_cell",
+ "parking_lot",
  "proptest",
  "pyo3",
  "rstest",

--- a/rust_extension/Cargo.toml
+++ b/rust_extension/Cargo.toml
@@ -11,6 +11,8 @@ crate-type = ["cdylib", "rlib"]
 pyo3 = { version = "0.21.2", features = ["extension-module"] }
 crossbeam-channel = "0.5.15"
 log = "0.4"
+once_cell = "1"
+parking_lot = "0.12"
 
 [dev-dependencies]
 rstest = "0.25"

--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -15,7 +15,7 @@ pub use handler::{FemtoHandler, FemtoHandlerTrait};
 pub use level::FemtoLevel;
 pub use log_record::{FemtoLogRecord, RecordMetadata};
 pub use logger::FemtoLogger;
-use manager::get_logger as manager_get_logger;
+use manager::{get_logger as manager_get_logger, reset_manager};
 pub use stream_handler::FemtoStreamHandler;
 
 #[pyfunction]
@@ -28,6 +28,11 @@ fn get_logger(py: Python<'_>, name: &str) -> PyResult<Py<FemtoLogger>> {
     manager_get_logger(py, name)
 }
 
+#[pyfunction]
+fn reset_manager_py() {
+    reset_manager();
+}
+
 #[allow(deprecated)]
 #[pymodule]
 fn _femtologging_rs(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
@@ -37,5 +42,6 @@ fn _femtologging_rs(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<FemtoFileHandler>()?;
     m.add_function(wrap_pyfunction!(hello, m)?)?;
     m.add_function(wrap_pyfunction!(get_logger, m)?)?;
+    m.add_function(wrap_pyfunction!(reset_manager_py, m)?)?;
     Ok(())
 }

--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -6,6 +6,7 @@ mod handler;
 mod level;
 mod log_record;
 mod logger;
+mod manager;
 mod stream_handler;
 
 pub use file_handler::FemtoFileHandler;
@@ -14,11 +15,17 @@ pub use handler::{FemtoHandler, FemtoHandlerTrait};
 pub use level::FemtoLevel;
 pub use log_record::{FemtoLogRecord, RecordMetadata};
 pub use logger::FemtoLogger;
+use manager::get_logger as manager_get_logger;
 pub use stream_handler::FemtoStreamHandler;
 
 #[pyfunction]
 fn hello() -> &'static str {
     "hello from Rust"
+}
+
+#[pyfunction]
+fn get_logger(py: Python<'_>, name: &str) -> PyResult<Py<FemtoLogger>> {
+    manager_get_logger(py, name)
 }
 
 #[allow(deprecated)]
@@ -29,5 +36,6 @@ fn _femtologging_rs(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<FemtoStreamHandler>()?;
     m.add_class::<FemtoFileHandler>()?;
     m.add_function(wrap_pyfunction!(hello, m)?)?;
+    m.add_function(wrap_pyfunction!(get_logger, m)?)?;
     Ok(())
 }

--- a/rust_extension/src/logger.rs
+++ b/rust_extension/src/logger.rs
@@ -23,6 +23,9 @@ use std::sync::{
 pub struct FemtoLogger {
     /// Identifier used to distinguish log messages from different loggers.
     name: String,
+    /// Parent logger name for dotted hierarchy.
+    #[pyo3(get)]
+    parent: Option<String>,
     formatter: Arc<dyn FemtoFormatter>,
     level: AtomicU8,
     handlers: Vec<Arc<dyn FemtoHandlerTrait>>,
@@ -34,15 +37,7 @@ impl FemtoLogger {
     #[new]
     #[pyo3(text_signature = "(name)")]
     pub fn new(name: String) -> Self {
-        // Default to a simple formatter using the "name [LEVEL] message" style.
-        let formatter: Arc<dyn FemtoFormatter> = Arc::new(DefaultFormatter);
-
-        Self {
-            name,
-            formatter,
-            level: AtomicU8::new(FemtoLevel::Info as u8),
-            handlers: Vec::new(),
-        }
+        Self::with_parent(name, None)
     }
 
     /// Format a message at the provided level and return it.
@@ -80,5 +75,18 @@ impl FemtoLogger {
     /// Attach a handler to this logger.
     pub fn add_handler(&mut self, handler: Arc<dyn FemtoHandlerTrait>) {
         self.handlers.push(handler);
+    }
+
+    /// Create a logger with an explicit parent name.
+    pub fn with_parent(name: String, parent: Option<String>) -> Self {
+        let formatter: Arc<dyn FemtoFormatter> = Arc::new(DefaultFormatter);
+
+        Self {
+            name,
+            parent,
+            formatter,
+            level: AtomicU8::new(FemtoLevel::Info as u8),
+            handlers: Vec::new(),
+        }
     }
 }

--- a/rust_extension/src/manager.rs
+++ b/rust_extension/src/manager.rs
@@ -28,11 +28,6 @@ fn is_invalid_logger_name(name: &str) -> bool {
         || name.split('.').any(|s| s.is_empty())
 }
 
-/// Return `true` when the provided name passes validation.
-fn is_valid_logger_name(name: &str) -> bool {
-    !is_invalid_logger_name(name)
-}
-
 fn ensure_root_logger(py: Python<'_>, mgr: &mut Manager) -> PyResult<()> {
     if !mgr.loggers.contains_key("root") {
         let root = Py::new(py, FemtoLogger::with_parent("root".into(), None))?;
@@ -49,9 +44,9 @@ fn calculate_parent_name(name: &str) -> Option<String> {
 
 /// Retrieve an existing logger or create one with a dotted-name parent.
 pub fn get_logger(py: Python<'_>, name: &str) -> PyResult<Py<FemtoLogger>> {
-    if !is_valid_logger_name(name) {
+    if is_invalid_logger_name(name) {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            "invalid logger name",
+            "logger name cannot be empty, start or end with '.', or contain consecutive dots",
         ));
     }
 

--- a/rust_extension/src/manager.rs
+++ b/rust_extension/src/manager.rs
@@ -1,0 +1,38 @@
+use once_cell::sync::Lazy;
+use parking_lot::RwLock;
+use pyo3::prelude::*;
+use std::collections::HashMap;
+
+use crate::logger::FemtoLogger;
+
+#[derive(Default)]
+struct Manager {
+    loggers: HashMap<String, Py<FemtoLogger>>,
+}
+
+static MANAGER: Lazy<RwLock<Manager>> = Lazy::new(|| RwLock::new(Manager::default()));
+
+pub fn get_logger(py: Python<'_>, name: &str) -> PyResult<Py<FemtoLogger>> {
+    {
+        let mgr = MANAGER.read();
+        if let Some(logger) = mgr.loggers.get(name) {
+            return Ok(logger.clone_ref(py));
+        }
+    }
+
+    let parent_name = if let Some((parent, _)) = name.rsplit_once('.') {
+        Some(parent.to_string())
+    } else if name != "root" {
+        Some("root".to_string())
+    } else {
+        None
+    };
+
+    let logger = Py::new(py, FemtoLogger::with_parent(name.to_string(), parent_name))?;
+    let mut mgr = MANAGER.write();
+    let entry = mgr
+        .loggers
+        .entry(name.to_string())
+        .or_insert_with(|| logger.clone_ref(py));
+    Ok(entry.clone_ref(py))
+}

--- a/rust_extension/src/manager.rs
+++ b/rust_extension/src/manager.rs
@@ -17,33 +17,51 @@ struct Manager {
 
 static MANAGER: Lazy<RwLock<Manager>> = Lazy::new(|| RwLock::new(Manager::default()));
 
-/// Retrieve an existing logger or create one with a dotted-name parent.
-pub fn get_logger(py: Python<'_>, name: &str) -> PyResult<Py<FemtoLogger>> {
-    if name.is_empty()
+/// Return `true` when the provided name is not a valid logger identifier.
+///
+/// A name is considered invalid when it is empty, begins or ends with a dot,
+/// or contains consecutive dots which would create empty segments.
+fn is_invalid_logger_name(name: &str) -> bool {
+    name.is_empty()
         || name.starts_with('.')
         || name.ends_with('.')
         || name.split('.').any(|s| s.is_empty())
-    {
+}
+
+/// Return `true` when the provided name passes validation.
+fn is_valid_logger_name(name: &str) -> bool {
+    !is_invalid_logger_name(name)
+}
+
+fn ensure_root_logger(py: Python<'_>, mgr: &mut Manager) -> PyResult<()> {
+    if !mgr.loggers.contains_key("root") {
+        let root = Py::new(py, FemtoLogger::with_parent("root".into(), None))?;
+        mgr.loggers.insert("root".to_string(), root);
+    }
+    Ok(())
+}
+
+fn calculate_parent_name(name: &str) -> Option<String> {
+    name.rsplit_once('.')
+        .map(|(p, _)| p.to_string())
+        .or_else(|| (name != "root").then(|| "root".to_string()))
+}
+
+/// Retrieve an existing logger or create one with a dotted-name parent.
+pub fn get_logger(py: Python<'_>, name: &str) -> PyResult<Py<FemtoLogger>> {
+    if !is_valid_logger_name(name) {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
             "invalid logger name",
         ));
     }
 
     let mut mgr = MANAGER.write();
-
-    if !mgr.loggers.contains_key("root") {
-        let root = Py::new(py, FemtoLogger::with_parent("root".into(), None))?;
-        mgr.loggers.insert("root".to_string(), root);
-    }
+    ensure_root_logger(py, &mut mgr)?;
 
     match mgr.loggers.entry(name.to_string()) {
         Entry::Occupied(o) => Ok(o.get().clone_ref(py)),
         Entry::Vacant(v) => {
-            let parent_name = name
-                .rsplit_once('.')
-                .map(|(p, _)| p.to_string())
-                .or_else(|| (name != "root").then(|| "root".to_string()));
-
+            let parent_name = calculate_parent_name(name);
             let logger = Py::new(py, FemtoLogger::with_parent(name.to_string(), parent_name))?;
             v.insert(logger.clone_ref(py));
             Ok(logger)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,13 +1,22 @@
-from femtologging import get_logger
+from femtologging import get_logger, reset_manager
 
 
 def test_get_logger_singleton() -> None:
+    reset_manager()
     a = get_logger("app.core")
     b = get_logger("app.core")
     assert a is b
 
 
+def test_get_logger_different_names() -> None:
+    reset_manager()
+    first = get_logger("first")
+    second = get_logger("second")
+    assert first is not second
+
+
 def test_get_logger_parents() -> None:
+    reset_manager()
     c = get_logger("a.b.c")
     b = get_logger("a.b")
     a = get_logger("a")
@@ -17,3 +26,21 @@ def test_get_logger_parents() -> None:
     assert b.parent == "a"
     assert a.parent == "root"
     assert root.parent is None
+
+
+def test_get_logger_auto_creates_root() -> None:
+    reset_manager()
+    child = get_logger("child")
+    root = get_logger("root")
+    assert child.parent == "root"
+    assert root.parent is None
+
+
+def test_get_logger_invalid_names() -> None:
+    reset_manager()
+    for name in ["", ".bad", "bad.", "a..b"]:
+        try:
+            get_logger(name)
+            assert False, "expected ValueError"
+        except ValueError:
+            pass

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,19 @@
+from femtologging import get_logger
+
+
+def test_get_logger_singleton() -> None:
+    a = get_logger("app.core")
+    b = get_logger("app.core")
+    assert a is b
+
+
+def test_get_logger_parents() -> None:
+    c = get_logger("a.b.c")
+    b = get_logger("a.b")
+    a = get_logger("a")
+    root = get_logger("root")
+
+    assert c.parent == "a.b"
+    assert b.parent == "a"
+    assert a.parent == "root"
+    assert root.parent is None


### PR DESCRIPTION
## Summary
- add Manager implementation with `get_logger`
- store dotted-name parents on loggers
- expose `get_logger` in Python API
- document registry in roadmap docs
- test Manager behaviour

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint`

------
https://chatgpt.com/codex/tasks/task_e_686c3f1c1f8483228fa0ee6f64f254aa

## Summary by Sourcery

Implement a singleton Manager-based logger registry that caches loggers by name, establishes parent relationships based on dotted names, and expose get_logger in the Python API. Extend FemtoLogger with a parent attribute, update docs, and add tests for registry behavior.

New Features:
- Introduce a Manager registry for logger caching and retrieval with dotted-name hierarchy
- Expose get_logger in the Python API

Enhancements:
- Add a parent field to FemtoLogger and update its constructor to support parent assignment

Build:
- Add once_cell and parking_lot crates for thread-safe Manager implementation

Documentation:
- Update configuration and roadmap docs to mark the registry and hierarchy support as implemented

Tests:
- Add tests verifying get_logger singleton behavior and parent relationships