### PR TITLE
Fix heavy workflow virtualenv setup

### DIFF
--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -14,11 +14,18 @@ jobs:
         with:
           python-version: '3.12'
       - uses: dtolnay/rust-toolchain@stable
-      - run: pip install maturin==1.4.0 pytest==7.4.4
-      - run: maturin develop --manifest-path rust_extension/Cargo.toml
+      - name: Set up virtualenv
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install maturin==1.4.0 pytest==7.4.4
+      - run: |
+          source .venv/bin/activate
+          maturin develop --manifest-path rust_extension/Cargo.toml
         env:
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
       - run: |
+          source .venv/bin/activate
           cargo fmt --manifest-path rust_extension/Cargo.toml -- --check
           cargo clippy --manifest-path rust_extension/Cargo.toml -- -D warnings
           cargo test --manifest-path rust_extension/Cargo.toml -- --ignored


### PR DESCRIPTION
## Summary
- ensure heavy tests create and use a virtual environment

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686ed34f335c8322b6e447d12aa9b0b6