### PR TITLE
Align PYO3 ABI3 config

### DIFF
--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -28,7 +28,7 @@ jobs:
           source .venv/bin/activate
           maturin develop --manifest-path rust_extension/Cargo.toml
         env:
-          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 0
       - run: |
           source .venv/bin/activate
           cargo fmt --manifest-path rust_extension/Cargo.toml -- --check
@@ -36,4 +36,4 @@ jobs:
           cargo test --manifest-path rust_extension/Cargo.toml -- --ignored
           pytest -q
         env:
-          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 0

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -8,10 +8,10 @@ across Python and Rust code.
 - `make fmt` – format Python, Rust and Markdown sources.
 - `make check-fmt` – verify formatting without modifying files.
 - `make lint` – run `ruff check` and `cargo clippy` with
-  `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`.
+  `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=0`.
 - `make typecheck` – run
-  `ty check --extra-search-path=/root/.pyenv/versions/3.13.3/lib/python3.13/site-packages`.
-  This target depends on `make build`.
+  `ty check --extra-search-path=/root/.pyenv/versions/3.13.3/lib/python3.13/
+  site-packages`. This target depends on `make build`.
 - `make build` – compile the Rust extension by running `pip install -e .`.
 - `make release` – build the extension with optimizations.
 - `make clean` – remove build artifacts.


### PR DESCRIPTION
## Summary
- update docs to mention `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=0`
- set ABI3 compatibility flag to 0 in the heavy tests workflow

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687538612dac8322b2ec45104ce9dd86