### PR TITLE
Validate Python handler interface on add

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -1,10 +1,9 @@
 # Porting Formatters and Handlers to Rust
 
-This document outlines a safe and thread‑aware design for moving formatting
-and handler components from Python to Rust. It complements the [roadmap](./
-roadmap.md) and expands on the design ideas described in [`rust-multithreaded-
-logging-framework-for-python-design.md`](./rust-multithreaded-logging-framework-
-for-python-design.md).
+This document outlines a safe and thread‑aware design for moving formatting and
+handler components from Python to Rust. It complements the
+[roadmap](./roadmap.md) and expands on the design ideas described in [design
+doc].
 
 ## Goals
 
@@ -19,9 +18,10 @@ for-python-design.md).
 - Use `crossbeam-channel` as the initial MPSC queue, consistent with
   [`dependency-analysis.md`](./dependency-analysis.md).
 
-`FemtoLogRecord` bundles these fields into a `RecordMetadata` struct. The struct
-contains timestamp, source location, thread data and structured key‑value pairs.
-Formatters read this metadata to produce fully detailed messages.
+`FemtoLogRecord` bundles these fields into a `RecordMetadata` struct. The
+struct contains timestamp, source location, thread data and structured
+key‑value pairs. Formatters read this metadata to produce fully detailed
+messages.
 
 ## FemtoFormatter Trait
 
@@ -66,22 +66,22 @@ pub struct FemtoHandler;
 ```
 
 Implementations should forward the record to an internal queue with `try_send`
-so the caller never blocks. If the queue is full, the record is silently dropped
-and a warning is written to `stderr`. This favours throughput over completeness:
-records may be lost to keep the application responsive. Advanced use cases can
-specify an overflow policy when constructing a handler. The Python API exposes
-this via `OverflowPolicy` and `FemtoFileHandler.with_capacity_flush_policy`.
-The policy may also be extended to support options like back pressure, writing
-overflowed messages to a separate file, or emitting metrics for monitoring
-purposes:
+so the caller never blocks. If the queue is full, the record is silently
+dropped and a warning is written to `stderr`. This favours throughput over
+completeness: records may be lost to keep the application responsive. Advanced
+use cases can specify an overflow policy when constructing a handler. The
+Python API exposes this via `OverflowPolicy` and
+`FemtoFileHandler.with_capacity_flush_policy`. The policy may also be extended
+to support options like back pressure, writing overflowed messages to a
+separate file, or emitting metrics for monitoring purposes:
 
 - **Drop** – current default; records are discarded when the queue is full.
 - **Block** – the call blocks until space becomes available.
 - **Timeout** – wait for a fixed duration before giving up and dropping the
   record.
 
-Every handler provides a `flush()` method, so callers can force pending messages
-to be written before shutdown.
+Every handler provides a `flush()` method, so callers can force pending
+messages to be written before shutdown.
 
 ```python
 from femtologging import FemtoFileHandler, OverflowPolicy, PyHandlerConfig
@@ -99,13 +99,13 @@ handler = FemtoFileHandler.with_capacity_flush_policy("app.log", config)
 
 ### StreamHandler
 
-`FemtoStreamHandler` writes formatted records to `stdout` or `stderr`.
-The consumer thread receives `FemtoLogRecord` values, moves the writer
-and formatter into the worker thread, and writes directly without locking.
-This mirrors the design in [`concurrency-models-in-high-performance-
-logging.md`][cmhp-log]. The default bounded queue size is 1024 records, but
-`FemtoStreamHandler::with_capacity` lets callers configure a custom capacity
-when needed.
+`FemtoStreamHandler` writes formatted records to `stdout` or `stderr`. The
+consumer thread receives `FemtoLogRecord` values, moves the writer and
+formatter into the worker thread, and writes directly without locking. This
+mirrors the design in
+[`concurrency-models-in-high-performance- logging.md`][cmhp-log]. The default
+bounded queue size is 1024 records, but `FemtoStreamHandler::with_capacity`
+lets callers configure a custom capacity when needed.
 
 Dropping a handler closes its channel and waits briefly for the worker thread
 to finish flushing. If the thread does not exit within the configured flush
@@ -148,32 +148,33 @@ module is split into three pieces, so each concern stays focused:
 use femtologging_rs::handlers::file::{FemtoFileHandler, HandlerConfig};
 ```
 
-`FemtoFileHandler` exposes `flush()` and `close()` methods, so callers can drain
-pending records and stop the background thread explicitly. Dropping the handler
-still performs this cleanup if the methods aren't invoked.
+`FemtoFileHandler` exposes `flush()` and `close()` methods, so callers can
+drain pending records and stop the background thread explicitly. Dropping the
+handler still performs this cleanup if the methods aren't invoked.
 
-By default, the file handler flushes the underlying file after every record
-to maximize durability. To reduce syscall overhead in high-volume scenarios,
+By default, the file handler flushes the underlying file after every record to
+maximize durability. To reduce syscall overhead in high-volume scenarios,
 `FemtoFileHandler.with_capacity_flush()` accepts a `flush_interval` parameter
 controlling how many records are written before the worker thread flushes.
 Passing `0` disables periodic flushing and flushes only when the handler shuts
 down.
 
 The worker thread begins processing records as soon as the handler is created.
-Production code therefore leaves the optional `start_barrier` field unset.
-Unit tests may use this barrier to synchronise multiple workers and avoid race
+Production code therefore leaves the optional `start_barrier` field unset. Unit
+tests may use this barrier to synchronise multiple workers and avoid race
 conditions. Should a future feature require coordinated startup (for example,
 rotating several files at once), the `WorkerConfig` creation logic will need to
 expose this.
 
-Calling `flush()` sends a `Flush` command to the worker thread and then waits on
-a dedicated acknowledgment channel for confirmation. The worker responds after
-flushing its writer, giving the caller a deterministic way to ensure all pending
-records are persisted. The wait is bounded by the handler's `flush_timeout_secs`
-setting (one second by default) to avoid indefinite blocking.
+Calling `flush()` sends a `Flush` command to the worker thread and then waits
+on a dedicated acknowledgment channel for confirmation. The worker responds
+after flushing its writer, giving the caller a deterministic way to ensure all
+pending records are persisted. The wait is bounded by the handler's
+`flush_timeout_secs` setting (one second by default) to avoid indefinite
+blocking.
 
-All handlers spawn their consumer threads on creation and expose a `snd:
-Sender<FemtoLogRecord>` to the logger. The logger clones this sender when
+All handlers spawn their consumer threads on creation and expose a
+`snd: Sender<FemtoLogRecord>` to the logger. The logger clones this sender when
 created, ensuring log messages are dispatched without blocking. Dropping the
 sender signals the consumer to finish once the queue is drained.
 
@@ -186,18 +187,19 @@ sender signals the consumer to finish once the queue is drained.
   thread. Only the `Sender` is shared with producer threads, eliminating the
   need for additional locks.
 - The default bounded capacity of 1024 records from
-  [`dependency-analysis.md`](./dependency-analysis.md) prevents unbounded memory
-  usage if a consumer stalls.
+  [`dependency-analysis.md`](./dependency-analysis.md) prevents unbounded
+  memory usage if a consumer stalls.
 - No `unsafe` blocks are necessary; all concurrency primitives come from `std`
   or `crossbeam-channel`.
 
 ## Testing
 
-Rust unit tests use the `rstest` crate, as shown in [`rust-testing-with-rstest-
-fixtures.md`][rstest-fixtures]. Handlers should expose minimal hooks (e.g.
-returning formatted strings in test mode) so tests can verify output without
-relying on external I/O. Integration tests will instantiate loggers and handlers
-together to ensure proper channel operation and thread termination.
+Rust unit tests use the `rstest` crate, as shown in
+[`rust-testing-with-rstest- fixtures.md`][rstest-fixtures]. Handlers should
+expose minimal hooks (e.g. returning formatted strings in test mode) so tests
+can verify output without relying on external I/O. Integration tests will
+instantiate loggers and handlers together to ensure proper channel operation
+and thread termination.
 
 ## Next Steps
 
@@ -207,5 +209,6 @@ together to ensure proper channel operation and thread termination.
 4. Expand with rotating and network handlers as described in the roadmap's later
    phases.
 
-[cmhp-log]: ./concurrency-models-in-high-performance-logging.md#1-the-picologging-concurrency-model-a-hybrid-approach
-[rstest-fixtures]: ./rust-testing-with-rstest-fixtures.md
+[cmhp-log]:
+./concurrency-models-in-high-performance-logging.md#1-the-picologging-concurrency-model-a-hybrid-approach
+ [design doc]: ./rust-multithreaded-logging-framework-for-python-design.md

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -141,8 +141,8 @@ module is split into three pieces, so each concern stays focused:
 
 1. `config.rs` – all configuration structures, including
    `HandlerConfig`, `PyHandlerConfig` and `OverflowPolicy`.
-2. `worker.rs` – the background writer thread and its helper types.
-3. `mod.rs` – the public `FemtoFileHandler` API re‑exporting the config types.
+2. `worker.rs` — the background writer thread and its helper types.
+3. `mod.rs` — the public `FemtoFileHandler` API re‑exporting the config types.
 
 ```rust
 use femtologging_rs::handlers::file::{FemtoFileHandler, HandlerConfig};

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -15,9 +15,9 @@ The file handler lives under `rust_extension/src/handlers/file`. This directory
 splits responsibilities into three modules:
 
 1. `config.rs` – configuration types shared with the Python bindings.
-1. `worker.rs` – the asynchronous consumer thread that writes log records.
-1. `mod.rs` – the public API exposing `FemtoFileHandler` and re‑exporting the
-   configuration items.
+2. `worker.rs` — the asynchronous consumer thread that writes log records.
+3. `mod.rs` — the public API exposing `FemtoFileHandler` and re‑exporting the
+    configuration items.
 
 ```rust
 use femtologging_rs::handlers::file::{FemtoFileHandler, HandlerConfig};
@@ -28,7 +28,7 @@ Packaging is handled by [maturin](https://maturin.rs/). Use version
 declares the extension module as `femtologging._femtologging_rs`, so running
 `pip install .` automatically builds the Rust code. Windows users may need the
 MSVC build tools installed or may need to run maturin with
-`--compatibility windows`.
+`--compatibility windows` to build.
 
 `FemtoLogRecord` now groups its contextual fields into a `RecordMetadata`
 struct. Each record stores a timestamp, source file and line, module path and
@@ -57,13 +57,12 @@ logged after the addition completes. The `remove_handler()` method works
 through `&self` as well and detaches a handler so it no longer receives
 subsequent records.
 
-Handlers manage their own worker threads; the logger simply forwards each
-record to every handler. Callers may invoke a handler's `flush()` method to
-ensure queued messages are written before dropping it.
+Handlers manage worker threads; the logger simply forwards each record to every
+handler. Callers may invoke a handler's `flush()` method to ensure queued
+messages are written before dropping it.
 
 The `add_handler()` method is exposed through the Python bindings and can be
 called on a shared logger instance. It verifies the provided object defines a
-callable `handle(logger, level, message)` method and raises `TypeError` if
-the check fails. Built-in handlers like `FemtoStreamHandler` and
-`FemtoFileHandler` pass automatically; custom classes must implement a
-compatible `handle` method.
+callable `handle(logger, level, message)` method and raises `TypeError` if the
+check fails. Built-in handlers like `FemtoStreamHandler` and `FemtoFileHandler`
+pass automatically; custom classes must implement a compatible `handle` method.

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -1,9 +1,9 @@
 # Rust Extension
 
-This project includes a small Rust extension built with [PyO3](https://pyo3.rs/)
-(currently `>=0.25.1,<0.26.0`). Initially, it exposed only a trivial `hello()`
-function and the `FemtoLogger` class. It has since grown to provide the core
-handler implementations as well:
+This project includes a small Rust extension built with
+[PyO3](https://pyo3.rs/) (currently `>=0.25.1,<0.26.0`). Initially, it exposed
+only a trivial `hello()` function and the `FemtoLogger` class. It has since
+grown to provide the core handler implementations as well:
 
 - `FemtoStreamHandler` writes log records to `stdout` or `stderr` on a
   background thread.
@@ -15,8 +15,8 @@ The file handler lives under `rust_extension/src/handlers/file`. This directory
 splits responsibilities into three modules:
 
 1. `config.rs` – configuration types shared with the Python bindings.
-2. `worker.rs` – the asynchronous consumer thread that writes log records.
-3. `mod.rs` – the public API exposing `FemtoFileHandler` and re‑exporting the
+1. `worker.rs` – the asynchronous consumer thread that writes log records.
+1. `mod.rs` – the public API exposing `FemtoFileHandler` and re‑exporting the
    configuration items.
 
 ```rust
@@ -27,12 +27,12 @@ Packaging is handled by [maturin](https://maturin.rs/). Use version
 `>=1.9.1,<2.0.0` as declared in `pyproject.toml`. The `[tool.maturin]` section
 declares the extension module as `femtologging._femtologging_rs`, so running
 `pip install .` automatically builds the Rust code. Windows users may need the
-MSVC build tools installed or may need to run maturin with `--compatibility
-windows`.
+MSVC build tools installed or may need to run maturin with
+`--compatibility windows`.
 
 `FemtoLogRecord` now groups its contextual fields into a `RecordMetadata`
-struct. Each record stores a timestamp, source file and line, module path
-and thread ID. The thread name is included when available, along with any
+struct. Each record stores a timestamp, source file and line, module path and
+thread ID. The thread name is included when available, along with any
 structured key‑value pairs. Use `FemtoLogRecord::new` for default metadata or
 `FemtoLogRecord::with_metadata` to supply explicit values.
 
@@ -40,29 +40,30 @@ structured key‑value pairs. Use `FemtoLogRecord::new` for default metadata or
 `WARN`, `ERROR`, `CRITICAL`). Each `FemtoLogger` holds a current level and
 drops messages below that threshold. The `set_level()` method updates the
 logger's minimum level using a `FemtoLevel` value. Likewise, `log()` accepts a
-`FemtoLevel` and message, returning the formatted string or `None` when a record
-is filtered out.
+`FemtoLevel` and message, returning the formatted string or `None` when a
+record is filtered out.
 
-`FemtoLogger` can now dispatch a record to multiple handlers. Handlers implement
-`FemtoHandlerTrait` and run their I/O on worker threads. The logger keeps its
-handler list inside an `RwLock<Vec<Arc<dyn FemtoHandlerTrait>>>`, allowing
-handlers to be added through `&self`. Calling `add_handler()` pushes another
-reference into that list. When `log()` creates a `FemtoLogRecord`, it sends a
-clone to each configured handler, ensuring thread‑safe routing via the handlers'
-MPSC queues.
+`FemtoLogger` can now dispatch a record to multiple handlers. Handlers
+implement `FemtoHandlerTrait` and run their I/O on worker threads. The logger
+keeps its handler list inside an `RwLock<Vec<Arc<dyn FemtoHandlerTrait>>>`,
+allowing handlers to be added through `&self`. Calling `add_handler()` pushes
+another reference into that list. When `log()` creates a `FemtoLogRecord`, it
+sends a clone to each configured handler, ensuring thread‑safe routing via the
+handlers' MPSC queues.
 
 Handlers observe log records in the order they are attached. Adding a handler
 while other threads are logging is safe—new handlers only receive records
-logged after the addition completes. The `remove_handler()` method works through
-`&self` as well and detaches a handler so it no longer receives subsequent
-records.
+logged after the addition completes. The `remove_handler()` method works
+through `&self` as well and detaches a handler so it no longer receives
+subsequent records.
 
-Handlers manage their own worker threads; the logger simply forwards each record
-to every handler. Callers may invoke a handler's `flush()` method to ensure
-queued messages are written before dropping it.
+Handlers manage their own worker threads; the logger simply forwards each
+record to every handler. Callers may invoke a handler's `flush()` method to
+ensure queued messages are written before dropping it.
 
 The `add_handler()` method is exposed through the Python bindings and can be
-called on a shared logger instance. Any object with a `handle(logger, level,
-message)` method can be attached to a `FemtoLogger`. Built-in handlers like
-`FemtoStreamHandler` and `FemtoFileHandler` work out of the box. Custom Python
-classes require a compatible `handle` implementation.
+called on a shared logger instance. It verifies the provided object defines a
+callable `handle(logger, level, message)` method and raises `TypeError` if
+the check fails. Built-in handlers like `FemtoStreamHandler` and
+`FemtoFileHandler` pass automatically; custom classes must implement a
+compatible `handle` method.

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -27,7 +27,7 @@ Packaging is handled by [maturin](https://maturin.rs/). Use version
 `>=1.9.1,<2.0.0` as declared in `pyproject.toml`. The `[tool.maturin]` section
 declares the extension module as `femtologging._femtologging_rs`, so running
 `pip install .` automatically builds the Rust code. Windows users may need the
-MSVC build tools installed or may need to run maturin with
+MSVC build tools installed, or may need to run maturin with
 `--compatibility windows` to build.
 
 `FemtoLogRecord` now groups its contextual fields into a `RecordMetadata`

--- a/rust_extension/src/logger.rs
+++ b/rust_extension/src/logger.rs
@@ -117,31 +117,35 @@ impl FemtoLogger {
     pub fn py_add_handler(&self, handler: Py<PyAny>) -> PyResult<()> {
         Python::with_gil(|py| {
             let obj = handler.bind(py);
-            let attr = obj.getattr("handle").map_err(|err| {
-                if err.is_instance_of::<pyo3::exceptions::PyAttributeError>(py) {
-                    pyo3::exceptions::PyTypeError::new_err(
-                        "handler must implement a callable 'handle' method",
-                    )
-                } else {
-                    err
-                }
-            })?;
-
-            if !attr.is_callable() {
-                let attr_type = attr
-                    .get_type()
-                    .name()
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|_| "<unknown>".to_string());
-                let handler_repr = obj
-                    .repr()
-                    .map(|r| r.to_string())
-                    .unwrap_or_else(|_| "<unrepresentable>".to_string());
-                let msg = format!(
-                    "'handler.handle' is not callable (type: {attr_type}, handler: {handler_repr})"
-                );
-                return Err(pyo3::exceptions::PyTypeError::new_err(msg));
-            }
+            obj
+                .getattr("handle")
+                .map_err(|err| {
+                    if err.is_instance_of::<pyo3::exceptions::PyAttributeError>(py) {
+                        pyo3::exceptions::PyTypeError::new_err(
+                            "handler must implement a callable 'handle' method",
+                        )
+                    } else {
+                        err
+                    }
+                })
+                .and_then(|attr| {
+                    if attr.is_callable() {
+                        Ok(())
+                    } else {
+                        let attr_type = attr
+                            .get_type()
+                            .name()
+                            .map(|s| s.to_string())
+                            .unwrap_or_else(|_| "<unknown>".to_string());
+                        let handler_repr = obj
+                            .repr()
+                            .map(|r| r.to_string())
+                            .unwrap_or_else(|_| "<unrepresentable>".to_string());
+                        Err(pyo3::exceptions::PyTypeError::new_err(format!(
+                            "'handler.handle' is not callable (type: {attr_type}, handler: {handler_repr})"
+                        )))
+                    }
+                })?;
 
             self.add_handler(Arc::new(PyHandler { obj: handler }) as Arc<dyn FemtoHandlerTrait>);
             Ok(())

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -88,6 +88,22 @@ class CollectingHandler:
         self.records.append((logger, level, message))
 
 
+def test_add_handler_requires_handle() -> None:
+    logger = FemtoLogger("core")
+
+    class MissingHandle:
+        pass
+
+    with pytest.raises(TypeError):
+        logger.add_handler(MissingHandle())
+
+    class NotCallable:
+        handle = "oops"
+
+    with pytest.raises(TypeError):
+        logger.add_handler(NotCallable())
+
+
 @pytest.mark.skip
 def test_python_handler_invocation() -> None:
     """Python handlers should receive records via PyHandler."""

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -94,17 +94,16 @@ def test_add_handler_requires_handle() -> None:
     class MissingHandle:
         pass
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="callable 'handle' method"):
         logger.add_handler(MissingHandle())
 
     class NotCallable:
         handle = "oops"
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="not callable"):
         logger.add_handler(NotCallable())
 
 
-@pytest.mark.skip
 def test_python_handler_invocation() -> None:
     """Python handlers should receive records via PyHandler."""
     logger = FemtoLogger("core")


### PR DESCRIPTION
## Summary
- enforce that Python handlers implement a callable `handle` method
- describe validation rules in the extension docs
- test that invalid handlers raise `TypeError`

## Testing
- `cargo clippy --manifest-path rust_extension/Cargo.toml --no-default-features -- -D warnings`
- `ty check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e845b78ec83228ff837cb01cd7c56

## Summary by Sourcery

Validate Python handlers when adding them to FemtoLogger

Enhancements:
- Enforce that add_handler requires a callable handle method on Python handler objects

Documentation:
- Document handler interface validation rules in rust-extension.md

Tests:
- Add tests to verify TypeError is raised for handlers missing or having non-callable handle methods