### PR TITLE
Refactor overflow policy config

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -1,9 +1,10 @@
 # Porting Formatters and Handlers to Rust
 
-This document outlines a safe and thread‑aware design for moving formatting and
-handler components from Python to Rust. It complements the
-[roadmap](./roadmap.md) and expands on the design ideas described in
-[`rust-multithreaded-logging-framework-for-python-design.md`](./rust-multithreaded-logging-framework-for-python-design.md).
+This document outlines a safe and thread‑aware design for moving formatting
+and handler components from Python to Rust. It complements the [roadmap](./
+roadmap.md) and expands on the design ideas described in [`rust-multithreaded-
+logging-framework-for-python-design.md`](./rust-multithreaded-logging-framework-
+for-python-design.md).
 
 ## Goals
 
@@ -69,8 +70,8 @@ so the caller never blocks. If the queue is full, the record is silently dropped
 and a warning is written to `stderr`. This favours throughput over completeness:
 records may be lost to keep the application responsive. Advanced use cases can
 specify an overflow policy when constructing a handler. The Python API exposes
-this via `OverflowPolicy` and `FemtoFileHandler.with_capacity_flush_policy`. The
-policy may also be extended to support options like back pressure, writing
+this via `OverflowPolicy` and `FemtoFileHandler.with_capacity_flush_policy`.
+The policy may also be extended to support options like back pressure, writing
 overflowed messages to a separate file, or emitting metrics for monitoring
 purposes:
 
@@ -83,15 +84,17 @@ Every handler provides a `flush()` method, so callers can force pending messages
 to be written before shutdown.
 
 ```python
-from femtologging import FemtoFileHandler, OverflowPolicy
+from femtologging import FemtoFileHandler, OverflowPolicy, PyHandlerConfig
 
 # Drop-in replacement that blocks instead of discarding.
 # Waiting ensures no log messages are lost if the queue becomes full.
-handler = FemtoFileHandler.with_capacity_flush_policy(
-    path="app.log",
+config = PyHandlerConfig(
     capacity=4096,
-    overflow_policy=OverflowPolicy.BLOCK,
+    flush_interval=1,
+    policy=OverflowPolicy.BLOCK.value,
+    timeout_ms=None,
 )
+handler = FemtoFileHandler.with_capacity_flush_policy("app.log", config)
 ```
 
 ### StreamHandler
@@ -99,15 +102,15 @@ handler = FemtoFileHandler.with_capacity_flush_policy(
 `FemtoStreamHandler` writes formatted records to `stdout` or `stderr`. The
 consumer thread receives `FemtoLogRecord` values, moves the writer and formatter
 into the worker thread, and writes directly without locking. This mirrors the
-design in
-[`concurrency-models-in-high-performance-logging.md`](./concurrency-models-in-high-performance-logging.md#1-the-picologging-concurrency-model-a-hybrid-approach).
-The default bounded queue size is 1024 records, but
+design in [`concurrency-models-in-high-performance-logging.md`](./concurrency-
+models-in-high-performance-logging.md#1-the-picologging-concurrency-model-
+a-hybrid-approach). The default bounded queue size is 1024 records, but
 `FemtoStreamHandler::with_capacity` lets callers configure a custom capacity
 when needed.
 
-Dropping a handler closes its channel and waits briefly for the worker thread to
-finish flushing. If the thread does not exit within the configured flush timeout
-(one second by default), a warning is printed, and the drop continues,
+Dropping a handler closes its channel and waits briefly for the worker thread
+to finish flushing. If the thread does not exit within the configured flush
+timeout (one second by default), a warning is printed, and the drop continues,
 preventing deadlocks during shutdown.
 
 #### Sequence Diagram
@@ -138,16 +141,16 @@ this by performing rotation logic inside their consumer threads.
 pending records and stop the background thread explicitly. Dropping the handler
 still performs this cleanup if the methods aren't invoked.
 
-By default, the file handler flushes the underlying file after every record to
-maximize durability. To reduce syscall overhead in high-volume scenarios,
+By default, the file handler flushes the underlying file after every record
+to maximize durability. To reduce syscall overhead in high-volume scenarios,
 `FemtoFileHandler.with_capacity_flush()` accepts a `flush_interval` parameter
 controlling how many records are written before the worker thread flushes.
 Passing `0` disables periodic flushing and flushes only when the handler shuts
 down.
 
 The worker thread begins processing records as soon as the handler is created.
-Production code therefore leaves the optional `start_barrier` field unset. Unit
-tests may use this barrier to synchronise multiple workers and avoid race
+Production code therefore leaves the optional `start_barrier` field unset.
+Unit tests may use this barrier to synchronise multiple workers and avoid race
 conditions. Should a future feature require coordinated startup (for example,
 rotating several files at once), the `WorkerConfig` creation logic will need to
 expose this.
@@ -158,8 +161,8 @@ flushing its writer, giving the caller a deterministic way to ensure all pending
 records are persisted. The wait is bounded by the handler's `flush_timeout_secs`
 setting (one second by default) to avoid indefinite blocking.
 
-All handlers spawn their consumer threads on creation and expose a
-`snd: Sender<FemtoLogRecord>` to the logger. The logger clones this sender when
+All handlers spawn their consumer threads on creation and expose a `snd:
+Sender<FemtoLogRecord>` to the logger. The logger clones this sender when
 created, ensuring log messages are dispatched without blocking. Dropping the
 sender signals the consumer to finish once the queue is drained.
 
@@ -179,12 +182,12 @@ sender signals the consumer to finish once the queue is drained.
 
 ## Testing
 
-Rust unit tests use the `rstest` crate, as shown in
-[`rust-testing-with-rstest-fixtures.md`](./rust-testing-with-rstest-fixtures.md).
-Handlers should expose minimal hooks (e.g. returning formatted strings in test
-mode) so tests can verify output without relying on external I/O. Integration
-tests will instantiate loggers and handlers together to ensure proper channel
-operation and thread termination.
+Rust unit tests use the `rstest` crate, as shown in [`rust-testing-with-
+rstest-fixtures.md`](./rust-testing-with-rstest-fixtures.md). Handlers should
+expose minimal hooks (e.g. returning formatted strings in test mode) so tests
+can verify output without relying on external I/O. Integration tests will
+instantiate loggers and handlers together to ensure proper channel operation and
+thread termination.
 
 ## Next Steps
 

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -99,12 +99,11 @@ handler = FemtoFileHandler.with_capacity_flush_policy("app.log", config)
 
 ### StreamHandler
 
-`FemtoStreamHandler` writes formatted records to `stdout` or `stderr`. The
-consumer thread receives `FemtoLogRecord` values, moves the writer and formatter
-into the worker thread, and writes directly without locking. This mirrors the
-design in [`concurrency-models-in-high-performance-logging.md`](./concurrency-
-models-in-high-performance-logging.md#1-the-picologging-concurrency-model-
-a-hybrid-approach). The default bounded queue size is 1024 records, but
+`FemtoStreamHandler` writes formatted records to `stdout` or `stderr`.
+The consumer thread receives `FemtoLogRecord` values, moves the writer
+and formatter into the worker thread, and writes directly without locking.
+This mirrors the design in [`concurrency-models-in-high-performance-
+logging.md`][cmhp-log]. The default bounded queue size is 1024 records, but
 `FemtoStreamHandler::with_capacity` lets callers configure a custom capacity
 when needed.
 
@@ -182,12 +181,11 @@ sender signals the consumer to finish once the queue is drained.
 
 ## Testing
 
-Rust unit tests use the `rstest` crate, as shown in [`rust-testing-with-
-rstest-fixtures.md`](./rust-testing-with-rstest-fixtures.md). Handlers should
-expose minimal hooks (e.g. returning formatted strings in test mode) so tests
-can verify output without relying on external I/O. Integration tests will
-instantiate loggers and handlers together to ensure proper channel operation and
-thread termination.
+Rust unit tests use the `rstest` crate, as shown in [`rust-testing-with-rstest-
+fixtures.md`][rstest-fixtures]. Handlers should expose minimal hooks (e.g.
+returning formatted strings in test mode) so tests can verify output without
+relying on external I/O. Integration tests will instantiate loggers and handlers
+together to ensure proper channel operation and thread termination.
 
 ## Next Steps
 
@@ -196,3 +194,6 @@ thread termination.
 3. Update the roadmap once these components have stable tests.
 4. Expand with rotating and network handlers as described in the roadmap's later
    phases.
+
+[cmhp-log]: ./concurrency-models-in-high-performance-logging.md#1-the-picologging-concurrency-model-a-hybrid-approach
+[rstest-fixtures]: ./rust-testing-with-rstest-fixtures.md

--- a/femtologging/__init__.py
+++ b/femtologging/__init__.py
@@ -15,6 +15,7 @@ reset_manager = rust.reset_manager_py  # type: ignore[attr-defined]
 FemtoHandler = rust.FemtoHandler  # type: ignore[attr-defined]
 FemtoStreamHandler = rust.FemtoStreamHandler  # type: ignore[attr-defined]
 FemtoFileHandler = rust.FemtoFileHandler  # type: ignore[attr-defined]
+PyHandlerConfig = rust.PyHandlerConfig  # type: ignore[attr-defined]
 
 __all__ = [
     "FemtoHandler",
@@ -23,6 +24,7 @@ __all__ = [
     "reset_manager",
     "FemtoStreamHandler",
     "FemtoFileHandler",
+    "PyHandlerConfig",
     "OverflowPolicy",
     "hello",
 ]

--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -9,7 +9,9 @@ mod logger;
 mod manager;
 mod stream_handler;
 
-pub use file_handler::{FemtoFileHandler, HandlerConfig, OverflowPolicy, TestConfig};
+pub use file_handler::{
+    FemtoFileHandler, HandlerConfig, OverflowPolicy, PyHandlerConfig, TestConfig,
+};
 pub use formatter::{DefaultFormatter, FemtoFormatter};
 pub use handler::{FemtoHandler, FemtoHandlerTrait};
 pub use level::FemtoLevel;
@@ -44,6 +46,7 @@ fn _femtologging_rs(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<FemtoHandler>()?;
     m.add_class::<FemtoStreamHandler>()?;
     m.add_class::<FemtoFileHandler>()?;
+    m.add_class::<PyHandlerConfig>()?;
     m.add_function(wrap_pyfunction!(hello, m)?)?;
     m.add_function(wrap_pyfunction!(get_logger, m)?)?;
     m.add_function(wrap_pyfunction!(reset_manager_py, m)?)?;


### PR DESCRIPTION
## Summary
- introduce `PyHandlerConfig` to group arguments for with_capacity_flush_policy
- expose config object in `__init__.py`
- update Python API docs and tests for new constructor signature

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68763b79ce04832289c547b453dfeb21

## Summary by Sourcery

Introduce a unified configuration object for file handler overflow policies and update the Python API, documentation, and tests to use the new constructor signature.

New Features:
- Add PyHandlerConfig class to encapsulate file handler settings in Python
- Expose PyHandlerConfig in the femtologging package and update with_capacity_flush_policy to accept it

Enhancements:
- Revise documentation examples and markdown formatting to reflect the new config-based API

Tests:
- Update file handler tests to instantiate and pass PyHandlerConfig instead of individual parameters