### PR TITLE
Refactor rate-limited warning logic into a separate module

### DIFF
--- a/rust_extension/Cargo.lock
+++ b/rust_extension/Cargo.lock
@@ -110,6 +110,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "pyo3",
+ "pyo3-build-config",
  "rstest",
  "tempfile",
 ]

--- a/rust_extension/Cargo.toml
+++ b/rust_extension/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 name = "_femtologging_rs"
 crate-type = ["cdylib", "rlib"]
 
+[build-dependencies]
+pyo3-build-config = "0.25.1"
+
 [dependencies]
 pyo3 = { version = ">=0.25.1,<0.26.0", default-features = false, features = ["macros", "auto-initialize"] }
 crossbeam-channel = "0.5.15"

--- a/rust_extension/build.rs
+++ b/rust_extension/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    pyo3_build_config::use_pyo3_cfgs();
+}

--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -7,6 +7,7 @@ mod level;
 mod log_record;
 mod logger;
 mod manager;
+pub mod rate_limiter;
 mod stream_handler;
 
 pub use file_handler::{FemtoFileHandler, HandlerConfig, OverflowPolicy, TestConfig};

--- a/rust_extension/src/rate_limiter.rs
+++ b/rust_extension/src/rate_limiter.rs
@@ -1,0 +1,67 @@
+//! Rate-limited warning mechanism for dropped records.
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use log::warn;
+
+const WARN_RATE_LIMIT_SECS: u64 = 5;
+
+/// Issues rate-limited warnings about dropped records.
+pub struct RateLimiter {
+    last_warn: AtomicU64,
+    dropped_records: Arc<Mutex<u64>>,
+    handler_name: String,
+}
+
+impl RateLimiter {
+    /// Create a new `RateLimiter` for the specified handler.
+    pub fn new(handler_name: &str) -> Self {
+        Self {
+            last_warn: AtomicU64::new(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs()
+                    .saturating_sub(WARN_RATE_LIMIT_SECS),
+            ),
+            dropped_records: Arc::new(Mutex::new(0)),
+            handler_name: handler_name.to_string(),
+        }
+    }
+
+    /// Increment the dropped record count and issue a warning if the rate
+    /// limit has expired.
+    pub fn record_dropped(&self) {
+        {
+            let mut dropped = self.dropped_records.lock().unwrap();
+            *dropped += 1;
+        }
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let prev = self.last_warn.load(Ordering::Relaxed);
+        if now.saturating_sub(prev) >= WARN_RATE_LIMIT_SECS {
+            self.report_dropped_records();
+            self.last_warn.store(now, Ordering::Relaxed);
+        }
+    }
+
+    /// Report the number of dropped records since the last interval.
+    pub fn report_dropped_records(&self) {
+        let mut dropped = self.dropped_records.lock().unwrap();
+        if *dropped > 0 {
+            warn!(
+                "{}: {} log records dropped in the last interval",
+                self.handler_name, *dropped
+            );
+            *dropped = 0;
+        }
+    }
+}

--- a/rust_extension/src/stream_handler.rs
+++ b/rust_extension/src/stream_handler.rs
@@ -8,12 +8,9 @@
 
 use std::{
     io::{self, Write},
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc, Mutex,
-    },
+    sync::Arc,
     thread::{self, JoinHandle},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::Duration,
 };
 
 use crossbeam_channel::{bounded, Receiver, Sender};
@@ -24,10 +21,10 @@ use crate::handler::FemtoHandlerTrait;
 use crate::{
     formatter::{DefaultFormatter, FemtoFormatter},
     log_record::FemtoLogRecord,
+    rate_limiter::RateLimiter,
 };
 
 const DEFAULT_CHANNEL_CAPACITY: usize = 1024;
-const WARN_RATE_LIMIT_SECS: u64 = 5;
 
 /// Handler that writes formatted log records to an `io::Write` stream.
 ///
@@ -47,10 +44,8 @@ pub struct FemtoStreamHandler {
     tx: Option<Sender<StreamCommand>>,
     handle: Option<JoinHandle<()>>,
     done_rx: Receiver<()>,
-    /// Timestamp (seconds since epoch) of the last dropped-record warning.
-    last_warn: AtomicU64,
-    /// Number of records dropped since the last warning.
-    dropped_records: Arc<Mutex<u64>>,
+    /// Rate limiter for dropped record warnings.
+    rate_limiter: Arc<RateLimiter>,
     /// Timeout for flush operations.
     flush_timeout: Duration,
 }
@@ -167,14 +162,7 @@ impl FemtoStreamHandler {
             tx: Some(tx),
             handle: Some(handle),
             done_rx,
-            last_warn: AtomicU64::new(
-                SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs()
-                    .saturating_sub(WARN_RATE_LIMIT_SECS),
-            ),
-            dropped_records: Arc::new(Mutex::new(0)),
+            rate_limiter: Arc::new(RateLimiter::new("FemtoStreamHandler")),
             flush_timeout,
         }
     }
@@ -182,18 +170,6 @@ impl FemtoStreamHandler {
     /// Flush any pending log records.
     pub fn flush(&self) -> bool {
         <Self as FemtoHandlerTrait>::flush(self)
-    }
-
-    /// Report the number of dropped records since the last interval.
-    fn report_dropped_records(&self) {
-        let mut dropped = self.dropped_records.lock().unwrap();
-        if *dropped > 0 {
-            warn!(
-                "FemtoStreamHandler: {} log records dropped in the last interval",
-                *dropped
-            );
-            *dropped = 0;
-        }
     }
 
     /// Close the handler and wait for the worker thread to exit.
@@ -221,29 +197,14 @@ impl FemtoHandlerTrait for FemtoStreamHandler {
             None => true,
         };
         if send_failed {
-            // increment dropped counter
-            {
-                let mut dropped = self.dropped_records.lock().unwrap();
-                *dropped += 1;
-            }
-
-            // check rate limit using atomic seconds
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_secs();
-            let prev = self.last_warn.load(Ordering::Relaxed);
-            if now.saturating_sub(prev) >= WARN_RATE_LIMIT_SECS {
-                self.report_dropped_records();
-                self.last_warn.store(now, Ordering::Relaxed);
-            }
+            self.rate_limiter.record_dropped();
         }
     }
 
     fn flush(&self) -> bool {
         match &self.tx {
             Some(tx) => {
-                self.report_dropped_records();
+                self.rate_limiter.report_dropped_records();
                 let (ack_tx, ack_rx) = bounded(1);
                 if tx
                     .send_timeout(StreamCommand::Flush(ack_tx), self.flush_timeout)


### PR DESCRIPTION
This commit extracts the rate-limiting logic for dropped records from `FemtoStreamHandler` into a new `RateLimiter` struct in its own module.

This closes #83 by reducing code duplication and improving maintainability.