### PR TITLE
Fix visibility for shared buffer helpers

### DIFF
--- a/rust_extension/tests/test_utils/shared_buffer.rs
+++ b/rust_extension/tests/test_utils/shared_buffer.rs
@@ -7,7 +7,7 @@ use crate::{Arc, Mutex};
 use std::io::{self, Write};
 
 #[derive(Clone)]
-pub struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+pub struct SharedBuf(pub Arc<Mutex<Vec<u8>>>);
 
 impl SharedBuf {
     /// Create a new, empty `SharedBuf`.
@@ -37,7 +37,7 @@ impl Write for SharedBuf {
     }
 }
 
-fn read_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
+pub fn read_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
     String::from_utf8(
         buffer
             .lock()


### PR DESCRIPTION
## Summary
- make `SharedBuf` tuple field public so tests can construct it
- expose `read_output` helper for use in integration tests

## Testing
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6874402c7e5c8322b88b783eb7c9ee66

## Summary by Sourcery

Fix visibility for shared buffer utilities to support external test construction and usage

Enhancements:
- Make SharedBuf tuple field public to allow external construction in tests
- Expose read_output helper function as public for use in integration tests