### PR TITLE
Improve README overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,37 @@
 # femtologging
 
-Example package generated from this Copier template.
+**femtologging** is an experiment in building a fast, thread-friendly logging
+library for Python using Rust. The project ports core ideas from
+[picologging](https://github.com/microsoft/picologging) and exposes them through
+a small [PyO3](https://pyo3.rs/) extension. Log records travel over
+`crossbeam-channel` queues to dedicated worker threads so your application stays
+responsive even when log output is slow.
 
-This variant includes a small Rust extension built with [PyO3](https://pyo3.rs/)
-and packaged using [maturin](https://maturin.rs/). Ensure the
-[Rust tool‑chain](https://www.rust-lang.org/tools/install) is installed, then
-run `pip install .` or `make build` to compile the extension.
+The goals are:
+
+- CPython logging API compatibility
+- strong compile-time guarantees from Rust
+- minimal overhead through a producer–consumer model
+
+For a deeper dive into the architecture and the crates involved, see the
+documents in [`docs/`](./docs), especially
+[`rust-multithreaded-logging-framework-for-python-design.md`](docs/rust-multithreaded-logging-framework-for-python-design.md)
+and [`dependency-analysis.md`](docs/dependency-analysis.md).
+
+## Installation
+
+Ensure the
+[Rust toolchain](https://www.rust-lang.org/tools/install) is available, then
+run:
+
+```bash
+pip install .
+```
+
+This compiles the extension with [maturin](https://maturin.rs/). You can also use
+`make build` for the same result.
+
+## Quick example
 
 ```python
 from femtologging import get_logger
@@ -13,3 +39,12 @@ from femtologging import get_logger
 log = get_logger("demo")
 log.log("INFO", "hello from femtologging")
 ```
+
+`FemtoStreamHandler` and `FemtoFileHandler` are available for basic output. Each
+runs its I/O in a separate thread so logging calls return immediately.
+
+## Development
+
+The [`Makefile`](./Makefile) defines tasks for formatting, linting, type
+checking and tests. See [`docs/dev-workflow.md`](docs/dev-workflow.md) for
+details.


### PR DESCRIPTION
## Summary
- write a friendly introduction to femtologging
- highlight architecture docs and dependency choices
- show a quick usage example
- note makefile tasks for development

## Testing
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_686d673db8988322a1d2ba5b405cd5d3