### PR TITLE
Update Maturin version

### DIFF
--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -23,7 +23,7 @@ jobs:
           # Cache wheels to avoid repeated downloads
           pip install \
             --cache-dir "${{ runner.tool_cache }}" \
-            maturin==1.4.0 pytest==7.4.4
+            "maturin>=1.9.1,<2.0.0" pytest==7.4.4
       - run: |
           source .venv/bin/activate
           maturin develop --manifest-path rust_extension/Cargo.toml

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -11,11 +11,12 @@ implementations as well:
   thread. It now provides `flush()` and `close()` to deterministically manage
   that thread.
 
-Packaging is handled by [maturin](https://maturin.rs/). The `[tool.maturin]`
-section in `pyproject.toml` declares the extension module as
-`femtologging._femtologging_rs`, so running `pip install .` automatically builds
-the Rust code. Windows users may need the MSVC build tools installed or may need
-to run maturin with `--compatibility windows`.
+Packaging is handled by [maturin](https://maturin.rs/). Use version
+`>=1.9.1,<2.0.0` as declared in `pyproject.toml`. The `[tool.maturin]` section
+declares the extension module as `femtologging._femtologging_rs`, so running
+`pip install .` automatically builds the Rust code. Windows users may need the
+MSVC build tools installed or may need to run maturin with `--compatibility
+windows`.
 
 `FemtoLogRecord` now groups its contextual fields into a `RecordMetadata`
 struct. Each record stores a timestamp, source file and line, module path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ package = true
 
 
 [build-system]
-requires = ["maturin>=1.5"]
+requires = ["maturin>=1.9.1,<2.0.0"]
 build-backend = "maturin"
 [tool.maturin]
 manifest-path = "rust_extension/Cargo.toml"


### PR DESCRIPTION
## Summary
- require Maturin `>=1.9.1,<2.0.0` in `pyproject.toml`
- use same Maturin range in heavy-tests workflow
- document Maturin version requirement

## Testing
- `CARGO_BUILD_ENV=PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 make lint`
- `CARGO_BUILD_ENV=PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 make typecheck`
- `CARGO_BUILD_ENV=PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 make test`


------
https://chatgpt.com/codex/tasks/task_e_6874f665c6b483228768d7260c12b0ad

## Summary by Sourcery

Unify and update the Maturin version requirement to >=1.9.1,<2.0.0 in build config, CI workflow, and documentation.

Enhancements:
- Bump Maturin requirement to >=1.9.1,<2.0.0 throughout the project

Build:
- Require maturin>=1.9.1,<2.0.0 in pyproject.toml

CI:
- Update heavy-tests workflow to install maturin>=1.9.1,<2.0.0

Documentation:
- Document the updated maturin version requirement in the rust-extension guide