### PR TITLE
Add From trait usage in docs

### DIFF
--- a/rust_extension/src/file_handler.rs
+++ b/rust_extension/src/file_handler.rs
@@ -1,8 +1,11 @@
 //! Asynchronous file handler used by `femtologging`.
 //!
-//! A dedicated worker thread receives `FemtoLogRecord` values over a bounded
+//! A dedicated worker thread receives [`FemtoLogRecord`] values over a bounded
 //! channel and writes them to disk. Python constructors map onto the Rust
-//! APIs via PyO3 wrappers defined below.
+//! APIs via PyO3 wrappers defined below. The worker thread flushes periodically
+//! and supports optional synchronisation for tests via a [`Barrier`].
+//! Worker configuration is built from a [`HandlerConfig`] using the standard
+//! [`From`] trait for ergonomic conversions.
 
 use std::{
     fs::{File, OpenOptions},
@@ -98,21 +101,21 @@ impl Default for WorkerConfig {
     }
 }
 
-impl WorkerConfig {
-    /// Create a worker configuration from a `HandlerConfig`.
-    ///
-    /// `start_barrier` is always set to `None`; tests may override this via
-    /// `with_writer_for_test`.
-    ///
-    /// # Rationale
-    ///
-    /// Production handlers spawn their worker threads immediately and do not
-    /// require synchronisation before processing records. The optional
-    /// `start_barrier` is therefore `None` by default. Tests may use a barrier to
-    /// coordinate multiple workers and eliminate startup races. If a future
-    /// production feature needs coordinated startup (e.g. simultaneous rotation
-    /// of several files), revisit this choice and update the documentation.
-    fn from_handler(cfg: &HandlerConfig) -> Self {
+/// Convert a [`HandlerConfig`] into a [`WorkerConfig`].
+///
+/// `start_barrier` is always set to `None`; tests may override this via
+/// `with_writer_for_test`.
+///
+/// # Rationale
+///
+/// Production handlers spawn their worker threads immediately and do not
+/// require synchronisation before processing records. The optional
+/// `start_barrier` is therefore `None` by default. Tests may use a barrier to
+/// coordinate multiple workers and eliminate startup races. If a future
+/// production feature needs coordinated startup (e.g. simultaneous rotation of
+/// several files), revisit this choice and update the documentation.
+impl From<&HandlerConfig> for WorkerConfig {
+    fn from(cfg: &HandlerConfig) -> Self {
         Self {
             capacity: cfg.capacity,
             flush_interval: cfg.flush_interval,
@@ -451,7 +454,7 @@ impl FemtoFileHandler {
     where
         F: FemtoFormatter + Send + 'static,
     {
-        let worker_cfg = WorkerConfig::from_handler(&config);
+        let worker_cfg = WorkerConfig::from(&config);
         Self::build_from_worker(file, formatter, worker_cfg, config.overflow_policy)
     }
 
@@ -560,13 +563,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn worker_config_from_handler_copies_values() {
+    fn worker_config_from_handlerconfig_copies_values() {
         let cfg = HandlerConfig {
             capacity: 42,
             flush_interval: 7,
             overflow_policy: OverflowPolicy::Drop,
         };
-        let worker = WorkerConfig::from_handler(&cfg);
+        let worker = WorkerConfig::from(&cfg);
         assert_eq!(worker.capacity, 42);
         assert_eq!(worker.flush_interval, 7);
         assert!(worker.start_barrier.is_none());


### PR DESCRIPTION
## Summary
- document how `WorkerConfig` uses `From<&HandlerConfig>` for conversions

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6870477894a08322a79c87946ad3862b

## Summary by Sourcery

Implement the standard From trait for converting HandlerConfig to WorkerConfig and update all usages, documentation, and tests to use this conversion.

Enhancements:
- Replace the custom WorkerConfig::from_handler method with impl From<&HandlerConfig> for WorkerConfig and adjust call sites accordingly.

Documentation:
- Revise documentation comments to describe the From<&HandlerConfig> conversion behaviour.

Tests:
- Update the worker config test to use WorkerConfig::from and rename the test function to reflect the new conversion approach.