### PR TITLE
Expose add_handler for Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,16 @@ The goals are:
 
 For a deeper dive into the architecture and the crates involved, see the
 documents in [`docs/`](./docs), especially
+
 <!-- markdownlint-disable-next-line MD013 -->
+
 [`rust-multithreaded-logging-framework-for-python-design.md`](docs/rust-multithreaded-logging-framework-for-python-design.md)
 and [`dependency-analysis.md`](docs/dependency-analysis.md).
 
 ## Installation
 
-Ensure the
-[Rust toolchain](https://www.rust-lang.org/tools/install) is available, then
-run:
+Ensure the [Rust toolchain](https://www.rust-lang.org/tools/install) is
+available, then run:
 
 ```bash
 pip install .
@@ -39,6 +40,11 @@ from femtologging import get_logger
 
 log = get_logger("demo")
 log.log("INFO", "hello from femtologging")
+
+# Attach a second handler
+from femtologging import FemtoStreamHandler
+
+log.add_handler(FemtoStreamHandler.stdout())
 ```
 
 `FemtoStreamHandler` and `FemtoFileHandler` are available for basic output. Each

--- a/docs/logger-hierarchy-and-multi-handler.md
+++ b/docs/logger-hierarchy-and-multi-handler.md
@@ -9,7 +9,7 @@ is implementing hierarchical configuration using dotted names with propagation.
 - [x] multiple handlers per logger
 - [x] multiple loggers targeting the same handler safely
 - hierarchical logger configuration using dotted names with propagation
-- add_handler is currently only exposed in Rust; Python APIs will follow
+- Python `add_handler` API available
 
 ## Steps to Implement
 

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -42,7 +42,8 @@ bounded `crossbeam-channel`, keeping the hot path non-blocking. Dropping the
 logger sends a shutdown signal, so the worker can drain remaining records and
 exit cleanly. A timeout warns if the thread does not finish within one second.
 
-Currently, `add_handler()` is only available from Rust code. Python users still
-create a logger with a single default handler. Support for attaching additional
-handlers from Python will be added once the trait objects can be safely
-transferred across the FFI boundary.
+The `add_handler()` method is now exposed through the Python bindings. Any
+object with a `handle(logger, level, message)` method can be attached to a
+`FemtoLogger`. Built-in handlers like `FemtoStreamHandler` and
+`FemtoFileHandler` work out of the box, while custom Python classes simply need
+a compatible `handle` implementation.


### PR DESCRIPTION
## Summary
- allow Python to attach handlers by wrapping them with `PyHandler`
- add new `add_handler` test for Python
- document the Python API in `rust-extension.md` and `logger-hierarchy-and-multi-handler.md`
- update README example

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68718be917b88322b9903127e3cc17a1