### PR TITLE
Fix logger drop deadlock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ nixie: ## Validate Mermaid diagrams
 test: build ## Run tests
 	cargo fmt --manifest-path $(RUST_MANIFEST) -- --check
 	$(CARGO_BUILD_ENV) cargo clippy --manifest-path $(RUST_MANIFEST) -- -D warnings
-	$(CARGO_BUILD_ENV) cargo test --manifest-path $(RUST_MANIFEST)
+	$(CARGO_BUILD_ENV) cargo test --manifest-path $(RUST_MANIFEST) --no-default-features
 	uv run pytest -v
 
 typecheck: build ## Static type analysis

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ check-fmt: ## Verify formatting
 
 lint: ## Run linters
 	ruff check
-	$(CARGO_BUILD_ENV) cargo clippy --manifest-path $(RUST_MANIFEST) -- -D warnings
+	$(CARGO_BUILD_ENV) cargo clippy --manifest-path $(RUST_MANIFEST) --no-default-features -- -D warnings
 
 markdownlint: ## Lint Markdown files
 	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(MDLINT)
@@ -54,7 +54,7 @@ nixie: ## Validate Mermaid diagrams
 
 test: build ## Run tests
 	cargo fmt --manifest-path $(RUST_MANIFEST) -- --check
-	$(CARGO_BUILD_ENV) cargo clippy --manifest-path $(RUST_MANIFEST) -- -D warnings
+	$(CARGO_BUILD_ENV) cargo clippy --manifest-path $(RUST_MANIFEST) --no-default-features -- -D warnings
 	$(CARGO_BUILD_ENV) cargo test --manifest-path $(RUST_MANIFEST) --no-default-features
 	uv run pytest -v
 

--- a/rust_extension/Cargo.toml
+++ b/rust_extension/Cargo.toml
@@ -8,13 +8,15 @@ name = "_femtologging_rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3 = { version = ">=0.25.1,<0.26.0", features = ["extension-module"] }
+pyo3 = { version = ">=0.25.1,<0.26.0", default-features = false, features = ["macros"] }
 crossbeam-channel = "0.5.15"
 log = "0.4"
 once_cell = "1"
 parking_lot = "0.12"
 
 [features]
+default = ["extension-module"]
+extension-module = ["pyo3/extension-module"]
 test-util = []
 
 [dev-dependencies]

--- a/rust_extension/Cargo.toml
+++ b/rust_extension/Cargo.toml
@@ -8,7 +8,7 @@ name = "_femtologging_rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3 = { version = ">=0.25.1,<0.26.0", default-features = false, features = ["macros"] }
+pyo3 = { version = ">=0.25.1,<0.26.0", default-features = false, features = ["macros", "auto-initialize"] }
 crossbeam-channel = "0.5.15"
 log = "0.4"
 once_cell = "1"
@@ -26,4 +26,4 @@ tempfile = "^3.20.0"
 proptest = "1.0.0"
 loom = "0.7.2"
 itertools = "0.10"
-_femtologging_rs = { path = ".", package = "femtologging_rs", features = ["test-util"] }
+_femtologging_rs = { path = ".", package = "femtologging_rs", default-features = false, features = ["test-util"] }

--- a/rust_extension/src/logger.rs
+++ b/rust_extension/src/logger.rs
@@ -217,9 +217,13 @@ impl Drop for FemtoLogger {
         }
         self.tx.take();
         if let Some(handle) = self.handle.take() {
-            if handle.join().is_err() {
-                warn!("FemtoLogger: worker thread panicked");
-            }
+            Python::with_gil(|py| {
+                py.allow_threads(move || {
+                    if handle.join().is_err() {
+                        warn!("FemtoLogger: worker thread panicked");
+                    }
+                })
+            });
         }
     }
 }

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -59,11 +59,10 @@ def test_level_parsing_and_filtering() -> None:
         logger.log("bogus", "drop")
 
 
-@pytest.mark.skip
-def test_logger_add_handler(
+def test_logger_drop_no_hang(
     tmp_path: Path, file_handler_factory: FileHandlerFactory
 ) -> None:
-    """Records should be written to every attached handler."""
+    """FemtoLogger cleanup shouldn't block waiting on its thread."""
     path1 = tmp_path / "one.log"
     path2 = tmp_path / "two.log"
     with (


### PR DESCRIPTION
## Summary
- release the logger's worker thread outside the GIL
- add regression test to ensure dropping a logger with file handlers doesn't hang

## Testing
- `make lint`
- `make typecheck`
- `make test` *(fails: undefined symbols for Python)*


------
https://chatgpt.com/codex/tasks/task_e_687577c12aa08322bbe72adf7b8125bc

## Summary by Sourcery

Prevent deadlock when dropping FemtoLogger by releasing the GIL before joining the worker thread and add a regression test to verify that dropping a logger with file handlers does not hang.

Bug Fixes:
- Release the GIL before joining the logger's worker thread to avoid deadlocking on drop.

Tests:
- Add regression test to ensure FemtoLogger cleanup does not block waiting on its thread.