### PR TITLE
Add From<&HandlerConfig> for WorkerConfig

### DIFF
--- a/rust_extension/src/file_handler.rs
+++ b/rust_extension/src/file_handler.rs
@@ -4,6 +4,8 @@
 //! channel and writes them to disk. Python constructors map onto the Rust
 //! APIs via PyO3 wrappers defined below. The worker thread flushes periodically
 //! and supports optional synchronisation for tests via a [`Barrier`].
+//! Worker configuration is built from a [`HandlerConfig`] using the standard
+//! [`From`] trait for ergonomic conversions.
 
 use std::{
     fs::{File, OpenOptions},

--- a/rust_extension/src/file_handler.rs
+++ b/rust_extension/src/file_handler.rs
@@ -1,8 +1,9 @@
 //! Asynchronous file handler used by `femtologging`.
 //!
-//! A dedicated worker thread receives `FemtoLogRecord` values over a bounded
+//! A dedicated worker thread receives [`FemtoLogRecord`] values over a bounded
 //! channel and writes them to disk. Python constructors map onto the Rust
-//! APIs via PyO3 wrappers defined below.
+//! APIs via PyO3 wrappers defined below. The worker thread flushes periodically
+//! and supports optional synchronisation for tests via a [`Barrier`].
 
 use std::{
     fs::{File, OpenOptions},
@@ -560,7 +561,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn worker_config_from_trait_copies_values() {
+    fn worker_config_from_handlerconfig_copies_values() {
         let cfg = HandlerConfig {
             capacity: 42,
             flush_interval: 7,


### PR DESCRIPTION
## Summary
- implement `From<&HandlerConfig>` for `WorkerConfig`
- use the trait implementation in `FemtoFileHandler`
- update unit test

## Testing
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6870477894a08322a79c87946ad3862b

## Summary by Sourcery

Provide a From<&HandlerConfig> implementation for WorkerConfig, remove the legacy from_handler method, and update the handler and tests to use the new trait-based conversion

New Features:
- Implement From<&HandlerConfig> for WorkerConfig to standardize configuration conversion

Enhancements:
- Replace the custom WorkerConfig::from_handler method with the From trait in FemtoFileHandler

Tests:
- Update and rename the worker config unit test to use WorkerConfig::from instead of from_handler