### PR TITLE
Improve queue overflow docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ When implementing changes, adhere to the following testing procedures:
   subsequent commit) should represent a single logical unit of work.
 - **Quality Gates:** Before considering a change complete or proposing a commit,
   ensure it meets the following criteria:
-  
+
   - For code changes files:
 
     - **Testing:** Passes all relevant unit and behavioural tests according to
@@ -92,9 +92,9 @@ When implementing changes, adhere to the following testing procedures:
 
     - **Linting:** Run `make markdownlint` or use integrated editor linting.
     - **Mermaid diagrams:** Validate diagrams with `make nixie`.
-      
+
 - **Committing:**
-  
+
   - Only changes that meet all the quality gates above should be committed.
   - Write clear, descriptive commit messages summarizing the change, following
     these formatting guidelines:

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -65,14 +65,30 @@ pub struct FemtoHandler;
 
 Implementations should forward the record to an internal queue with `try_send`
 so the caller never blocks. If the queue is full, the record is silently dropped
-and a warning is written to `stderr`. Advanced use cases can specify an overflow
-policy when constructing a handler. The Python API exposes this via
-`OverflowPolicy` and `FemtoFileHandler.with_capacity_flush_policy`:
+and a warning is written to `stderr`. This favours throughput over completeness:
+records may be lost to keep the application responsive. Advanced use cases can
+specify an overflow policy when constructing a handler. The Python API exposes
+this via `OverflowPolicy` and `FemtoFileHandler.with_capacity_flush_policy`. The
+policy may also be extended to support options like back pressure, writing
+overflowed messages to a separate file, or emitting metrics for monitoring
+purposes:
 
 - **Drop** – current default; records are discarded when the queue is full.
 - **Block** – the call blocks until space becomes available.
 - **Timeout** – wait for a fixed duration before giving up and dropping the
   record.
+
+```python
+from femtologging import FemtoFileHandler, OverflowPolicy
+
+# Drop-in replacement that blocks instead of discarding.
+# Waiting ensures no log messages are lost if the queue becomes full.
+handler = FemtoFileHandler.with_capacity_flush_policy(
+    path="app.log",
+    capacity=4096,
+    overflow_policy=OverflowPolicy.BLOCK,
+)
+```
 
 ### StreamHandler
 


### PR DESCRIPTION
## Summary
- warn about record loss when queue overflows
- support AGENTS markdownlint
- document blocking overflow policy
- clarify overflow policy example

## Testing
- `make markdownlint`
- `make nixie`
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68718b3adac48322b4e6bd3d8bf55671

## Summary by Sourcery

Improve documentation for queue overflow policies in the Rust port and enforce markdownlint formatting in AGENTS.md

Documentation:
- Clarify that the default queue overflow policy drops records silently and may lead to data loss
- Document the blocking overflow policy option with a Python code example
- Expand overflow policy section to mention back pressure, separate file handling, and metrics extensions
- Update AGENTS.md to enforce markdownlint formatting rules by cleaning up trailing whitespace