### PR TITLE
Fix FemtoLogger shutdown

### DIFF
--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -38,8 +38,8 @@ queues.
 
 Each logger also spawns a small worker thread. Log calls send records over a
 bounded `crossbeam-channel`, keeping the hot path non-blocking. Dropping the
-logger sends a shutdown signal so the worker can drain remaining records and
-exit cleanly. A timeout warns if the thread does not finish within one second.
+logger closes the channel, so the worker can drain remaining records and exit
+cleanly. A timeout warns if the thread does not finish within one second.
 
 Currently, `add_handler()` is only available from Rust code. Python users still
 create a logger with a single default handler. Support for attaching additional

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -39,8 +39,8 @@ queues.
 
 Each logger also spawns a small worker thread. Log calls send records over a
 bounded `crossbeam-channel`, keeping the hot path non-blocking. Dropping the
-logger closes the channel, so the worker can drain remaining records and exit
-cleanly. A timeout warns if the thread does not finish within one second.
+logger sends a shutdown signal, so the worker can drain remaining records and
+exit cleanly. A timeout warns if the thread does not finish within one second.
 
 Currently, `add_handler()` is only available from Rust code. Python users still
 create a logger with a single default handler. Support for attaching additional

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -26,8 +26,9 @@ key‑value pairs. Use `FemtoLogRecord::new` for default metadata or
 `FemtoLevel` defines the standard logging levels (`TRACE`, `DEBUG`, `INFO`,
 `WARN`, `ERROR`, `CRITICAL`). Each `FemtoLogger` holds a current level and drops
 messages below that threshold. The `set_level()` method updates the logger's
-minimum level from Python or Rust code. The `log()` method returns the formatted
-string or `None` when a message is filtered out.
+minimum level using a `FemtoLevel` value. Likewise, `log()` accepts a
+`FemtoLevel` and message, returning the formatted string or `None` when a record
+is filtered out.
 
 `FemtoLogger` can now dispatch a record to multiple handlers. Handlers implement
 `FemtoHandlerTrait` and run their I/O on worker threads. A logger holds a

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -36,6 +36,11 @@ handler reference. When `log()` creates a `FemtoLogRecord`, it sends a clone to
 each configured handler, ensuring thread‑safe routing via the handlers' MPSC
 queues.
 
+Each logger also spawns a small worker thread. Log calls send records over a
+bounded `crossbeam-channel`, keeping the hot path non-blocking. Dropping the
+logger sends a shutdown signal so the worker can drain remaining records and
+exit cleanly. A timeout warns if the thread does not finish within one second.
+
 Currently, `add_handler()` is only available from Rust code. Python users still
 create a logger with a single default handler. Support for attaching additional
 handlers from Python will be added once the trait objects can be safely

--- a/rust_extension/src/level.rs
+++ b/rust_extension/src/level.rs
@@ -4,6 +4,7 @@
 //! converting between strings and numeric representations so loggers can
 //! efficiently filter records.
 
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use std::fmt;
 use std::str::FromStr;
@@ -93,6 +94,11 @@ impl TryFrom<u8> for FemtoLevel {
 impl<'source> FromPyObject<'source> for FemtoLevel {
     fn extract(obj: &'source PyAny) -> PyResult<Self> {
         let s: &str = obj.extract()?;
-        Ok(Self::parse_or_warn(s))
+        match s.parse() {
+            Ok(level) => Ok(level),
+            Err(_) => Err(PyErr::new::<PyValueError, _>(format!(
+                "invalid log level: {s}"
+            ))),
+        }
     }
 }

--- a/rust_extension/src/level.rs
+++ b/rust_extension/src/level.rs
@@ -4,6 +4,7 @@
 //! converting between strings and numeric representations so loggers can
 //! efficiently filter records.
 
+use pyo3::prelude::*;
 use std::fmt;
 use std::str::FromStr;
 
@@ -86,5 +87,12 @@ impl TryFrom<u8> for FemtoLevel {
             5 => Ok(Self::Critical),
             _ => Err(()),
         }
+    }
+}
+
+impl<'source> FromPyObject<'source> for FemtoLevel {
+    fn extract(obj: &'source PyAny) -> PyResult<Self> {
+        let s: &str = obj.extract()?;
+        Ok(Self::parse_or_warn(s))
     }
 }

--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -140,8 +140,8 @@ fn drop_with_sender_clone_exits() {
     let t = std::thread::spawn(move || {
         let res = tx.send(FemtoLogRecord::new("clone", "INFO", "late"));
         assert!(
-            res.is_ok(),
-            "Expected send to succeed while a sender clone is alive"
+            res.is_err(),
+            "Expected send to fail after logger is dropped"
         );
     });
     drop(logger);

--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -123,7 +123,11 @@ fn drop_with_sender_clone_exits() {
     let logger = FemtoLogger::new("clone".to_string());
     let tx = logger.clone_sender_for_test().expect("sender should exist");
     let t = std::thread::spawn(move || {
-        let _ = tx.send(FemtoLogRecord::new("clone", "INFO", "late"));
+        let res = tx.send(FemtoLogRecord::new("clone", "INFO", "late"));
+        assert!(
+            res.is_ok(),
+            "Expected send to succeed while a sender clone is alive"
+        );
     });
     drop(logger);
     t.join().unwrap();

--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -137,7 +137,10 @@ fn shared_handler_across_loggers() {
 fn drop_with_sender_clone_exits() {
     let logger = FemtoLogger::new("clone".to_string());
     let tx = logger.clone_sender_for_test().expect("sender should exist");
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let thread_barrier = std::sync::Arc::clone(&barrier);
     let t = std::thread::spawn(move || {
+        thread_barrier.wait();
         let res = tx.send(FemtoLogRecord::new("clone", "INFO", "late"));
         assert!(
             res.is_err(),
@@ -145,5 +148,6 @@ fn drop_with_sender_clone_exits() {
         );
     });
     drop(logger);
+    barrier.wait();
     t.join().unwrap();
 }

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -47,4 +47,5 @@ def test_level_parsing_and_filtering() -> None:
 
     logger.set_level("ERROR")
     assert logger.log("WARN", "drop") is None
-    assert logger.log("bogus", "drop") is None
+    with pytest.raises(ValueError):
+        logger.log("bogus", "drop")

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -12,21 +12,14 @@ from femtologging import FemtoLogger
     [
         ("core", "INFO", "hello", "core [INFO] hello"),
         ("sys", "ERROR", "fail", "sys [ERROR] fail"),
-        # Edge cases:
         ("", "INFO", "empty name", " [INFO] empty name"),
-        ("core", "", "empty level", "core [] empty level"),
         ("core", "INFO", "", "core [INFO] "),
-        ("", "", "", " [] "),
-        # Non-ASCII characters
-        ("核", "信息", "你好", "核 [信息] 你好"),
-        ("core", "INFO", "¡Hola!", "core [INFO] ¡Hola!"),
-        ("система", "ОШИБКА", "не удалось", "система [ОШИБКА] не удалось"),
-        # Very long strings
+        ("i18n", "INFO", "こんにちは世界", "i18n [INFO] こんにちは世界"),
         (
             "n" * 1000,
-            "L" * 1000,
+            "INFO",
             "m" * 1000,
-            f"{'n' * 1000} [{'L' * 1000}] {'m' * 1000}",
+            f"{'n' * 1000} [INFO] {'m' * 1000}",
         ),
     ],
 )


### PR DESCRIPTION
## Summary
- add background worker thread shutdown via separate channel
- expose sender cloning for tests
- document logger thread lifecycle
- test logger drop with active sender clone

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make check-fmt`


------
https://chatgpt.com/codex/tasks/task_e_6870329f25c08322b83e1f0735b4f31a

## Summary by Sourcery

Implement asynchronous logging dispatch and clean shutdown for FemtoLogger using a background worker thread and crossbeam channel, update API to use FemtoLevel enums, and revise tests and documentation accordingly.

New Features:
- Spawn a background worker thread per logger to dispatch records via a bounded crossbeam channel for non-blocking I/O
- Expose clone_sender_for_test to clone the internal sender for testing shutdown behavior

Bug Fixes:
- Ensure the logger’s worker thread is joined cleanly on drop and warn on panic or shutdown failures

Enhancements:
- Change log() and set_level() methods to accept FemtoLevel enums instead of string parsing
- Manage handlers behind an RwLock for concurrent access and issue warnings when the channel is full

Documentation:
- Document the new worker thread lifecycle, channel-based dispatch, and updated method signatures

Tests:
- Update existing tests to use FemtoLevel variants and add a new test verifying logger thread exit when a sender clone is dropped