### PR TITLE
Refactor FemtoLogger worker loop

### DIFF
--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -151,3 +151,23 @@ fn drop_with_sender_clone_exits() {
     barrier.wait();
     t.join().unwrap();
 }
+
+#[test]
+fn logger_drains_records_on_drop() {
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let handler = Arc::new(FemtoStreamHandler::new(
+        SharedBuf(Arc::clone(&buffer)),
+        DefaultFormatter,
+    ));
+    let mut logger = FemtoLogger::new("core".to_string());
+    logger.add_handler(handler.clone() as Arc<dyn FemtoHandlerTrait>);
+    logger.log(FemtoLevel::Info, "one");
+    logger.log(FemtoLevel::Info, "two");
+    logger.log(FemtoLevel::Info, "three");
+    drop(logger);
+    drop(handler);
+    assert_eq!(
+        read_output(&buffer),
+        "core [INFO] one\ncore [INFO] two\ncore [INFO] three\n"
+    );
+}


### PR DESCRIPTION
## Summary
- reorganize FemtoLogger worker thread logic
- add helper methods for handling records and shutdown
- add unit tests for the new helper methods
- add behavioural test covering logger shutdown record draining
- improve test harness to use `expect` when locking test handler

## Testing
- `make fmt lint typecheck test`

------
https://chatgpt.com/codex/tasks/task_e_6870ccbc205c83229d62e7bec12aac6d