### PR TITLE
Improve queue overflow docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ When implementing changes, adhere to the following testing procedures:
   subsequent commit) should represent a single logical unit of work.
 - **Quality Gates:** Before considering a change complete or proposing a commit,
   ensure it meets the following criteria:
-  
+
   - For code changes files:
 
     - **Testing:** Passes all relevant unit and behavioural tests according to
@@ -92,9 +92,9 @@ When implementing changes, adhere to the following testing procedures:
 
     - **Linting:** Run `make markdownlint` or use integrated editor linting.
     - **Mermaid diagrams:** Validate diagrams with `make nixie`.
-      
+
 - **Committing:**
-  
+
   - Only changes that meet all the quality gates above should be committed.
   - Write clear, descriptive commit messages summarizing the change, following
     these formatting guidelines:


### PR DESCRIPTION
## Summary
- warn about record loss when queue overflows
- support AGENTS markdownlint
- document blocking overflow policy

## Testing
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68718b3adac48322b4e6bd3d8bf55671

## Summary by Sourcery

Improve documentation around queue overflow behavior by warning about record loss, explaining throughput tradeoffs, detailing blocking and timeout policies with example usage, and fix AGENTS.md formatting to comply with markdownlint.

Documentation:
- Warn about silent record drops when the internal queue overflows and note the throughput vs completeness tradeoff
- Document blocking and timeout overflow policies in the Python API and include a code example
- Clean up AGENTS.md whitespace and formatting to support markdownlint