### PR TITLE
Fix loom type usage in tests

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -1,10 +1,9 @@
 # Porting Formatters and Handlers to Rust
 
 This document outlines a safe and thread‑aware design for moving formatting
-and handler components from Python to Rust. It complements the [roadmap](./
-roadmap.md) and expands on the design ideas described in [`rust-multithreaded-
-logging-framework-for-python-design.md`](./rust-multithreaded-logging-framework-
-for-python-design.md).
+and handler components from Python to Rust. It complements the
+[roadmap](./roadmap.md) and expands on the design ideas described in
+[`rust-multithreaded-logging-framework-for-python-design.md`](./rust-multithreaded-logging-framework-for-python-design.md).
 
 ## Goals
 

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -1280,6 +1280,20 @@ logic to these generated tests.22 This allows `rstest` to focus on test
 structure and data provision, while `test-with` provides an orthogonal layer of
 control over test execution conditions.
 
+### C. Concurrency Testing with `loom`
+
+`femtologging` uses the [`loom`](https://crates.io/crates/loom) crate to
+systematically explore thread interleavings. When writing these tests, import
+`Arc` and `Mutex` directly from `loom::sync`:
+
+```rust
+use loom::sync::{Arc, Mutex};
+```
+
+Avoid aliasing these types or mixing them with the `std` variants. Doing so can
+defeat Loom's model checking. Helpers like `SharedBuf` should depend on these
+Loom primitives internally.
+
 ## XI. Conclusion and Further Resources
 
 `rstest` significantly enhances the testing experience in Rust by providing a

--- a/rust_extension/tests/heavy/loom_push.rs
+++ b/rust_extension/tests/heavy/loom_push.rs
@@ -5,7 +5,8 @@
 
 mod test_utils;
 use test_utils::shared_buffer::loom::read_output;
-use test_utils::shared_buffer::loom::{Arc as LoomArc, Mutex as LoomMutex, SharedBuf as LoomBuf};
+use test_utils::shared_buffer::loom::SharedBuf as LoomBuf;
+use loom::sync::{Arc, Mutex};
 use loom::thread;
 use std::io::{self, Write};
 

--- a/rust_extension/tests/heavy/loom_topologies.rs
+++ b/rust_extension/tests/heavy/loom_topologies.rs
@@ -5,7 +5,8 @@
 
 mod test_utils;
 use test_utils::shared_buffer::loom::read_output;
-use test_utils::shared_buffer::loom::{Arc as LoomArc, Mutex as LoomMutex, SharedBuf as LoomBuf};
+use test_utils::shared_buffer::loom::SharedBuf as LoomBuf;
+use loom::sync::{Arc, Mutex};
 use loom::thread;
 use std::io::Write;
 


### PR DESCRIPTION
## Summary
- use `loom::sync` types directly in `loom_push` and `loom_topologies` tests
- correct docs about porting formatters and about concurrency tests

## Testing
- `make fmt`
- `RUSTC_WRAPPER= make lint`
- `RUSTC_WRAPPER= make typecheck`
- `RUSTC_WRAPPER= make test`
- `make markdownlint`
- `make nixie`

------
https://chatgpt.com/codex/tasks/task_e_687eb75bb14083228c69e4dcf364cdf7