### PR TITLE
Improve queue overflow docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ When implementing changes, adhere to the following testing procedures:
   subsequent commit) should represent a single logical unit of work.
 - **Quality Gates:** Before considering a change complete or proposing a commit,
   ensure it meets the following criteria:
-  
+
   - For code changes files:
 
     - **Testing:** Passes all relevant unit and behavioural tests according to
@@ -92,9 +92,9 @@ When implementing changes, adhere to the following testing procedures:
 
     - **Linting:** Run `make markdownlint` or use integrated editor linting.
     - **Mermaid diagrams:** Validate diagrams with `make nixie`.
-      
+
 - **Committing:**
-  
+
   - Only changes that meet all the quality gates above should be committed.
   - Write clear, descriptive commit messages summarizing the change, following
     these formatting guidelines:

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -65,9 +65,13 @@ pub struct FemtoHandler;
 
 Implementations should forward the record to an internal queue with `try_send`
 so the caller never blocks. If the queue is full, the record is silently dropped
-and a warning is written to `stderr`. Advanced use cases can specify an overflow
-policy when constructing a handler. The Python API exposes this via
-`OverflowPolicy` and `FemtoFileHandler.with_capacity_flush_policy`:
+and a warning is written to `stderr`. This favours throughput over completeness:
+records may be lost to keep the application responsive. Advanced use cases can
+specify an overflow policy when constructing a handler. The Python API exposes
+this via `OverflowPolicy` and `FemtoFileHandler.with_capacity_flush_policy`. The
+policy may also be extended to support options like back pressure, writing
+overflowed messages to a separate file, or emitting metrics for monitoring
+purposes:
 
 - **Drop** – current default; records are discarded when the queue is full.
 - **Block** – the call blocks until space becomes available.


### PR DESCRIPTION
## Summary
- warn about record loss when queue overflows
- support AGENTS markdownlint

## Testing
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68718b3adac48322b4e6bd3d8bf55671