### PR TITLE
Add callback overflow policy

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -72,6 +72,7 @@ policy when constructing a handler:
 - **Block** – the call blocks until space becomes available.
 - **Timeout** – wait for a fixed duration before giving up and dropping the
   record.
+- **Callback** – invoke a user-provided function when a record would be dropped.
 
 ### StreamHandler
 


### PR DESCRIPTION
## Summary
- support overflow callbacks in FemtoFileHandler
- document new callback policy
- test callback behaviour in Rust and Python

## Testing
- `make lint`
- `make typecheck`
- `make fmt`
- `make test` *(fails: undefined symbol: PyObject_GetAttr)*

------
https://chatgpt.com/codex/tasks/task_e_687036e1e1708322901ca86d595fb3f5