### PR TITLE
Allow dynamic handler addition on shared loggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ from femtologging import FemtoStreamHandler
 
 log.add_handler(FemtoStreamHandler.stdout())
 
-# Handlers can be added at any time, even when the logger is shared.
+# Handlers can be added or removed at any time, even when the logger is
+# shared. Newly added handlers only see subsequent records.
 
 # Attach a custom Python handler
 class Collector:
@@ -59,6 +60,7 @@ class Collector:
 
 collector = Collector()
 log.add_handler(collector)
+log.remove_handler(collector)
 ```
 
 `FemtoStreamHandler` and `FemtoFileHandler` are available for basic output. Each

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ from femtologging import FemtoStreamHandler
 
 log.add_handler(FemtoStreamHandler.stdout())
 
+# Handlers can be added at any time, even when the logger is shared.
+
 # Attach a custom Python handler
 class Collector:
     def __init__(self) -> None:

--- a/docs/logger-hierarchy-and-multi-handler.md
+++ b/docs/logger-hierarchy-and-multi-handler.md
@@ -1,7 +1,7 @@
 # Logger Hierarchy and Handler Relationships
 
-This note outlines the remaining work to add flexible logger/handler wiring to
-`femtologging`. The prototype originally assumed each logger owned a single
+This note outlines the remaining work to add flexible logger/handler wiring
+to `femtologging`. The prototype originally assumed each logger owned a single
 handler and that handlers were not shared. The codebase now supports multiple
 handlers per logger and safely sharing a handler between loggers. The next step
 is implementing hierarchical configuration using dotted names with propagation.
@@ -24,8 +24,9 @@ is implementing hierarchical configuration using dotted names with propagation.
 
 2. **Allow multiple handlers per logger**
 
-   - Change `FemtoLogger` to hold a `Vec<Arc<dyn FemtoHandlerTrait>>`.
-   - Expose `add_handler()` and `remove_handler()` APIs.
+   - Change `FemtoLogger` to hold an `RwLock<Vec<Arc<dyn FemtoHandlerTrait>>>`.
+   - Expose `add_handler()` and `remove_handler()` APIs that work through
+     `&self`.
    - Update logging macros to dispatch each record to every configured handler.
 
 3. **Support handler sharing**
@@ -47,8 +48,8 @@ is implementing hierarchical configuration using dotted names with propagation.
    - Extend the builder API to attach multiple handler IDs per logger.
    - Allow handlers defined once to be referenced from several loggers.
    - Implement a `get_logger(name)` helper exposed through the Python bindings.
-     It mirrors CPython's semantics and returns existing instances from the
-     registry. Provide a camelCase alias `getLogger()` for backwards
+     It mirrors CPython's semantics and returns existing instances from
+     the registry. Provide a camelCase alias `getLogger()` for backwards
      compatibility, though new code should prefer the snake_case form.
 
 ## Testing Considerations

--- a/docs/logger-hierarchy-and-multi-handler.md
+++ b/docs/logger-hierarchy-and-multi-handler.md
@@ -26,7 +26,9 @@ is implementing hierarchical configuration using dotted names with propagation.
 
    - Change `FemtoLogger` to hold an `RwLock<Vec<Arc<dyn FemtoHandlerTrait>>>`.
    - Expose `add_handler()` and `remove_handler()` APIs that work through
-     `&self`.
+     `&self`. Adding or removing a handler while other threads log is safe—new
+     handlers only process messages logged after they are added, and removed
+     handlers stop receiving further records.
    - Update logging macros to dispatch each record to every configured handler.
 
 3. **Support handler sharing**

--- a/docs/logger-hierarchy-and-multi-handler.md
+++ b/docs/logger-hierarchy-and-multi-handler.md
@@ -51,8 +51,8 @@ is implementing hierarchical configuration using dotted names with propagation.
    - Allow handlers defined once to be referenced from several loggers.
    - Implement a `get_logger(name)` helper exposed through the Python bindings.
      It mirrors CPython's semantics and returns existing instances from
-     the registry. Provide a camelCase alias `getLogger()` for backwards
-     compatibility, though new code should prefer the snake_case form.
+    the registry. Provide a camelCase alias `getLogger()` for backward
+    compatibility, though new code should prefer the snake_case form.
 
 ## Testing Considerations
 

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -39,6 +39,12 @@ reference into that list. When `log()` creates a `FemtoLogRecord`, it sends a
 clone to each configured handler, ensuring thread‑safe routing via the handlers'
 MPSC queues.
 
+Handlers observe log records in the order they are attached. Adding a handler
+while other threads are logging is safe—new handlers only receive records
+logged after the addition completes. The `remove_handler()` method works through
+`&self` as well and detaches a handler so it no longer receives subsequent
+records.
+
 Handlers manage their own worker threads; the logger simply forwards each record
 to every handler. Callers may invoke a handler's `flush()` method to ensure
 queued messages are written before dropping it.

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -32,18 +32,19 @@ logger's minimum level using a `FemtoLevel` value. Likewise, `log()` accepts a
 is filtered out.
 
 `FemtoLogger` can now dispatch a record to multiple handlers. Handlers implement
-`FemtoHandlerTrait` and run their I/O on worker threads. A logger holds a
-`Vec<Arc<dyn FemtoHandlerTrait>>`; calling `add_handler()` stores another
-handler reference. When `log()` creates a `FemtoLogRecord`, it sends a clone
-to each configured handler, ensuring thread‑safe routing via the handlers' MPSC
-queues.
+`FemtoHandlerTrait` and run their I/O on worker threads. The logger keeps its
+handler list inside an `RwLock<Vec<Arc<dyn FemtoHandlerTrait>>>`, allowing
+handlers to be added through `&self`. Calling `add_handler()` pushes another
+reference into that list. When `log()` creates a `FemtoLogRecord`, it sends a
+clone to each configured handler, ensuring thread‑safe routing via the handlers'
+MPSC queues.
 
 Handlers manage their own worker threads; the logger simply forwards each record
 to every handler. Callers may invoke a handler's `flush()` method to ensure
 queued messages are written before dropping it.
 
-The `add_handler()` method is now exposed through the Python bindings.
-Any object with a `handle(logger, level, message)` method can be attached
-to a `FemtoLogger`. Built-in handlers like `FemtoStreamHandler` and
-`FemtoFileHandler` work out of the box. Custom Python classes require a
-compatible `handle` implementation.
+The `add_handler()` method is exposed through the Python bindings and can be
+called on a shared logger instance. Any object with a `handle(logger, level,
+message)` method can be attached to a `FemtoLogger`. Built-in handlers like
+`FemtoStreamHandler` and `FemtoFileHandler` work out of the box. Custom Python
+classes require a compatible `handle` implementation.

--- a/rust_extension/src/file_handler.rs
+++ b/rust_extension/src/file_handler.rs
@@ -19,6 +19,7 @@ use std::{
 use crossbeam_channel::{bounded, Receiver, Sender};
 use log::warn;
 use pyo3::prelude::*;
+use std::any::Any;
 
 use crate::handler::FemtoHandlerTrait;
 use crate::{
@@ -650,6 +651,10 @@ impl FemtoHandlerTrait for FemtoFileHandler {
 
     fn flush(&self) -> bool {
         FemtoFileHandler::flush(self)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/rust_extension/src/handler.rs
+++ b/rust_extension/src/handler.rs
@@ -1,12 +1,13 @@
 use crate::log_record::FemtoLogRecord;
 use pyo3::prelude::*;
+use std::any::Any;
 
 /// Trait implemented by all log handlers.
 ///
 /// `FemtoHandler` is `Send + Sync` so it can be safely called from multiple
 /// threads by reference. Each implementation forwards the record to its own
 /// consumer thread without blocking the caller.
-pub trait FemtoHandlerTrait: Send + Sync {
+pub trait FemtoHandlerTrait: Send + Sync + Any {
     /// Dispatch a log record for handling.
     fn handle(&self, record: FemtoLogRecord);
 
@@ -19,6 +20,9 @@ pub trait FemtoHandlerTrait: Send + Sync {
         // Default to a no-op flush for handlers that do not buffer writes.
         true
     }
+
+    /// Expose a typed reference for downcasting.
+    fn as_any(&self) -> &dyn Any;
 }
 
 /// Base Python class for handlers. Methods do nothing by default.
@@ -39,5 +43,9 @@ impl FemtoHandlerTrait for FemtoHandler {
 
     fn flush(&self) -> bool {
         true
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }

--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -14,7 +14,7 @@ pub use formatter::{DefaultFormatter, FemtoFormatter};
 pub use handler::{FemtoHandler, FemtoHandlerTrait};
 pub use level::FemtoLevel;
 pub use log_record::{FemtoLogRecord, RecordMetadata};
-pub use logger::FemtoLogger;
+pub use logger::{FemtoLogger, QueuedRecord};
 use manager::{get_logger as manager_get_logger, reset_manager};
 pub use stream_handler::FemtoStreamHandler;
 

--- a/rust_extension/src/logger.rs
+++ b/rust_extension/src/logger.rs
@@ -102,14 +102,14 @@ impl FemtoLogger {
 
     /// Attach a handler implemented in Python or Rust.
     #[pyo3(name = "add_handler", text_signature = "(self, handler)")]
-    pub fn py_add_handler(&mut self, handler: Py<PyAny>) {
+    pub fn py_add_handler(&self, handler: Py<PyAny>) {
         self.add_handler(Arc::new(PyHandler { obj: handler }) as Arc<dyn FemtoHandlerTrait>);
     }
 }
 
 impl FemtoLogger {
     /// Attach a handler to this logger.
-    pub fn add_handler(&mut self, handler: Arc<dyn FemtoHandlerTrait>) {
+    pub fn add_handler(&self, handler: Arc<dyn FemtoHandlerTrait>) {
         self.handlers.write().push(handler);
     }
 

--- a/rust_extension/src/logger.rs
+++ b/rust_extension/src/logger.rs
@@ -26,6 +26,12 @@ use std::thread::{self, JoinHandle};
 
 const DEFAULT_CHANNEL_CAPACITY: usize = 1024;
 
+/// Record queued for processing by the worker thread.
+pub struct QueuedRecord {
+    pub record: FemtoLogRecord,
+    pub handlers: Vec<Arc<dyn FemtoHandlerTrait>>,
+}
+
 /// Wrapper allowing Python handler objects to be used by the logger.
 struct PyHandler {
     obj: Py<PyAny>,
@@ -61,7 +67,7 @@ pub struct FemtoLogger {
     formatter: Arc<dyn FemtoFormatter>,
     level: AtomicU8,
     handlers: Arc<RwLock<Vec<Arc<dyn FemtoHandlerTrait>>>>,
-    tx: Option<Sender<FemtoLogRecord>>,
+    tx: Option<Sender<QueuedRecord>>,
     shutdown_tx: Option<Sender<()>>,
     handle: Option<JoinHandle<()>>,
 }
@@ -88,7 +94,8 @@ impl FemtoLogger {
         let record = FemtoLogRecord::new(&self.name, &level.to_string(), message);
         let msg = self.formatter.format(&record);
         if let Some(tx) = &self.tx {
-            if tx.try_send(record).is_err() {
+            let handlers = self.handlers.read().clone();
+            if tx.try_send(QueuedRecord { record, handlers }).is_err() {
                 warn!("FemtoLogger: queue full or shutting down, dropping record");
             }
         }
@@ -156,7 +163,7 @@ impl FemtoLogger {
     /// Holding a clone alive after dropping the logger will prevent the worker
     /// thread from exiting.
     #[cfg(feature = "test-util")]
-    pub fn clone_sender_for_test(&self) -> Option<Sender<FemtoLogRecord>> {
+    pub fn clone_sender_for_test(&self) -> Option<Sender<QueuedRecord>> {
         self.tx.as_ref().cloned()
     }
 
@@ -166,11 +173,10 @@ impl FemtoLogger {
         let handlers: Arc<RwLock<Vec<Arc<dyn FemtoHandlerTrait>>>> =
             Arc::new(RwLock::new(Vec::new()));
 
-        let (tx, rx) = bounded::<FemtoLogRecord>(DEFAULT_CHANNEL_CAPACITY);
+        let (tx, rx) = bounded::<QueuedRecord>(DEFAULT_CHANNEL_CAPACITY);
         let (shutdown_tx, shutdown_rx) = bounded::<()>(1);
-        let thread_handlers = Arc::clone(&handlers);
         let handle = thread::spawn(move || {
-            Self::worker_thread_loop(rx, shutdown_rx, thread_handlers);
+            Self::worker_thread_loop(rx, shutdown_rx);
         });
 
         Self {
@@ -186,12 +192,9 @@ impl FemtoLogger {
     }
 
     /// Process a single `FemtoLogRecord` by dispatching it to all handlers.
-    fn handle_log_record(
-        handlers: &Arc<RwLock<Vec<Arc<dyn FemtoHandlerTrait>>>>,
-        record: FemtoLogRecord,
-    ) {
-        for h in handlers.read().iter() {
-            h.handle(record.clone());
+    fn handle_log_record(job: QueuedRecord) {
+        for h in job.handlers.iter() {
+            h.handle(job.record.clone());
         }
     }
 
@@ -205,12 +208,9 @@ impl FemtoLogger {
     ///
     /// * `rx` - Channel receiver holding pending log records.
     /// * `handlers` - Shared collection of handlers used to process records.
-    fn drain_remaining_records(
-        rx: &Receiver<FemtoLogRecord>,
-        handlers: &Arc<RwLock<Vec<Arc<dyn FemtoHandlerTrait>>>>,
-    ) {
-        while let Ok(record) = rx.try_recv() {
-            Self::handle_log_record(handlers, record);
+    fn drain_remaining_records(rx: &Receiver<QueuedRecord>) {
+        while let Ok(job) = rx.try_recv() {
+            Self::handle_log_record(job);
         }
     }
 
@@ -226,19 +226,15 @@ impl FemtoLogger {
     /// * `rx` - Channel receiver for new log records.
     /// * `shutdown_rx` - Channel receiver signaling shutdown.
     /// * `handlers` - Shared collection of handlers for processing records.
-    fn worker_thread_loop(
-        rx: Receiver<FemtoLogRecord>,
-        shutdown_rx: Receiver<()>,
-        handlers: Arc<RwLock<Vec<Arc<dyn FemtoHandlerTrait>>>>,
-    ) {
+    fn worker_thread_loop(rx: Receiver<QueuedRecord>, shutdown_rx: Receiver<()>) {
         loop {
             select! {
                 recv(rx) -> rec => match rec {
-                    Ok(record) => Self::handle_log_record(&handlers, record),
+                    Ok(job) => Self::handle_log_record(job),
                     Err(_) => break,
                 },
                 recv(shutdown_rx) -> _ => {
-                    Self::drain_remaining_records(&rx, &handlers);
+                    Self::drain_remaining_records(&rx);
                     break;
                 }
             }
@@ -302,13 +298,15 @@ mod tests {
     fn handle_log_record_dispatches() {
         let h1 = Arc::new(CollectingHandler::new());
         let h2 = Arc::new(CollectingHandler::new());
-        let handlers = Arc::new(RwLock::new(vec![
-            h1.clone() as Arc<dyn FemtoHandlerTrait>,
-            h2.clone(),
-        ]));
-        let record = FemtoLogRecord::new("core", "INFO", "msg");
+        let record = QueuedRecord {
+            record: FemtoLogRecord::new("core", "INFO", "msg"),
+            handlers: vec![
+                h1.clone() as Arc<dyn FemtoHandlerTrait>,
+                h2.clone() as Arc<dyn FemtoHandlerTrait>,
+            ],
+        };
 
-        FemtoLogger::handle_log_record(&handlers, record);
+        FemtoLogger::handle_log_record(record);
 
         let r1 = h1.collected();
         let r2 = h2.collected();
@@ -321,16 +319,17 @@ mod tests {
     #[test]
     fn drain_remaining_records_pulls_all() {
         let (tx, rx) = crossbeam_channel::bounded(4);
+        let h = Arc::new(CollectingHandler::new());
         for i in 0..3 {
-            tx.send(FemtoLogRecord::new("core", "INFO", &format!("{i}")))
-                .expect("Failed to send test record");
+            tx.send(QueuedRecord {
+                record: FemtoLogRecord::new("core", "INFO", &format!("{i}")),
+                handlers: vec![h.clone() as Arc<dyn FemtoHandlerTrait>],
+            })
+            .expect("Failed to send test record");
         }
         drop(tx);
 
-        let h = Arc::new(CollectingHandler::new());
-        let handlers = Arc::new(RwLock::new(vec![h.clone() as Arc<dyn FemtoHandlerTrait>]));
-
-        FemtoLogger::drain_remaining_records(&rx, &handlers);
+        FemtoLogger::drain_remaining_records(&rx);
 
         let msgs: Vec<String> = h.collected().into_iter().map(|r| r.message).collect();
         assert_eq!(msgs, vec!["0", "1", "2"]);
@@ -341,16 +340,21 @@ mod tests {
         let (tx, rx) = crossbeam_channel::bounded(4);
         let (shutdown_tx, shutdown_rx) = crossbeam_channel::bounded(1);
         let h = Arc::new(CollectingHandler::new());
-        let handlers = Arc::new(RwLock::new(vec![h.clone() as Arc<dyn FemtoHandlerTrait>]));
 
         let thread = std::thread::spawn(move || {
-            FemtoLogger::worker_thread_loop(rx, shutdown_rx, handlers);
+            FemtoLogger::worker_thread_loop(rx, shutdown_rx);
         });
 
-        tx.send(FemtoLogRecord::new("core", "INFO", "one"))
-            .expect("Failed to send first test record");
-        tx.send(FemtoLogRecord::new("core", "INFO", "two"))
-            .expect("Failed to send second test record");
+        tx.send(QueuedRecord {
+            record: FemtoLogRecord::new("core", "INFO", "one"),
+            handlers: vec![h.clone() as Arc<dyn FemtoHandlerTrait>],
+        })
+        .expect("Failed to send first test record");
+        tx.send(QueuedRecord {
+            record: FemtoLogRecord::new("core", "INFO", "two"),
+            handlers: vec![h.clone() as Arc<dyn FemtoHandlerTrait>],
+        })
+        .expect("Failed to send second test record");
         shutdown_tx
             .send(())
             .expect("Failed to send shutdown signal");

--- a/rust_extension/src/stream_handler.rs
+++ b/rust_extension/src/stream_handler.rs
@@ -19,6 +19,7 @@ use std::{
 use crossbeam_channel::{bounded, Receiver, Sender};
 use log::warn;
 use pyo3::prelude::*;
+use std::any::Any;
 
 use crate::handler::FemtoHandlerTrait;
 use crate::{
@@ -255,6 +256,10 @@ impl FemtoHandlerTrait for FemtoStreamHandler {
             }
             None => false,
         }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/rust_extension/tests/handler_tests.rs
+++ b/rust_extension/tests/handler_tests.rs
@@ -14,6 +14,10 @@ impl FemtoHandlerTrait for DummyHandler {
         *flag = true;
         true
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 #[test]

--- a/rust_extension/tests/heavy/loom_topologies.rs
+++ b/rust_extension/tests/heavy/loom_topologies.rs
@@ -52,7 +52,7 @@ fn loom_single_logger_multi_handlers() {
             LoomBuf(Arc::clone(&buf2)),
             DefaultFormatter,
         ));
-        let mut logger = FemtoLogger::new("core".to_string());
+        let logger = FemtoLogger::new("core".to_string());
         logger.add_handler(h1.clone() as Arc<dyn FemtoHandlerTrait>);
         logger.add_handler(h2.clone() as Arc<dyn FemtoHandlerTrait>);
         let logger = Arc::new(logger);
@@ -83,8 +83,8 @@ fn loom_shared_handler_multi_loggers() {
             LoomBuf(Arc::clone(&buffer)),
             DefaultFormatter,
         ));
-        let mut l1 = FemtoLogger::new("a".to_string());
-        let mut l2 = FemtoLogger::new("b".to_string());
+        let l1 = FemtoLogger::new("a".to_string());
+        let l2 = FemtoLogger::new("b".to_string());
         l1.add_handler(handler.clone() as Arc<dyn FemtoHandlerTrait>);
         l2.add_handler(handler.clone() as Arc<dyn FemtoHandlerTrait>);
         let l1 = Arc::new(l1);
@@ -125,10 +125,10 @@ fn loom_multiple_loggers_multiple_handlers() {
             LoomBuf(Arc::clone(&buf2)),
             DefaultFormatter,
         ));
-        let mut l1 = FemtoLogger::new("l1".to_string());
+        let l1 = FemtoLogger::new("l1".to_string());
         l1.add_handler(shared_handler.clone() as Arc<dyn FemtoHandlerTrait>);
         l1.add_handler(h1.clone() as Arc<dyn FemtoHandlerTrait>);
-        let mut l2 = FemtoLogger::new("l2".to_string());
+        let l2 = FemtoLogger::new("l2".to_string());
         l2.add_handler(shared_handler.clone() as Arc<dyn FemtoHandlerTrait>);
         l2.add_handler(h2.clone() as Arc<dyn FemtoHandlerTrait>);
         let l1 = Arc::new(l1);

--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -113,7 +113,7 @@ fn logger_routes_to_multiple_handlers() {
         SharedBuf(Arc::clone(&buf2)),
         DefaultFormatter,
     ));
-    let mut logger = FemtoLogger::new("core".to_string());
+    let logger = FemtoLogger::new("core".to_string());
     logger.add_handler(handler1.clone() as Arc<dyn FemtoHandlerTrait>);
     logger.add_handler(handler2.clone() as Arc<dyn FemtoHandlerTrait>);
     logger.log(FemtoLevel::Info, "hello");
@@ -131,8 +131,8 @@ fn shared_handler_across_loggers() {
         SharedBuf(Arc::clone(&buffer)),
         DefaultFormatter,
     ));
-    let mut l1 = FemtoLogger::new("a".to_string());
-    let mut l2 = FemtoLogger::new("b".to_string());
+    let l1 = FemtoLogger::new("a".to_string());
+    let l2 = FemtoLogger::new("b".to_string());
     l1.add_handler(handler.clone() as Arc<dyn FemtoHandlerTrait>);
     l2.add_handler(handler.clone() as Arc<dyn FemtoHandlerTrait>);
     l1.log(FemtoLevel::Info, "one");
@@ -171,7 +171,7 @@ fn logger_drains_records_on_drop() {
         SharedBuf(Arc::clone(&buffer)),
         DefaultFormatter,
     ));
-    let mut logger = FemtoLogger::new("core".to_string());
+    let logger = FemtoLogger::new("core".to_string());
     logger.add_handler(handler.clone() as Arc<dyn FemtoHandlerTrait>);
     logger.log(FemtoLevel::Info, "one");
     logger.log(FemtoLevel::Info, "two");

--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -215,6 +215,9 @@ fn handler_can_be_removed() {
     logger.add_handler(Arc::clone(&handler));
     logger.log(FemtoLevel::Info, "one");
     handler.flush();
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    let output = read_output(&buffer);
+    assert!(output.contains("one"));
     assert!(logger.remove_handler(&handler));
     logger.log(FemtoLevel::Info, "two");
     drop(logger);

--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -4,7 +4,6 @@ use _femtologging_rs::{
     DefaultFormatter, FemtoHandlerTrait, FemtoLevel, FemtoLogRecord, FemtoStreamHandler,
 };
 use rstest::{fixture, rstest};
-use std::io::{self, Write};
 use std::sync::{Arc as StdArc, Mutex as StdMutex};
 
 type Arc<T> = StdArc<T>;
@@ -103,7 +102,7 @@ fn level_parsing_and_filtering() {
 
 #[rstest]
 fn logger_routes_to_multiple_handlers(
-    #[from(dual_handler_setup)] (buf1, buf2, handler1, handler2, mut logger): (
+    #[from(dual_handler_setup)] (buf1, buf2, handler1, handler2, logger): (
         Arc<Mutex<Vec<u8>>>,
         Arc<Mutex<Vec<u8>>>,
         Arc<dyn FemtoHandlerTrait>,
@@ -160,7 +159,7 @@ fn adding_same_handler_multiple_times_duplicates_output() {
 
 #[rstest]
 fn handler_added_after_logging_only_sees_future_records(
-    #[from(dual_handler_setup)] (buf1, buf2, h1, h2, mut logger): (
+    #[from(dual_handler_setup)] (buf1, buf2, h1, h2, logger): (
         Arc<Mutex<Vec<u8>>>,
         Arc<Mutex<Vec<u8>>>,
         Arc<dyn FemtoHandlerTrait>,

--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -1,4 +1,5 @@
 use _femtologging_rs::FemtoLogger;
+use _femtologging_rs::QueuedRecord; // needed for clone_sender test
 use _femtologging_rs::{
     DefaultFormatter, FemtoHandlerTrait, FemtoLevel, FemtoLogRecord, FemtoStreamHandler,
 };
@@ -146,6 +147,48 @@ fn shared_handler_across_loggers() {
 }
 
 #[test]
+fn adding_same_handler_multiple_times_duplicates_output() {
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let handler: Arc<dyn FemtoHandlerTrait> = Arc::new(FemtoStreamHandler::new(
+        SharedBuf(Arc::clone(&buffer)),
+        DefaultFormatter,
+    ));
+    let logger = FemtoLogger::new("dup".to_string());
+    logger.add_handler(handler.clone());
+    logger.add_handler(handler.clone());
+    logger.log(FemtoLevel::Info, "hello");
+    drop(logger);
+    drop(handler);
+    assert_eq!(read_output(&buffer), "dup [INFO] hello\ndup [INFO] hello\n");
+}
+
+#[test]
+fn handler_added_after_logging_only_sees_future_records() {
+    let buf1 = Arc::new(Mutex::new(Vec::new()));
+    let buf2 = Arc::new(Mutex::new(Vec::new()));
+    let h1 = Arc::new(FemtoStreamHandler::new(
+        SharedBuf(Arc::clone(&buf1)),
+        DefaultFormatter,
+    ));
+    let h2 = Arc::new(FemtoStreamHandler::new(
+        SharedBuf(Arc::clone(&buf2)),
+        DefaultFormatter,
+    ));
+    let logger = FemtoLogger::new("core".to_string());
+    logger.add_handler(h1.clone() as Arc<dyn FemtoHandlerTrait>);
+    logger.log(FemtoLevel::Info, "before");
+    logger.add_handler(h2.clone() as Arc<dyn FemtoHandlerTrait>);
+    logger.log(FemtoLevel::Info, "after");
+    drop(logger);
+    drop(h1);
+    drop(h2);
+    assert_eq!(
+        read_output(&buf1),
+        "core [INFO] before\ncore [INFO] after\n"
+    );
+    assert_eq!(read_output(&buf2), "core [INFO] after\n");
+}
+#[test]
 fn handler_can_be_removed() {
     let buffer = Arc::new(Mutex::new(Vec::new()));
     let handler: Arc<dyn FemtoHandlerTrait> = Arc::new(FemtoStreamHandler::new(
@@ -173,7 +216,10 @@ fn drop_with_sender_clone_exits() {
     let thread_barrier = std::sync::Arc::clone(&barrier);
     let t = std::thread::spawn(move || {
         thread_barrier.wait();
-        let res = tx.send(FemtoLogRecord::new("clone", "INFO", "late"));
+        let res = tx.send(QueuedRecord {
+            record: FemtoLogRecord::new("clone", "INFO", "late"),
+            handlers: Vec::new(),
+        });
         assert!(
             res.is_err(),
             "Expected send to fail after logger is dropped"


### PR DESCRIPTION
## Summary
- allow `FemtoLogger::add_handler` to accept `&self`
- note thread-safe handler modification in documentation
- update tests for the new API

## Testing
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68763aa679fc83229c5f3f3e62666f79

## Summary by Sourcery

Enable runtime handler addition on shared loggers by switching FemtoLogger's handler storage to an RwLock and updating the API, docs, and tests to reflect the change

New Features:
- Allow dynamic addition of handlers on shared FemtoLogger instances

Enhancements:
- Change FemtoLogger to store handlers in an RwLock<Vec<Arc<dyn FemtoHandlerTrait>>>
- Update add_handler API to take &self in both Rust and Python bindings
- Revise documentation and README to note thread-safe handler modification

Tests:
- Adjust tests to use immutable logger instances when adding handlers