### PR TITLE
Implement handler flush API

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -75,7 +75,7 @@ policy when constructing a handler. The Python API exposes this via
 - **Timeout** – wait for a fixed duration before giving up and dropping the
   record.
 
-Every handler provides a `flush()` method so callers can force pending messages
+Every handler provides a `flush()` method, so callers can force pending messages
 to be written before shutdown.
 
 ### StreamHandler

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -56,6 +56,7 @@ common trait:
 ```rust
 pub trait FemtoHandlerTrait: Send + Sync {
     fn handle(&self, record: FemtoLogRecord);
+    fn flush(&self) -> bool { true }
 }
 
 /// Base Python-exposed class. Methods are no-ops by default.
@@ -73,6 +74,9 @@ policy when constructing a handler. The Python API exposes this via
 - **Block** – the call blocks until space becomes available.
 - **Timeout** – wait for a fixed duration before giving up and dropping the
   record.
+
+Every handler provides a `flush()` method so callers can force pending messages
+to be written before shutdown.
 
 ### StreamHandler
 

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -90,8 +90,9 @@ The default bounded queue size is 1024 records, but
 when needed.
 
 Dropping a handler closes its channel and waits briefly for the worker thread to
-finish flushing. If the thread does not exit within one second, a warning is
-printed, and the drop continues, preventing deadlocks during shutdown.
+finish flushing. If the thread does not exit within the configured flush timeout
+(one second by default), a warning is printed, and the drop continues,
+preventing deadlocks during shutdown.
 
 #### Sequence Diagram
 
@@ -138,8 +139,8 @@ expose this.
 Calling `flush()` sends a `Flush` command to the worker thread and then waits on
 a dedicated acknowledgment channel for confirmation. The worker responds after
 flushing its writer, giving the caller a deterministic way to ensure all pending
-records are persisted. The wait is bounded to one second to avoid indefinite
-blocking.
+records are persisted. The wait is bounded by the handler's `flush_timeout_secs`
+setting (one second by default) to avoid indefinite blocking.
 
 All handlers spawn their consumer threads on creation and expose a
 `snd: Sender<FemtoLogRecord>` to the logger. The logger clones this sender when

--- a/docs/logging-cpython-picologging-comparison.md
+++ b/docs/logging-cpython-picologging-comparison.md
@@ -1,12 +1,12 @@
 # CPython `logging` vs Microsoft `picologging`: Architecture and Implementation Comparison
 
-Python’s built-in `logging` module and Microsoft’s **picologging** (a
-high-performance drop-in replacement) share the same goal and API, but diverge
+Python’s built-in `logging` module and Microsoft’s **picologging** (a high-
+performance drop-in replacement) share the same goal and API, but diverge
 significantly in design and implementation. This comparison examines their
-architectural differences (class design, handler/formatter mechanics,
-locking/thread-safety, data structures, extensibility vs performance,
-startup/runtime overhead), surveys available performance data, and discusses use
-cases and migration issues. Key differences emerge from picologging’s C++-based
+architectural differences (class design, handler/formatter mechanics, locking/
+thread-safety, data structures, extensibility vs performance, startup/
+runtime overhead), surveys available performance data, and discusses use cases
+and migration issues. Key differences emerge from picologging’s C++-based
 implementation and aggressive optimization versus the flexibility of CPython’s
 pure-Python logging.
 
@@ -19,34 +19,33 @@ tree) under a root logger via a `Manager` holding a `loggerDict` of names to
 logger instances. Each `Logger` has attributes like `name`, `level`, a list of
 child handlers, and links to its parent logger, and inherits filtering behavior
 via the `Filterer` mixin. Handlers (e.g. `StreamHandler`, `FileHandler`) hold
-output streams and optional `Formatter` objects, and each has its own lock for
-thread-safe I/O. When a logger emits, it creates a `LogRecord` (a Python object
-with fields like `msg`, `args`, `levelno`, timestamp, etc.), runs it through
-logger filters, then calls each handler’s `handle()` method. The handler filters
-it again, formats it (via `Formatter.format(record)`), and writes to its
+output streams and optional `Formatter` objects, and each has its own lock
+for thread-safe I/O. When a logger emits, it creates a `LogRecord` (a Python
+object with fields like `msg`, `args`, `levelno`, timestamp, etc.), runs it
+through logger filters, then calls each handler’s `handle()` method. The handler
+filters it again, formats it (via `Formatter.format(record)`), and writes to its
 destination (often wrapped in `with self.lock:`).
 
-In contrast, **picologging** implements most core classes in C++ (exposed as
-Python types) for speed. It has analogous classes: `Logger`, `Handler`,
+In contrast, **picologging** implements most core classes in C++ (exposed
+as Python types) for speed. It has analogous classes: `Logger`, `Handler`,
 `Formatter`, and `LogRecord`, but implemented natively. Picologging’s `Manager`
 and `_Placeholder` (for tree structure) exist in Python, but key operations
-occur in C. For example, `Logger` is a C-struct type (see
-[logger.hxx](https://github.com/microsoft/picologging/blob/%E2%80%A6/logger.hxx))
-with fixed fields (e.g.
-`PyObject *name, unsigned short level, PyObject *handlers, bool propagate`, plus
-several boolean flags for fast level checks). A C++ `Handler` struct contains a
-`Filterer` object (for filters), a `std::recursive_mutex *lock`, and pointers
-for name, formatter, and methods (see
-[handler.hxx](https://github.com/microsoft/picologging/blob/%E2%80%A6/handler.hxx)).
+occur in C. For example, `Logger` is a C-struct type (see [logger.hxx](https://
+github.com/microsoft/picologging/blob/%E2%80%A6/logger.hxx)) with fixed
+fields (e.g. `PyObject *name, unsigned short level, PyObject *handlers, bool
+propagate`, plus several boolean flags for fast level checks). A C++ `Handler`
+struct contains a `Filterer` object (for filters), a `std::recursive_mutex
+*lock`, and pointers for name, formatter, and methods (see [handler.hxx]
+(<https://github.com/microsoft/picologging/blob/%E2%80%A6/handler.hxx>)).
 Picologging’s `LogRecord` is likewise a C struct with fields mirroring Python’s
 (name, msg, args, levelno, pathname, lineno, thread, process, etc.).
 
-Picologging’s Logger class has no Python-level inheritance hierarchy beyond the
-C struct (though it also embeds a `Filterer`). It uses boolean flags
+Picologging’s Logger class has no Python-level inheritance hierarchy beyond
+the C struct (though it also embeds a `Filterer`). It uses boolean flags
 (`enabledForDebug`, etc.) set at init to speed up `isEnabledFor` checks, rather
 than dynamic lookups. Extensible hooks in CPython (like custom `LogRecord`
-factories) are largely absent: notably `Manager.setLogRecordFactory` is **not
-implemented** in picologging. In effect, CPython logging emphasizes
+factories) are largely absent: notably `Manager.setLogRecordFactory` is
+**not implemented** in picologging. In effect, CPython logging emphasizes
 extensibility and configurability, while picologging emphasizes a streamlined,
 lower-overhead class design (trading off some features).
 
@@ -98,15 +97,15 @@ and creates `LogRecord` objects. Handlers reference `Formatter` instances.
 
 ## Handler and Formatter Mechanics
 
-In both systems, **handlers** encapsulate where and how to output messages, and
-**formatters** convert `LogRecord` data to text. CPython’s `Handler` base class
-(in `logging/__init__.py`) defines the interface: `setLevel()`,
-`setFormatter()`, `handle()`, `emit()`, etc. Subclasses like `StreamHandler` or
-`FileHandler` override `emit()` to write to streams or files. A handler’s
-`handle(record)` method checks filters and then does
-`with self.lock: self.emit(record)`, ensuring thread-safe emission. The
-handler’s `format(record)` delegates to its `Formatter.format()` if set, or a
-default formatter otherwise.
+In both systems, **handlers** encapsulate where and how to output messages,
+and **formatters** convert `LogRecord` data to text. CPython’s `Handler`
+base class (in `logging/__init__.py`) defines the interface: `setLevel()`,
+`setFormatter()`, `handle()`, `emit()`, etc. Subclasses like `StreamHandler`
+or `FileHandler` override `emit()` to write to streams or files. A
+handler’s `handle(record)` method checks filters and then does `with
+self.lock: self.emit(record)`, ensuring thread-safe emission. The handler’s
+`format(record)` delegates to its `Formatter.format()` if set, or a default
+formatter otherwise.
 
 Picologging provides corresponding handler types, but implemented in C++ for
 speed. For example, its `Handler_handle` method (in [handler.cxx]) first applies
@@ -148,16 +147,16 @@ string, and writes to the output (wrapped by its lock for thread safety).
 Thread safety is a major differentiator. **CPython logging** uses two levels of
 locking: a global module lock (`_lock = threading.RLock()`) to protect shared
 structures (logger hierarchy, handler registry, caches) and individual locks per
-handler. The global lock is used in operations like `Manager.getLogger(name)` to
-update `loggerDict` and fix up parents safely. It also guards handler
-registration and cleanup (e.g. `Handler.close()` uses `with _lock` to update the
-internal handlers map). This ensures that configuring loggers/handlers from
+handler. The global lock is used in operations like `Manager.getLogger(name)`
+to update `loggerDict` and fix up parents safely. It also guards handler
+registration and cleanup (e.g. `Handler.close()` uses `with _lock` to update
+the internal handlers map). This ensures that configuring loggers/handlers from
 multiple threads is safe but means some contention on `_lock`.
 
 By contrast, **picologging** minimizes global locking. Its `Manager.getLogger`
 does not acquire any module-level lock. Instead, it relies on the Python Global
-Interpreter Lock (GIL) and the assumption that logger setup is usually
-single-threaded. Handlers each have their own `std::recursive_mutex` (allocated
+Interpreter Lock (GIL) and the assumption that logger setup is usually single-
+threaded. Handlers each have their own `std::recursive_mutex` (allocated
 in `Handler_new`) for I/O locking. When handling a record, picologging’s
 `Handler_handle` explicitly locks and unlocks this mutex around the emit,
 similar in effect to Python’s `with self.lock`. The net effect: both systems
@@ -170,20 +169,20 @@ these locks in native code.
 
 CPython logging uses standard Python collections. The `Manager.loggerDict` is a
 dict mapping names to `Logger` or `_PlaceHolder` objects. Each `Logger.handlers`
-is a list, and `_handlerList` tracks all handlers for shutdown. Log levels and
-names are in Python dicts (`_levelToName`, `_nameToLevel`). LogRecords are
+is a list, and `_handlerList` tracks all handlers for shutdown. Log levels
+and names are in Python dicts (`_levelToName`, `_nameToLevel`). LogRecords are
 Python objects with many attributes (as shown in [67] and docstring). CPython
 also caches effective log levels: each `Logger` has a `_cache` dict mapping
 levels to True/False to speed up `isEnabledFor`. The code even defines a
 `_clear_cache` method (with `_lock`) to reset caches on level changes.
 
-Picologging, in contrast, uses C++ types for performance. Its `LogRecord` is a C
-struct (see [68†L10-L17]) with fixed fields (name, msg, args, levelno, pathname,
-lineno, thread ID, etc.). `Logger` is also a C struct with fixed fields,
-including booleans (`enabledForDebug`, etc.) set once in `Logger_init` to
-indicate which levels are active. Picologging **does not implement** a dynamic
-record factory or caching layers: it precomputes level flags (but note it does
-*not* clear or update them on level changes beyond init) and skips the
+Picologging, in contrast, uses C++ types for performance. Its `LogRecord` is
+a C struct (see [68†L10-L17]) with fixed fields (name, msg, args, levelno,
+pathname, lineno, thread ID, etc.). `Logger` is also a C struct with fixed
+fields, including booleans (`enabledForDebug`, etc.) set once in `Logger_init`
+to indicate which levels are active. Picologging **does not implement** a
+dynamic record factory or caching layers: it precomputes level flags (but note
+it does *not* clear or update them on level changes beyond init) and skips the
 Python-level `_cache`. The manager’s `loggerDict` is a normal Python dict, but
 since picologging avoids global locking, care must be taken if multiple threads
 add loggers simultaneously (the GIL provides some safety). In summary, CPython
@@ -194,20 +193,20 @@ fixed C/C++ memory layouts to reduce per-record overhead.
 
 CPython’s logging is highly extensible: you can subclass `Logger` or `Handler`,
 override methods, use `setLogRecordFactory()` to customize records, and freely
-mix Python-formatters or even swap in custom `logging.Logger` implementations at
-runtime (via `Manager.setLoggerClass`). This flexibility comes with Python-level
-overhead.
+mix Python-formatters or even swap in custom `logging.Logger` implementations
+at runtime (via `Manager.setLoggerClass`). This flexibility comes with Python-
+level overhead.
 
-Picologging trades some of that flexibility for speed. It aims to be *drop-in*
-compatible, but some APIs aren’t supported. For instance,
+Picologging trades some of that flexibility for speed. It aims to be
+*drop-in* compatible, but some APIs aren’t supported. For instance,
 `Manager.setLogRecordFactory` is explicitly **not implemented** in picologging
 (it raises `NotImplementedError`), so user code relying on custom record
 factories won’t work. Similarly, certain configuration helpers (like
-`logging.Formatter` styles beyond the built-in percent/str/template support) may
-differ. On the other hand, picologging incorporates optimized techniques: it
-hardcodes level checks, implements critical paths in C++, and avoids Python
-exception overhead in common cases. The result is much higher throughput for
-logging calls, as discussed below. Thus, the design reflects a classic
+`logging.Formatter` styles beyond the built-in percent/str/template support)
+may differ. On the other hand, picologging incorporates optimized techniques:
+it hardcodes level checks, implements critical paths in C++, and avoids Python
+exception overhead in common cases. The result is much higher throughput
+for logging calls, as discussed below. Thus, the design reflects a classic
 extensibility-vs-performance trade-off: CPython logging favors ease of
 modification, while picologging sacrifices some features for raw speed.
 
@@ -215,16 +214,16 @@ modification, while picologging sacrifices some features for raw speed.
 
 Benchmarks (as reported by picologging’s maintainers) show **substantial
 speedups**. The picologging README reports that it is *“4–17× faster than the*
-`logging` *module”*. Sample microbenchmarks on macOS indicate, for example, a
-simple `Logger(level=DEBUG).debug()` call taking ~0.58 µs on CPython vs
+`logging` *module”*. Sample microbenchmarks on macOS indicate, for example,
+a simple `Logger(level=DEBUG).debug()` call taking ~0.58 µs on CPython vs
 ~0.033 µs with picologging (about **17×** speedup). Even with arguments or at
-INFO level, picologging’s latencies remain several times lower. These gains come
-from eliminating Python-layer dispatch: e.g. picologging’s `Logger.debug()` goes
-straight to optimized C code and avoids many dynamic checks if the logger is
-disabled.
+INFO level, picologging’s latencies remain several times lower. These gains
+come from eliminating Python-layer dispatch: e.g. picologging’s `Logger.debug()`
+goes straight to optimized C code and avoids many dynamic checks if the logger
+is disabled.
 
-Concrete measured *throughput* numbers vary by environment, but the
-order-of-magnitude improvements are widely noted. (For example, publishing these
+Concrete measured *throughput* numbers vary by environment, but the order-
+of-magnitude improvements are widely noted. (For example, publishing these
 benchmarks in a blog or issue would confirm them, but as of this writing the
 claim inis the primary source.) Latency per record is drastically lower in
 picologging, which benefits real-time logging. In terms of *memory usage*, no
@@ -236,10 +235,10 @@ In multi-threaded scenarios, both libraries are thread-safe but behave
 differently: CPython logging’s global lock can become a bottleneck if many
 threads are concurrently creating loggers or modifying handlers. Picologging’s
 lack of a global lock means threads only contend on individual handler locks or
-Python’s GIL. This suggests picologging should scale better under heavy
-multi-threaded logging, although real-world gains depend on workload. (No
-specific multithread benchmarks are publicly available to cite; this conclusion
-follows from the architecture.)
+Python’s GIL. This suggests picologging should scale better under heavy multi-
+threaded logging, although real-world gains depend on workload. (No specific
+multithread benchmarks are publicly available to cite; this conclusion follows
+from the architecture.)
 
 ## Use-Case Suitability
 
@@ -252,8 +251,8 @@ follows from the architecture.)
 - **Heavily multithreaded applications:** Picologging’s finer-grained locking
   (per-handler) may offer better concurrency than CPython’s one big lock. In
   CPython logging, adding handlers or modifying logger hierarchy is serialized
-  by the module-wide `_lock`. Picologging avoids that, so in a heavily threaded
-  app logging to multiple handlers, contention could be lower. Both
+  by the module-wide `_lock`. Picologging avoids that, so in a heavily
+  threaded app logging to multiple handlers, contention could be lower. Both
   implementations ensure thread safety in handlers, so correctness is preserved,
   but picologging’s design is more throughput-oriented.
 
@@ -274,9 +273,9 @@ installed, leveraging these performance characteristics.
 
 ## Migration and Compatibility
 
-Picologging is designed as a *drop-in* replacement. In most cases, simply using
-`import picologging as logging` makes code work unchanged. Handler and formatter
-classes have the same names (`StreamHandler`, `Formatter`, etc.), and
+Picologging is designed as a *drop-in* replacement. In most cases, simply
+using `import picologging as logging` makes code work unchanged. Handler and
+formatter classes have the same names (`StreamHandler`, `Formatter`, etc.), and
 `getLogger`, `basicConfig`, etc., behave identically.
 
 However, there are important caveats:
@@ -295,18 +294,18 @@ However, there are important caveats:
   Python and inject it may not work as intended.
 
 - **Import timing:** To benefit from picologging, it must be imported before any
-  loggers are created. Once a `Logger` from `logging` is created, using
-  `import picologging` may not retroactively convert it. Thus, one should import
-  and configure `picologging` at program start.
+  loggers are created. Once a `Logger` from `logging` is created, using `import
+  picologging` may not retroactively convert it. Thus, one should import and
+  configure `picologging` at program start.
 
 - **Binary dependency:** Picologging requires building a C extension. This adds
   a dependency at deployment time and is incompatible with environments where
   installing extensions is not allowed (e.g. certain serverless or restricted
   environments).
 
-In summary, **most simple use cases migrate with no code changes**, but any code
-using the very flexible hooks of CPython logging should be reviewed. The
-performance gains often outweigh these downsides for throughput-sensitive
+In summary, **most simple use cases migrate with no code changes**, but any
+code using the very flexible hooks of CPython logging should be reviewed.
+The performance gains often outweigh these downsides for throughput-sensitive
 applications.
 
 ## Summary
@@ -315,9 +314,9 @@ CPython’s `logging` module is a mature, feature-rich, pure-Python logging
 framework with flexible configuration and extensibility. Microsoft’s
 `picologging` reimplements the same API in (mostly) C++ for high performance.
 Key differences include: **class implementation** (Python classes vs C structs),
-**locking** (global RLock plus per-handler RLock vs per-handler C++ mutex, no
-global lock), **data structures** (dynamic vs static fields), and **features
-supported** (full logging API vs a subset). These design choices give
+**locking** (global RLock plus per-handler RLock vs per-handler C++ mutex
+with no global lock), **data structures** (dynamic vs static fields), and
+**features supported** (full logging API vs a subset). These design choices give
 picologging much higher throughput at the cost of some flexibility.
 
 For latency-sensitive or heavily threaded applications, picologging is generally

--- a/docs/logging-cpython-picologging-comparison.md
+++ b/docs/logging-cpython-picologging-comparison.md
@@ -19,11 +19,11 @@ tree) under a root logger via a `Manager` holding a `loggerDict` of names to
 logger instances. Each `Logger` has attributes like `name`, `level`, a list of
 child handlers, and links to its parent logger, and inherits filtering behavior
 via the `Filterer` mixin. Handlers (e.g. `StreamHandler`, `FileHandler`) hold
-output streams and optional `Formatter` objects, and each has its own lock
-for thread-safe I/O. When a logger emits, it creates a `LogRecord` (a Python
-object with fields like `msg`, `args`, `levelno`, timestamp, etc.), runs it
-through logger filters, then calls each handler’s `handle()` method. The handler
-filters it again, formats it (via `Formatter.format(record)`), and writes to its
+output streams and optional `Formatter` objects, and each has a lock for thread-
+safe I/O. When a logger emits, it creates a `LogRecord` (a Python object with
+fields like `msg`, `args`, `levelno`, timestamp, etc.), runs it through logger
+filters, then calls each handler’s `handle()` method. The handler filters
+it again, formats it (via `Formatter.format(record)`), and writes to its
 destination (often wrapped in `with self.lock:`).
 
 In contrast, **picologging** implements most core classes in C++ (exposed
@@ -44,7 +44,7 @@ Picologging’s Logger class has no Python-level inheritance hierarchy beyond
 the C struct (though it also embeds a `Filterer`). It uses boolean flags
 (`enabledForDebug`, etc.) set at init to speed up `isEnabledFor` checks, rather
 than dynamic lookups. Extensible hooks in CPython (like custom `LogRecord`
-factories) are largely absent: notably `Manager.setLogRecordFactory` is
+factories) are largely absent: notably, `Manager.setLogRecordFactory` is
 **not implemented** in picologging. In effect, CPython logging emphasizes
 extensibility and configurability, while picologging emphasizes a streamlined,
 lower-overhead class design (trading off some features).
@@ -235,8 +235,7 @@ In multi-threaded scenarios, both libraries are thread-safe but behave
 differently: CPython logging’s global lock can become a bottleneck if many
 threads are concurrently creating loggers or modifying handlers. Picologging’s
 lack of a global lock means threads only contend on individual handler locks or
-Python’s GIL. This suggests picologging should scale better under heavy multi-
-threaded logging, although real-world gains depend on workload. (No specific
+Python’s GIL. This suggests picologging should scale better under heavy multi-threaded logging, although real-world gains depend on workload. (No specific
 multithread benchmarks are publicly available to cite; this conclusion follows
 from the architecture.)
 

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -37,10 +37,9 @@ handler reference. When `log()` creates a `FemtoLogRecord`, it sends a clone to
 each configured handler, ensuring thread‑safe routing via the handlers' MPSC
 queues.
 
-Each logger also spawns a small worker thread. Log calls send records over a
-bounded `crossbeam-channel`, keeping the hot path non-blocking. Dropping the
-logger sends a shutdown signal, so the worker can drain remaining records and
-exit cleanly. A timeout warns if the thread does not finish within one second.
+Handlers manage their own worker threads; the logger simply forwards each record
+to every handler. Callers may invoke a handler's `flush()` method to ensure
+queued messages are written before dropping it.
 
 Currently, `add_handler()` is only available from Rust code. Python users still
 create a logger with a single default handler. Support for attaching additional

--- a/rust_extension/src/file_handler.rs
+++ b/rust_extension/src/file_handler.rs
@@ -644,6 +644,10 @@ impl FemtoHandlerTrait for FemtoFileHandler {
             warn!("FemtoFileHandler: handle called after close");
         }
     }
+
+    fn flush(&self) -> bool {
+        self.flush()
+    }
 }
 
 impl Drop for FemtoFileHandler {

--- a/rust_extension/src/file_handler.rs
+++ b/rust_extension/src/file_handler.rs
@@ -646,7 +646,7 @@ impl FemtoHandlerTrait for FemtoFileHandler {
     }
 
     fn flush(&self) -> bool {
-        self.flush()
+        FemtoFileHandler::flush(self)
     }
 }
 

--- a/rust_extension/src/handler.rs
+++ b/rust_extension/src/handler.rs
@@ -9,6 +9,16 @@ use pyo3::prelude::*;
 pub trait FemtoHandlerTrait: Send + Sync {
     /// Dispatch a log record for handling.
     fn handle(&self, record: FemtoLogRecord);
+
+    /// Flush any pending log records.
+    ///
+    /// Returning `true` signals the flush completed successfully. Implementations
+    /// may return `false` when the handler has been closed or if the flush
+    /// command could not be processed.
+    fn flush(&self) -> bool {
+        // Default to a no-op flush for handlers that do not buffer writes.
+        true
+    }
 }
 
 /// Base Python class for handlers. Methods do nothing by default.
@@ -26,4 +36,8 @@ impl FemtoHandler {
 
 impl FemtoHandlerTrait for FemtoHandler {
     fn handle(&self, _record: FemtoLogRecord) {}
+
+    fn flush(&self) -> bool {
+        true
+    }
 }

--- a/rust_extension/src/stream_handler.rs
+++ b/rust_extension/src/stream_handler.rs
@@ -1,9 +1,10 @@
 //! Stream-based logging handler implementation.
 //!
 //! This module defines `FemtoStreamHandler`, which formats log records and
-//! writes them to a stream on a background thread. The handler forwards
-//! `FemtoLogRecord` values over a bounded channel so the producer never blocks
-//! on I/O.
+//! writes them to a stream on a background thread. The handler forwards log
+//! records and flush commands over a bounded channel so the producer never
+//! blocks on I/O. The handler supports explicit flushing to ensure all pending
+//! records are written.
 
 use std::{
     io::{self, Write},
@@ -25,9 +26,11 @@ const DEFAULT_CHANNEL_CAPACITY: usize = 1024;
 
 /// Handler that writes formatted log records to an `io::Write` stream.
 ///
-/// Each instance owns a background thread which receives records via a
-/// channel and writes them to the provided stream. The writer and formatter
-/// are moved into that thread so the caller never locks or blocks.
+/// Each instance owns a background thread which receives records and flush
+/// commands via a channel and writes them to the provided stream. The writer
+/// and formatter are moved into that thread so the caller never locks or
+/// blocks. The handler supports explicit flushing to ensure all queued records
+/// are written.
 enum StreamCommand {
     Record(FemtoLogRecord),
     Flush,

--- a/rust_extension/tests/handler_tests.rs
+++ b/rust_extension/tests/handler_tests.rs
@@ -1,0 +1,31 @@
+use _femtologging_rs::{FemtoHandler, FemtoHandlerTrait, FemtoLogRecord};
+use std::sync::Mutex;
+
+#[derive(Default)]
+struct DummyHandler {
+    flushed: Mutex<bool>,
+}
+
+impl FemtoHandlerTrait for DummyHandler {
+    fn handle(&self, _record: FemtoLogRecord) {}
+
+    fn flush(&self) -> bool {
+        let mut flag = self.flushed.lock().unwrap();
+        *flag = true;
+        true
+    }
+}
+
+#[test]
+fn default_handler_flush_returns_true() {
+    let handler = FemtoHandler::default();
+    assert!(handler.flush());
+}
+
+#[test]
+fn overridden_flush_called_via_trait() {
+    let handler = DummyHandler::default();
+    let trait_obj: &dyn FemtoHandlerTrait = &handler;
+    assert!(trait_obj.flush());
+    assert!(*handler.flushed.lock().unwrap());
+}

--- a/rust_extension/tests/stream_handler_tests.rs
+++ b/rust_extension/tests/stream_handler_tests.rs
@@ -75,6 +75,18 @@ fn stream_handler_multiple_records(
 }
 
 #[rstest]
+fn stream_handler_flush(
+    #[from(handler_tuple)] (buffer, handler): (Arc<Mutex<Vec<u8>>>, FemtoStreamHandler),
+) {
+    handler.handle(FemtoLogRecord::new("core", "INFO", "one"));
+    assert!(handler.flush());
+    handler.handle(FemtoLogRecord::new("core", "INFO", "two"));
+    drop(handler);
+
+    assert_eq!(read_output(&buffer), "core [INFO] one\ncore [INFO] two\n");
+}
+
+#[rstest]
 fn stream_handler_concurrent_usage(
     #[from(handler_tuple)] (buffer, handler): (Arc<Mutex<Vec<u8>>>, FemtoStreamHandler),
 ) {

--- a/rust_extension/tests/stream_handler_tests.rs
+++ b/rust_extension/tests/stream_handler_tests.rs
@@ -87,6 +87,24 @@ fn stream_handler_flush(
 }
 
 #[rstest]
+fn stream_handler_close_flushes_pending(
+    #[from(handler_tuple)] (buffer, mut handler): (Arc<Mutex<Vec<u8>>>, FemtoStreamHandler),
+) {
+    handler.handle(FemtoLogRecord::new("core", "INFO", "close"));
+    handler.close();
+
+    assert_eq!(read_output(&buffer), "core [INFO] close\n");
+}
+
+#[rstest]
+fn stream_handler_flush_after_close(
+    #[from(handler_tuple)] (_buffer, mut handler): (Arc<Mutex<Vec<u8>>>, FemtoStreamHandler),
+) {
+    handler.close();
+    assert!(!handler.flush());
+}
+
+#[rstest]
 fn stream_handler_concurrent_usage(
     #[from(handler_tuple)] (buffer, handler): (Arc<Mutex<Vec<u8>>>, FemtoStreamHandler),
 ) {


### PR DESCRIPTION
## Summary
- add `flush` to `FemtoHandlerTrait`
- implement flushing for `FemtoStreamHandler`
- expose `close()` and `flush()` on stream handler
- update docs to reflect new API and adjust logger description
- test that `FemtoStreamHandler.flush()` drains pending records

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68718b9fa05483228bca146768fb7ab6

## Summary by Sourcery

Introduce an explicit flush API to the handler trait and implement flush and close on stream and file handlers, update internal command processing, documentation, and add tests to ensure pending records are drained.

New Features:
- Add flush method to FemtoHandlerTrait with default no-op implementation
- Implement flush and close methods on FemtoStreamHandler to drain pending records
- Expose flush for FemtoFileHandler

Enhancements:
- Refactor stream handler to use a command channel handling Record and Flush, with configurable flush timeouts and rate-limited drop warnings

Documentation:
- Update Rust and Python documentation to describe new flush API and handler closing behavior

Tests:
- Add tests verifying flush and close semantics on stream handlers and default/overridden flush on handlers