### PR TITLE
Update docs for file handler module layout

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -136,6 +136,18 @@ sequenceDiagram
 variants (`FemtoRotatingFileHandler`, `FemtoTimedRotatingFileHandler`) build on
 this by performing rotation logic inside their consumer threads.
 
+The Rust implementation resides under `rust_extension/src/handlers/file`. This
+module is split into three pieces so each concern stays focused:
+
+1. `config.rs` – all configuration structures, including
+   `HandlerConfig`, `PyHandlerConfig` and `OverflowPolicy`.
+2. `worker.rs` – the background writer thread and its helper types.
+3. `mod.rs` – the public `FemtoFileHandler` API re‑exporting the config types.
+
+```rust
+use femtologging_rs::handlers::file::{FemtoFileHandler, HandlerConfig};
+```
+
 `FemtoFileHandler` exposes `flush()` and `close()` methods, so callers can drain
 pending records and stop the background thread explicitly. Dropping the handler
 still performs this cleanup if the methods aren't invoked.

--- a/docs/multithreading-in-pyo3.md
+++ b/docs/multithreading-in-pyo3.md
@@ -431,6 +431,6 @@ Developing multithreaded Python extensions in Rust with PyO3 is a powerful techn
 
   22. Appendix A: Migration Guide - PyO3 user guide, accessed on July 14, 2025, <https://pyo3.rs/v0.12.0/migration>
 
-  23. Error handling - PyO3 user guide, accessed on July 14, 2025, <https://pyo3.rs/main/function/error-handling.html> 
+  23. Error handling - PyO3 user guide, accessed on July 14, 2025, <https://pyo3.rs/main/function/error-handling.html>
 
   24. PyErr in pyo3::err - Rust, accessed on July 14, 2025, <https://pyo3.rs/internal/doc/pyo3/err/struct.pyerr>

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -11,6 +11,18 @@ handler implementations as well:
   thread. It now provides `flush()` and `close()` to deterministically manage
   that thread.
 
+The file handler lives under `rust_extension/src/handlers/file`. This directory
+splits responsibilities into three modules:
+
+1. `config.rs` – configuration types shared with the Python bindings.
+2. `worker.rs` – the asynchronous consumer thread that writes log records.
+3. `mod.rs` – the public API exposing `FemtoFileHandler` and re‑exporting the
+   configuration items.
+
+```rust
+use femtologging_rs::handlers::file::{FemtoFileHandler, HandlerConfig};
+```
+
 Packaging is handled by [maturin](https://maturin.rs/). Use version
 `>=1.9.1,<2.0.0` as declared in `pyproject.toml`. The `[tool.maturin]` section
 declares the extension module as `femtologging._femtologging_rs`, so running


### PR DESCRIPTION
## Summary
- document the handlers/file module structure
- explain separation of config, worker logic and public API
- fix trailing space in multithreading docs

## Testing
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_687a09d1764c83228666507d5e3f8b0c