### PR TITLE
Fix inline feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-#uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.

--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
+#   Project freezes Python deps with uv, so the lock file is tracked for reproducibility.
 uv.lock
 
 # poetry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,9 +74,7 @@ When implementing changes, adhere to the following testing procedures:
   subsequent commit) should represent a single logical unit of work.
 - **Quality Gates:** Before considering a change complete or proposing a commit,
   ensure it meets the following criteria:
-
-  - For code changes files:
-
+  - For code-change files:
     - **Testing:** Passes all relevant unit and behavioural tests according to
       the guidelines above. (Execute these using `make test`).
     - **Linting:** Run `make lint` and ensure that there are no lint rule

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ When implementing changes, adhere to the following testing procedures:
   subsequent commit) should represent a single logical unit of work.
 - **Quality Gates:** Before considering a change complete or proposing a commit,
   ensure it meets the following criteria:
-  
+
   - For code changes files:
 
     - **Testing:** Passes all relevant unit and behavioural tests according to
@@ -92,9 +92,9 @@ When implementing changes, adhere to the following testing procedures:
 
     - **Linting:** Run `make markdownlint` or use integrated editor linting.
     - **Mermaid diagrams:** Validate diagrams with `make nixie`.
-      
+
 - **Committing:**
-  
+
   - Only changes that meet all the quality gates above should be committed.
   - Write clear, descriptive commit messages summarizing the change, following
     these formatting guidelines:
@@ -148,8 +148,8 @@ When implementing changes, adhere to the following testing procedures:
 ## Rust Specific Guidance
 
 This repository is written in Rust and uses Cargo for building and dependency
-management. Contributors should follow these best practices when working on the
-project:
+management. Contributors should follow these best practices when working on
+the project:
 
 - Run `make fmt`, `make lint`, `make typecheck`, and `make test` before
   committing.

--- a/docs/logging-cpython-picologging-comparison.md
+++ b/docs/logging-cpython-picologging-comparison.md
@@ -237,7 +237,7 @@ threads are concurrently creating loggers or modifying handlers. Picologging’s
 lack of a global lock means threads only contend on individual handler locks or
 Python’s GIL. This suggests picologging should scale better under heavy multi-
 threaded logging, although real-world gains depend on workload. (No specific
-multithread benchmarks are publicly available to cite; this conclusion follows
+multi-thread benchmarks are publicly available to cite; this conclusion follows
 from the architecture.)
 
 ## Use-Case Suitability
@@ -248,7 +248,7 @@ from the architecture.)
   mean log throughput is much higher, reducing the impact of logging on
   application latency.
 
-- **Heavily multithreaded applications:** Picologging’s finer-grained locking
+- **Heavily multi-threaded applications:** Picologging’s finer-grained locking
   (per-handler) may offer better concurrency than CPython’s one big lock. In
   CPython logging, adding handlers or modifying logger hierarchy is serialized
   by the module-wide `_lock`. Picologging avoids that, so in a heavily

--- a/docs/logging-cpython-picologging-comparison.md
+++ b/docs/logging-cpython-picologging-comparison.md
@@ -44,7 +44,7 @@ Picologging’s Logger class has no Python-level inheritance hierarchy beyond
 the C struct (though it also embeds a `Filterer`). It uses boolean flags
 (`enabledForDebug`, etc.) set at init to speed up `isEnabledFor` checks, rather
 than dynamic lookups. Extensible hooks in CPython (like custom `LogRecord`
-factories) are largely absent: notably `Manager.setLogRecordFactory` is
+factories) are largely absent: notably, `Manager.setLogRecordFactory` is
 **not implemented** in picologging. In effect, CPython logging emphasizes
 extensibility and configurability, while picologging emphasizes a streamlined,
 lower-overhead class design (trading off some features).

--- a/docs/logging-cpython-picologging-comparison.md
+++ b/docs/logging-cpython-picologging-comparison.md
@@ -1,12 +1,12 @@
 # CPython `logging` vs Microsoft `picologging`: Architecture and Implementation Comparison
 
-Python’s built-in `logging` module and Microsoft’s **picologging** (a
-high-performance drop-in replacement) share the same goal and API, but diverge
+Python’s built-in `logging` module and Microsoft’s **picologging** (a high-
+performance drop-in replacement) share the same goal and API, but diverge
 significantly in design and implementation. This comparison examines their
-architectural differences (class design, handler/formatter mechanics,
-locking/thread-safety, data structures, extensibility vs performance,
-startup/runtime overhead), surveys available performance data, and discusses use
-cases and migration issues. Key differences emerge from picologging’s C++-based
+architectural differences (class design, handler/formatter mechanics, locking/
+thread-safety, data structures, extensibility vs performance, startup/
+runtime overhead), surveys available performance data, and discusses use cases
+and migration issues. Key differences emerge from picologging’s C++-based
 implementation and aggressive optimization versus the flexibility of CPython’s
 pure-Python logging.
 
@@ -19,34 +19,33 @@ tree) under a root logger via a `Manager` holding a `loggerDict` of names to
 logger instances. Each `Logger` has attributes like `name`, `level`, a list of
 child handlers, and links to its parent logger, and inherits filtering behavior
 via the `Filterer` mixin. Handlers (e.g. `StreamHandler`, `FileHandler`) hold
-output streams and optional `Formatter` objects, and each has its own lock for
-thread-safe I/O. When a logger emits, it creates a `LogRecord` (a Python object
-with fields like `msg`, `args`, `levelno`, timestamp, etc.), runs it through
-logger filters, then calls each handler’s `handle()` method. The handler filters
-it again, formats it (via `Formatter.format(record)`), and writes to its
+output streams and optional `Formatter` objects, each with a dedicated lock
+for thread-safe I/O. When a logger emits, it creates a `LogRecord` (a Python
+object with fields like `msg`, `args`, `levelno`, timestamp, etc.), runs it
+through logger filters, then calls each handler’s `handle()` method. The handler
+filters it again, formats it (via `Formatter.format(record)`), and writes to its
 destination (often wrapped in `with self.lock:`).
 
-In contrast, **picologging** implements most core classes in C++ (exposed as
-Python types) for speed. It has analogous classes: `Logger`, `Handler`,
+In contrast, **picologging** implements most core classes in C++ (exposed
+as Python types) for speed. It has analogous classes: `Logger`, `Handler`,
 `Formatter`, and `LogRecord`, but implemented natively. Picologging’s `Manager`
 and `_Placeholder` (for tree structure) exist in Python, but key operations
-occur in C. For example, `Logger` is a C-struct type (see
-[logger.hxx](https://github.com/microsoft/picologging/blob/%E2%80%A6/logger.hxx))
-with fixed fields (e.g.
-`PyObject *name, unsigned short level, PyObject *handlers, bool propagate`, plus
-several boolean flags for fast level checks). A C++ `Handler` struct contains a
-`Filterer` object (for filters), a `std::recursive_mutex *lock`, and pointers
-for name, formatter, and methods (see
-[handler.hxx](https://github.com/microsoft/picologging/blob/%E2%80%A6/handler.hxx)).
+occur in C. For example, `Logger` is a C-struct type (see [logger.hxx](https://
+github.com/microsoft/picologging/blob/%E2%80%A6/logger.hxx)) with fixed
+fields (e.g. `PyObject *name, unsigned short level, PyObject *handlers, bool
+propagate`, plus several boolean flags for fast level checks). A C++ `Handler`
+struct contains a `Filterer` object (for filters), a `std::recursive_mutex
+*lock`, and pointers for name, formatter, and methods (see [handler.hxx]
+(<https://github.com/microsoft/picologging/blob/%E2%80%A6/handler.hxx>)).
 Picologging’s `LogRecord` is likewise a C struct with fields mirroring Python’s
 (name, msg, args, levelno, pathname, lineno, thread, process, etc.).
 
-Picologging’s Logger class has no Python-level inheritance hierarchy beyond the
-C struct (though it also embeds a `Filterer`). It uses boolean flags
+Picologging’s Logger class has no Python-level inheritance hierarchy beyond
+the C struct (though it also embeds a `Filterer`). It uses boolean flags
 (`enabledForDebug`, etc.) set at init to speed up `isEnabledFor` checks, rather
 than dynamic lookups. Extensible hooks in CPython (like custom `LogRecord`
-factories) are largely absent: notably `Manager.setLogRecordFactory` is **not
-implemented** in picologging. In effect, CPython logging emphasizes
+factories) are largely absent: notably `Manager.setLogRecordFactory` is
+**not implemented** in picologging. In effect, CPython logging emphasizes
 extensibility and configurability, while picologging emphasizes a streamlined,
 lower-overhead class design (trading off some features).
 
@@ -98,15 +97,15 @@ and creates `LogRecord` objects. Handlers reference `Formatter` instances.
 
 ## Handler and Formatter Mechanics
 
-In both systems, **handlers** encapsulate where and how to output messages, and
-**formatters** convert `LogRecord` data to text. CPython’s `Handler` base class
-(in `logging/__init__.py`) defines the interface: `setLevel()`,
-`setFormatter()`, `handle()`, `emit()`, etc. Subclasses like `StreamHandler` or
-`FileHandler` override `emit()` to write to streams or files. A handler’s
-`handle(record)` method checks filters and then does
-`with self.lock: self.emit(record)`, ensuring thread-safe emission. The
-handler’s `format(record)` delegates to its `Formatter.format()` if set, or a
-default formatter otherwise.
+In both systems, **handlers** encapsulate where and how to output messages,
+and **formatters** convert `LogRecord` data to text. CPython’s `Handler`
+base class (in `logging/__init__.py`) defines the interface: `setLevel()`,
+`setFormatter()`, `handle()`, `emit()`, etc. Subclasses like `StreamHandler`
+or `FileHandler` override `emit()` to write to streams or files. A
+handler’s `handle(record)` method checks filters and then does `with
+self.lock: self.emit(record)`, ensuring thread-safe emission. The handler’s
+`format(record)` delegates to its `Formatter.format()` if set, or a default
+formatter otherwise.
 
 Picologging provides corresponding handler types, but implemented in C++ for
 speed. For example, its `Handler_handle` method (in [handler.cxx]) first applies
@@ -148,16 +147,16 @@ string, and writes to the output (wrapped by its lock for thread safety).
 Thread safety is a major differentiator. **CPython logging** uses two levels of
 locking: a global module lock (`_lock = threading.RLock()`) to protect shared
 structures (logger hierarchy, handler registry, caches) and individual locks per
-handler. The global lock is used in operations like `Manager.getLogger(name)` to
-update `loggerDict` and fix up parents safely. It also guards handler
-registration and cleanup (e.g. `Handler.close()` uses `with _lock` to update the
-internal handlers map). This ensures that configuring loggers/handlers from
+handler. The global lock is used in operations like `Manager.getLogger(name)`
+to update `loggerDict` and fix up parents safely. It also guards handler
+registration and cleanup (e.g. `Handler.close()` uses `with _lock` to update
+the internal handlers map). This ensures that configuring loggers/handlers from
 multiple threads is safe but means some contention on `_lock`.
 
 By contrast, **picologging** minimizes global locking. Its `Manager.getLogger`
 does not acquire any module-level lock. Instead, it relies on the Python Global
-Interpreter Lock (GIL) and the assumption that logger setup is usually
-single-threaded. Handlers each have their own `std::recursive_mutex` (allocated
+Interpreter Lock (GIL) and the assumption that logger setup is usually single-
+threaded. Handlers each have their own `std::recursive_mutex` (allocated
 in `Handler_new`) for I/O locking. When handling a record, picologging’s
 `Handler_handle` explicitly locks and unlocks this mutex around the emit,
 similar in effect to Python’s `with self.lock`. The net effect: both systems
@@ -170,20 +169,20 @@ these locks in native code.
 
 CPython logging uses standard Python collections. The `Manager.loggerDict` is a
 dict mapping names to `Logger` or `_PlaceHolder` objects. Each `Logger.handlers`
-is a list, and `_handlerList` tracks all handlers for shutdown. Log levels and
-names are in Python dicts (`_levelToName`, `_nameToLevel`). LogRecords are
+is a list, and `_handlerList` tracks all handlers for shutdown. Log levels
+and names are in Python dicts (`_levelToName`, `_nameToLevel`). LogRecords are
 Python objects with many attributes (as shown in [67] and docstring). CPython
 also caches effective log levels: each `Logger` has a `_cache` dict mapping
 levels to True/False to speed up `isEnabledFor`. The code even defines a
 `_clear_cache` method (with `_lock`) to reset caches on level changes.
 
-Picologging, in contrast, uses C++ types for performance. Its `LogRecord` is a C
-struct (see [68†L10-L17]) with fixed fields (name, msg, args, levelno, pathname,
-lineno, thread ID, etc.). `Logger` is also a C struct with fixed fields,
-including booleans (`enabledForDebug`, etc.) set once in `Logger_init` to
-indicate which levels are active. Picologging **does not implement** a dynamic
-record factory or caching layers: it precomputes level flags (but note it does
-*not* clear or update them on level changes beyond init) and skips the
+Picologging, in contrast, uses C++ types for performance. Its `LogRecord` is
+a C struct (see [68†L10-L17]) with fixed fields (name, msg, args, levelno,
+pathname, lineno, thread ID, etc.). `Logger` is also a C struct with fixed
+fields, including booleans (`enabledForDebug`, etc.) set once in `Logger_init`
+to indicate which levels are active. Picologging **does not implement** a
+dynamic record factory or caching layers: it precomputes level flags (but note
+it does *not* clear or update them on level changes beyond init) and skips the
 Python-level `_cache`. The manager’s `loggerDict` is a normal Python dict, but
 since picologging avoids global locking, care must be taken if multiple threads
 add loggers simultaneously (the GIL provides some safety). In summary, CPython
@@ -194,20 +193,20 @@ fixed C/C++ memory layouts to reduce per-record overhead.
 
 CPython’s logging is highly extensible: you can subclass `Logger` or `Handler`,
 override methods, use `setLogRecordFactory()` to customize records, and freely
-mix Python-formatters or even swap in custom `logging.Logger` implementations at
-runtime (via `Manager.setLoggerClass`). This flexibility comes with Python-level
-overhead.
+mix Python-formatters or even swap in custom `logging.Logger` implementations
+at runtime (via `Manager.setLoggerClass`). This flexibility comes with Python-
+level overhead.
 
-Picologging trades some of that flexibility for speed. It aims to be *drop-in*
-compatible, but some APIs aren’t supported. For instance,
+Picologging trades some of that flexibility for speed. It aims to be
+*drop-in* compatible, but some APIs aren’t supported. For instance,
 `Manager.setLogRecordFactory` is explicitly **not implemented** in picologging
 (it raises `NotImplementedError`), so user code relying on custom record
 factories won’t work. Similarly, certain configuration helpers (like
-`logging.Formatter` styles beyond the built-in percent/str/template support) may
-differ. On the other hand, picologging incorporates optimized techniques: it
-hardcodes level checks, implements critical paths in C++, and avoids Python
-exception overhead in common cases. The result is much higher throughput for
-logging calls, as discussed below. Thus, the design reflects a classic
+`logging.Formatter` styles beyond the built-in percent/str/template support)
+may differ. On the other hand, picologging incorporates optimized techniques:
+it hardcodes level checks, implements critical paths in C++, and avoids Python
+exception overhead in common cases. The result is much higher throughput
+for logging calls, as discussed below. Thus, the design reflects a classic
 extensibility-vs-performance trade-off: CPython logging favors ease of
 modification, while picologging sacrifices some features for raw speed.
 
@@ -215,31 +214,31 @@ modification, while picologging sacrifices some features for raw speed.
 
 Benchmarks (as reported by picologging’s maintainers) show **substantial
 speedups**. The picologging README reports that it is *“4–17× faster than the*
-`logging` *module”*. Sample microbenchmarks on macOS indicate, for example, a
-simple `Logger(level=DEBUG).debug()` call taking ~0.58 µs on CPython vs
+`logging` *module”*. Sample microbenchmarks on macOS indicate, for example,
+a simple `Logger(level=DEBUG).debug()` call taking ~0.58 µs on CPython vs
 ~0.033 µs with picologging (about **17×** speedup). Even with arguments or at
-INFO level, picologging’s latencies remain several times lower. These gains come
-from eliminating Python-layer dispatch: e.g. picologging’s `Logger.debug()` goes
-straight to optimized C code and avoids many dynamic checks if the logger is
-disabled.
+INFO level, picologging’s latencies remain several times lower. These gains
+come from eliminating Python-layer dispatch: e.g. picologging’s `Logger.debug()`
+goes straight to optimized C code and avoids many dynamic checks if the logger
+is disabled.
 
-Concrete measured *throughput* numbers vary by environment, but the
-order-of-magnitude improvements are widely noted. (For example, publishing these
+Concrete measured *throughput* numbers vary by environment, but the order-
+of-magnitude improvements are widely noted. (For example, publishing these
 benchmarks in a blog or issue would confirm them, but as of this writing the
-claim inis the primary source.) Latency per record is drastically lower in
-picologging, which benefits real-time logging. In terms of *memory usage*, no
-detailed comparison is documented. One might expect picologging’s C-structs to
-use less per-record overhead than Python objects, but the C extension itself
+claim itself is the primary source.) Latency per record is drastically lower
+in picologging, which benefits real-time logging. In terms of *memory usage*,
+no detailed comparison is documented. One might expect picologging’s C-structs
+to use less per-record overhead than Python objects, but the C extension itself
 increases the binary size. We did not find published memory profiles.
 
 In multi-threaded scenarios, both libraries are thread-safe but behave
 differently: CPython logging’s global lock can become a bottleneck if many
 threads are concurrently creating loggers or modifying handlers. Picologging’s
 lack of a global lock means threads only contend on individual handler locks or
-Python’s GIL. This suggests picologging should scale better under heavy
-multi-threaded logging, although real-world gains depend on workload. (No
-specific multithread benchmarks are publicly available to cite; this conclusion
-follows from the architecture.)
+Python’s GIL. This suggests picologging should scale better under heavy multi-
+threaded logging, although real-world gains depend on workload. (No specific
+multithread benchmarks are publicly available to cite; this conclusion follows
+from the architecture.)
 
 ## Use-Case Suitability
 
@@ -252,8 +251,8 @@ follows from the architecture.)
 - **Heavily multithreaded applications:** Picologging’s finer-grained locking
   (per-handler) may offer better concurrency than CPython’s one big lock. In
   CPython logging, adding handlers or modifying logger hierarchy is serialized
-  by the module-wide `_lock`. Picologging avoids that, so in a heavily threaded
-  app logging to multiple handlers, contention could be lower. Both
+  by the module-wide `_lock`. Picologging avoids that, so in a heavily
+  threaded app logging to multiple handlers, contention could be lower. Both
   implementations ensure thread safety in handlers, so correctness is preserved,
   but picologging’s design is more throughput-oriented.
 
@@ -274,9 +273,9 @@ installed, leveraging these performance characteristics.
 
 ## Migration and Compatibility
 
-Picologging is designed as a *drop-in* replacement. In most cases, simply using
-`import picologging as logging` makes code work unchanged. Handler and formatter
-classes have the same names (`StreamHandler`, `Formatter`, etc.), and
+Picologging is designed as a *drop-in* replacement. In most cases, simply
+using `import picologging as logging` makes code work unchanged. Handler and
+formatter classes have the same names (`StreamHandler`, `Formatter`, etc.), and
 `getLogger`, `basicConfig`, etc., behave identically.
 
 However, there are important caveats:
@@ -295,18 +294,18 @@ However, there are important caveats:
   Python and inject it may not work as intended.
 
 - **Import timing:** To benefit from picologging, it must be imported before any
-  loggers are created. Once a `Logger` from `logging` is created, using
-  `import picologging` may not retroactively convert it. Thus, one should import
-  and configure `picologging` at program start.
+  loggers are created. Once a `Logger` from `logging` is created, using `import
+  picologging` may not retroactively convert it. Thus, one should import and
+  configure `picologging` at program start.
 
 - **Binary dependency:** Picologging requires building a C extension. This adds
   a dependency at deployment time and is incompatible with environments where
   installing extensions is not allowed (e.g. certain serverless or restricted
   environments).
 
-In summary, **most simple use cases migrate with no code changes**, but any code
-using the very flexible hooks of CPython logging should be reviewed. The
-performance gains often outweigh these downsides for throughput-sensitive
+In summary, **most simple use cases migrate with no code changes**, but any
+code using the very flexible hooks of CPython logging should be reviewed.
+The performance gains often outweigh these downsides for throughput-sensitive
 applications.
 
 ## Summary
@@ -314,10 +313,11 @@ applications.
 CPython’s `logging` module is a mature, feature-rich, pure-Python logging
 framework with flexible configuration and extensibility. Microsoft’s
 `picologging` reimplements the same API in (mostly) C++ for high performance.
-Key differences include: **class implementation** (Python classes vs C structs),
-**locking** (global RLock plus per-handler RLock vs per-handler C++ mutex, no
-global lock), **data structures** (dynamic vs static fields), and **features
-supported** (full logging API vs a subset). These design choices give
+<!-- markdownlint-disable MD032 --> Key differences include: **class
+implementation** (Python classes vs C structs), **locking** (global RLock plus
+per-handler RLock vs per-handler C++ mutex, no global lock), **data structures**
+(dynamic vs static fields), and **features supported** (full logging API
+vs a subset). These design choices give <!-- markdownlint-enable MD032 -->
 picologging much higher throughput at the cost of some flexibility.
 
 For latency-sensitive or heavily threaded applications, picologging is generally

--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -3,25 +3,13 @@ use _femtologging_rs::{
     DefaultFormatter, FemtoHandlerTrait, FemtoLevel, FemtoLogRecord, FemtoStreamHandler,
 };
 use rstest::rstest;
-use std::io::{self, Write};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc as StdArc, Mutex as StdMutex};
 
-#[derive(Clone)]
-struct SharedBuf(Arc<Mutex<Vec<u8>>>);
-
-impl Write for SharedBuf {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.lock().unwrap().write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.0.lock().unwrap().flush()
-    }
-}
-
-fn read_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
-    String::from_utf8(buffer.lock().unwrap().clone()).unwrap()
-}
+type Arc<T> = StdArc<T>;
+type Mutex<T> = StdMutex<T>;
+#[path = "test_utils/shared_buffer.rs"]
+mod shared_buffer;
+use shared_buffer::{read_output, SharedBuf};
 
 #[rstest]
 #[case("core", FemtoLevel::Info, "hello", "core [INFO] hello")]

--- a/rust_extension/tests/test_utils/shared_buffer.rs
+++ b/rust_extension/tests/test_utils/shared_buffer.rs
@@ -1,0 +1,29 @@
+//! Shared buffer utilities for concurrency tests.
+//!
+//! Provides thread-safe buffer types and helpers for capturing
+//! log output in both standard and loom-based scenarios.
+
+use crate::{Arc, Mutex};
+use std::io::{self, Write};
+
+#[derive(Clone)]
+pub struct SharedBuf(pub Arc<Mutex<Vec<u8>>>);
+
+impl Write for SharedBuf {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().expect("SharedBuf mutex poisoned").write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.lock().expect("SharedBuf mutex poisoned").flush()
+    }
+}
+
+/// Return the captured output as a `String`.
+///
+/// This clones the entire buffer for simplicity, which is fine for tests
+/// but could be expensive with large data sets.
+pub fn read_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
+    String::from_utf8(buffer.lock().expect("Buffer mutex poisoned").clone())
+        .expect("Buffer contains invalid UTF-8")
+}


### PR DESCRIPTION
## Summary
- tighten language in logging comparison doc
- mention buffer clone cost in test helper
- ignore `uv.lock` file
- fix doc typo and trim whitespace

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_68718bbd850483229fc0e73c41854cfb

## Summary by Sourcery

Introduce a shared buffer helper for concurrency tests, refactor loom-based tests to use it, improve documentation clarity and formatting, fix typos, trim whitespace, and ignore uv.lock in version control

Enhancements:
- Introduce a shared_buffer.rs test utility to consolidate thread-safe buffer types and helper functions
- Refactor loom-based concurrency tests to use the new SharedBuf and read_output helpers and simplify Arc/Mutex imports

Documentation:
- Tighten language and formatting in the logging comparison docs
- Fix documentation typos and trim extraneous whitespace in AGENTS.md

Chores:
- Add uv.lock to .gitignore