### PR TITLE
Refactor buffer setup in tests

### DIFF
--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -3,25 +3,13 @@ use _femtologging_rs::{
     DefaultFormatter, FemtoHandlerTrait, FemtoLevel, FemtoLogRecord, FemtoStreamHandler,
 };
 use rstest::rstest;
-use std::io::{self, Write};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc as StdArc, Mutex as StdMutex};
 
-#[derive(Clone)]
-struct SharedBuf(Arc<Mutex<Vec<u8>>>);
-
-impl Write for SharedBuf {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.lock().unwrap().write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.0.lock().unwrap().flush()
-    }
-}
-
-fn read_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
-    String::from_utf8(buffer.lock().unwrap().clone()).unwrap()
-}
+type Arc<T> = StdArc<T>;
+type Mutex<T> = StdMutex<T>;
+#[path = "test_utils/shared_buffer.rs"]
+mod shared_buffer;
+use shared_buffer::{read_output, SharedBuf};
 
 #[rstest]
 #[case("core", FemtoLevel::Info, "hello", "core [INFO] hello")]

--- a/rust_extension/tests/test_utils/shared_buffer.rs
+++ b/rust_extension/tests/test_utils/shared_buffer.rs
@@ -1,0 +1,19 @@
+use crate::{Arc, Mutex};
+use std::io::{self, Write};
+
+#[derive(Clone)]
+pub struct SharedBuf(pub Arc<Mutex<Vec<u8>>>);
+
+impl Write for SharedBuf {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.lock().unwrap().flush()
+    }
+}
+
+pub fn read_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
+    String::from_utf8(buffer.lock().unwrap().clone()).unwrap()
+}


### PR DESCRIPTION
## Summary
- add `shared_buffer` helper under `tests/test_utils`
- use helper in `logger_tests` and loom concurrency tests

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68718bbd850483229fc0e73c41854cfb