### PR TITLE
Fix loom sync types in heavy tests

### DIFF
--- a/rust_extension/tests/heavy/loom_push.rs
+++ b/rust_extension/tests/heavy/loom_push.rs
@@ -4,8 +4,8 @@
 //! there are no race conditions when multiple threads push records.
 
 mod test_utils;
-use test_utils::shared_buffer::loom::read_output;
-use test_utils::shared_buffer::loom::{Arc as LoomArc, Mutex as LoomMutex, SharedBuf as LoomBuf};
+use test_utils::shared_buffer::loom::{read_output, SharedBuf as LoomBuf};
+use loom::sync::{Arc, Mutex};
 use loom::thread;
 use std::io::{self, Write};
 

--- a/rust_extension/tests/heavy/loom_topologies.rs
+++ b/rust_extension/tests/heavy/loom_topologies.rs
@@ -4,8 +4,8 @@
 //! and ensure log records are routed correctly without duplication.
 
 mod test_utils;
-use test_utils::shared_buffer::loom::read_output;
-use test_utils::shared_buffer::loom::{Arc as LoomArc, Mutex as LoomMutex, SharedBuf as LoomBuf};
+use test_utils::shared_buffer::loom::{read_output, SharedBuf as LoomBuf};
+use loom::sync::{Arc, Mutex};
 use loom::thread;
 use std::io::Write;
 

--- a/rust_extension/tests/test_utils/shared_buffer.rs
+++ b/rust_extension/tests/test_utils/shared_buffer.rs
@@ -31,10 +31,8 @@ pub mod std {
 
 #[allow(dead_code)]
 pub mod loom {
+    use loom::sync::{Arc, Mutex};
     use std::io::{self, Write};
-
-    pub type Arc<T> = loom::sync::Arc<T>;
-    pub type Mutex<T> = loom::sync::Mutex<T>;
 
     #[derive(Clone)]
     pub struct SharedBuf(pub Arc<Mutex<Vec<u8>>>);


### PR DESCRIPTION
## Summary
- ensure loom-heavy tests use loom `Arc` and `Mutex`
- clean up unused type aliases in `shared_buffer`

## Testing
- `make fmt`
- `make lint` *(fails: unsuccessful tunnel to `s3.fr-par.scw.cloud`)*
- `make typecheck` *(fails: unsuccessful tunnel to `s3.fr-par.scw.cloud`)*
- `make test` *(fails: unsuccessful tunnel to `s3.fr-par.scw.cloud`)*

------
https://chatgpt.com/codex/tasks/task_e_687ea6dd7dc48322b009b51477465036

## Summary by Sourcery

Fix loom synchronization type imports in heavy tests and remove redundant type aliases

Enhancements:
- Import Arc and Mutex directly from loom::sync in shared_buffer instead of defining aliases

Tests:
- Update heavy loom tests to use loom’s Arc and Mutex through the revised shared_buffer imports