### PR TITLE
Fix PyO3 init function

### DIFF
--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -41,13 +41,8 @@ fn reset_manager_py() {
     reset_manager();
 }
 
-#[expect(
-    deprecated,
-    reason = "module init signature uses Bound for PyO3 0.25; will be cleaned up in issue #92"
-)]
-#[allow(unfulfilled_lint_expectations)]
 #[pymodule]
-fn _femtologging_rs(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn _femtologging_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<FemtoLogger>()?;
     m.add_class::<FemtoHandler>()?;
     m.add_class::<FemtoStreamHandler>()?;


### PR DESCRIPTION
## Summary
- remove deprecated attribute from module init
- update module init to use new API

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687e8c747cb48322ad0b78d91a9166f8

## Summary by Sourcery

Fix PyO3 module initialization by removing deprecated attributes and updating the init signature to the new API

Bug Fixes:
- Remove deprecated attribute annotations from the pymodule init
- Simplify module init signature to accept only the module parameter per upgraded PyO3 API