### PR TITLE
Add documentation style guide

### DIFF
--- a/docs/contents.md
+++ b/docs/contents.md
@@ -9,6 +9,8 @@ libraries. Use the links below to explore each topic.
   - Describes Makefile commands for building, linting, formatting and tests.
 - [dependency-analysis.md](./dependency-analysis.md)
   - Summarizes third-party crates chosen for the Rust implementation.
+- [documentation-style-guide.md](./documentation-style-guide.md)
+  - Provides conventions for documentation and Python docstrings.
 - [roadmap.md](./roadmap.md)
   - Lists milestones for porting picologging to a Rust/PyO3 implementation.
 

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -1,7 +1,7 @@
 # Documentation style guide
 
 This guide outlines conventions for authoring documentation for Lille.
-Apply these rules to keep the documentation clear and consistent for
+These rules help keep the documentation clear and consistent for
 developers.
 
 ## Spelling
@@ -9,7 +9,7 @@ developers.
 - Use British English based on the
   [Oxford English Dictionary](https://public.oed.com/) (en-oxendict).
 - The word **"outwith"** is acceptable.
-- Keep US spelling when used in an API, for example `color`.
+- Keep US spelling when used in an API, for example, `color`.
 - The project licence file is spelled `LICENSE` for community consistency.
 
 ## Punctuation and grammar
@@ -24,7 +24,8 @@ developers.
 
 ## Markdown rules
 
-- Follow [markdownlint](https://github.com/DavidAnson/markdownlint) recommendations[^markdownlint].
+- Follow [markdownlint](https://github.com/DavidAnson/markdownlint)
+  recommendations[^markdownlint].
 - Provide code blocks and lists using standard Markdown syntax.
 - Always provide a language identifier for fenced code blocks; use
   `plaintext` for non-code text.
@@ -64,7 +65,9 @@ contents of the manual.
 - Document the return value with `# Returns`.
 - Document any panics or errors with `# Panics` or `# Errors` as appropriate.
 - Place examples under `# Examples` and mark the code block with `no_run`
-  so they do not execute during documentation tests.
+  so they compile but do not execute during documentation tests. Use
+  `ignore` instead of `no_run` when the example does not compile or relies on
+  external tools.
 - Put function attributes after the doc comment.
 
 ````rust
@@ -93,7 +96,7 @@ pub fn add(a: i32, b: i32) -> i32 {
 Where it adds clarity, include [Mermaid](https://mermaid.js.org/) diagrams.
 When embedding figures, use `![alt text](path/to/image)` and provide concise
 alt text describing the content. Add a short description before each Mermaid
-diagram so screen readers can understand it.
+diagram, so screen readers can understand it.
 
 ```mermaid
 flowchart TD
@@ -105,7 +108,9 @@ flowchart TD
 ## Python docstrings
 
 Docstrings document public modules, classes, and functions. Use the NumPy
-style and keep descriptions short.
+style and keep descriptions short. See the
+[NumPy docstring standard][numpydoc]
+for the full specification.
 
 - Begin with a one-line summary followed by a blank line and extended description.
 - List parameters and return values under `Parameters` and `Returns` headings.
@@ -130,5 +135,7 @@ def scale(values: list[float], factor: float) -> list[float]:
     """
     return [v * factor for v in values]
 ```
+
+[numpydoc]: https://numpydoc.readthedocs.io/en/stable/format.html
 
 [^markdownlint]: A linter that enforces consistent Markdown formatting.

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -1,0 +1,134 @@
+# Documentation style guide
+
+This guide outlines conventions for authoring documentation for Lille.
+Apply these rules to keep the documentation clear and consistent for
+developers.
+
+## Spelling
+
+- Use British English based on the
+  [Oxford English Dictionary](https://public.oed.com/) (en-oxendict).
+- The word **"outwith"** is acceptable.
+- Keep US spelling when used in an API, for example `color`.
+- The project licence file is spelled `LICENSE` for community consistency.
+
+## Punctuation and grammar
+
+- Use the Oxford comma: "ships, planes, and hovercraft".
+- Company names are treated as collective nouns: "Lille Industries are expanding".
+
+## Headings
+
+- Write headings in sentence case.
+- Use Markdown headings (`#`, `##`, `###`, and so on) in order without skipping levels.
+
+## Markdown rules
+
+- Follow [markdownlint](https://github.com/DavidAnson/markdownlint) recommendations[^markdownlint].
+- Provide code blocks and lists using standard Markdown syntax.
+- Always provide a language identifier for fenced code blocks; use
+  `plaintext` for non-code text.
+- Use `-` as the first level bullet and renumber lists when items change.
+- Prefer inline links using `[text](url)` or angle brackets around the URL.
+- Ensure blank lines before and after bulleted lists and fenced blocks.
+- Ensure tables have a delimiter line below the header row.
+
+## Expanding acronyms
+
+- Expand any uncommon acronym on first use, for example, Continuous Integration (CI).
+
+## Formatting
+
+- Wrap paragraphs at 80 columns.
+- Wrap code at 120 columns.
+- Do not wrap tables.
+- Use footnotes referenced with `[^label]`.
+
+## Example snippet
+
+```rust
+/// A simple function demonstrating documentation style.
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+```
+
+## API doc comments (Rust)
+
+Use doc comments to document public APIs. Keep them consistent with the
+contents of the manual.
+
+- Begin each block with `///`.
+- Keep the summary line short, followed by further detail.
+- Explicitly document all parameters with `# Parameters`, describing each argument.
+- Document the return value with `# Returns`.
+- Document any panics or errors with `# Panics` or `# Errors` as appropriate.
+- Place examples under `# Examples` and mark the code block with `no_run`
+  so they do not execute during documentation tests.
+- Put function attributes after the doc comment.
+
+````rust
+/// Returns the sum of `a` and `b`.
+///
+/// # Parameters
+/// - `a`: The first integer to add.
+/// - `b`: The second integer to add.
+///
+/// # Returns
+/// The sum of `a` and `b`.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// assert_eq!(add(2, 3), 5);
+/// ```
+#[inline]
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+````
+
+## Diagrams and images
+
+Where it adds clarity, include [Mermaid](https://mermaid.js.org/) diagrams.
+When embedding figures, use `![alt text](path/to/image)` and provide concise
+alt text describing the content. Add a short description before each Mermaid
+diagram so screen readers can understand it.
+
+```mermaid
+flowchart TD
+    A[Start] --> B[Draft]
+    B --> C[Review]
+    C --> D[Merge]
+```
+
+## Python docstrings
+
+Docstrings document public modules, classes, and functions. Use the NumPy
+style and keep descriptions short.
+
+- Begin with a one-line summary followed by a blank line and extended description.
+- List parameters and return values under `Parameters` and `Returns` headings.
+- Document exceptions under `Raises` and include examples in fenced `python` blocks.
+- Keep lines within 80 columns and prefer present tense.
+
+```python
+def scale(values: list[float], factor: float) -> list[float]:
+    """Scale numeric values by a factor.
+
+    Parameters
+    ----------
+    values : list of float
+        The numeric values to scale.
+    factor : float
+        The multiplier applied to each value.
+
+    Returns
+    -------
+    list of float
+        The scaled values.
+    """
+    return [v * factor for v in values]
+```
+
+[^markdownlint]: A linter that enforces consistent Markdown formatting.

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -56,7 +56,7 @@ fn add(a: i32, b: i32) -> i32 {
 
 ## API doc comments (Rust)
 
-Use doc comments to document public APIs. Keep them consistent with the
+Doc comments document public APIs and must remain consistent with the
 contents of the manual.
 
 - Begin each block with `///`.


### PR DESCRIPTION
## Summary
- add a documentation style guide with Python docstrings section
- link the style guide from the docs contents page

## Testing
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_686e11f9dd5483228012d6bf9e617dc5

## Summary by Sourcery

Add a comprehensive documentation style guide and link it from the docs contents

New Features:
- Introduce docs/documentation-style-guide.md outlining documentation conventions

Enhancements:
- Define spelling, punctuation, heading, Markdown formatting, acronym expansion, and wrapping rules
- Establish guidelines for Rust API doc comments with sections for parameters, returns, examples, and attributes
- Provide NumPy-style Python docstring conventions with parameters, returns, raises, and examples
- Offer guidance for embedding Mermaid diagrams and images with alt text

Documentation:
- Link the new documentation-style-guide.md from docs/contents.md