### PR TITLE
Fix Arc type alias in logger tests

### DIFF
--- a/rust_extension/src/handlers/file/worker.rs
+++ b/rust_extension/src/handlers/file/worker.rs
@@ -82,9 +82,7 @@ impl FlushTracker {
     }
 
     fn should_flush(&self) -> bool {
-        self.flush_interval != 0
-            && self.writes > 0
-            && self.writes.is_multiple_of(self.flush_interval)
+        self.flush_interval != 0 && self.writes > 0 && self.writes % self.flush_interval == 0
     }
 
     fn flush_if_due<W: Write>(&self, writer: &mut W) -> io::Result<()> {

--- a/rust_extension/src/handlers/file/worker.rs
+++ b/rust_extension/src/handlers/file/worker.rs
@@ -82,7 +82,9 @@ impl FlushTracker {
     }
 
     fn should_flush(&self) -> bool {
-        self.flush_interval != 0 && self.writes > 0 && self.writes % self.flush_interval == 0
+        self.flush_interval != 0
+            && self.writes > 0
+            && self.writes.is_multiple_of(self.flush_interval)
     }
 
     fn flush_if_due<W: Write>(&self, writer: &mut W) -> io::Result<()> {

--- a/rust_extension/tests/file_handler_tests.rs
+++ b/rust_extension/tests/file_handler_tests.rs
@@ -15,7 +15,8 @@ use _femtologging_rs::{
 use tempfile::NamedTempFile;
 
 mod test_utils;
-use test_utils::std::{SharedBuf, StdArc as Arc, StdMutex as Mutex};
+use std::sync::{Arc, Mutex};
+use test_utils::std::SharedBuf;
 
 /// Execute `f` with a `FemtoFileHandler` backed by a fresh temporary file
 /// and return whatever the handler wrote.

--- a/rust_extension/tests/heavy/prop_stream_handler.rs
+++ b/rust_extension/tests/heavy/prop_stream_handler.rs
@@ -10,8 +10,9 @@ use itertools::iproduct;
 use proptest::prelude::*;
 
 mod test_utils;
+use std::sync::{Arc, Mutex};
 use test_utils::shared_buffer::std::read_output;
-use test_utils::std::{SharedBuf, StdArc as Arc, StdMutex as Mutex};
+use test_utils::std::SharedBuf;
 
 proptest! {
     #[test]

--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -6,8 +6,9 @@ use _femtologging_rs::{
 use rstest::{fixture, rstest};
 
 mod test_utils;
+use std::sync::{Arc, Mutex};
 use test_utils::shared_buffer::std::read_output;
-use test_utils::std::{SharedBuf, StdArc as Arc, StdMutex as Mutex};
+use test_utils::std::SharedBuf;
 
 #[fixture]
 fn dual_handler_setup() -> (

--- a/rust_extension/tests/stream_handler_tests.rs
+++ b/rust_extension/tests/stream_handler_tests.rs
@@ -10,9 +10,10 @@ use rstest::*;
 use serial_test::serial;
 
 mod test_utils;
+use std::sync::{Arc, Mutex};
 use test_utils::fixtures::{handler_tuple, handler_tuple_custom};
 use test_utils::shared_buffer::std::read_output;
-use test_utils::std::{SharedBuf, StdArc as Arc, StdMutex as Mutex};
+use test_utils::std::SharedBuf;
 
 #[derive(Clone)]
 struct BlockingBuf {

--- a/rust_extension/tests/test_utils/fixtures.rs
+++ b/rust_extension/tests/test_utils/fixtures.rs
@@ -1,3 +1,7 @@
+//! Test fixtures that provide `(Arc<Mutex<Vec<u8>>>, FemtoStreamHandler)` pairs for
+//! integration and property tests. These helpers wrap a shared in-memory buffer
+//! so that handlers can be exercised without touching the filesystem.
+
 use super::shared_buffer::std::SharedBuf;
 use _femtologging_rs::{
     rate_limited_warner::RateLimitedWarner, DefaultFormatter, FemtoStreamHandler,
@@ -7,6 +11,7 @@ use rstest::fixture;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+/// Return a handler with a fresh in-memory buffer using the default configuration.
 #[fixture]
 pub fn handler_tuple() -> (Arc<Mutex<Vec<u8>>>, FemtoStreamHandler) {
     let buffer = Arc::new(Mutex::new(Vec::new()));

--- a/rust_extension/tests/test_utils/fixtures.rs
+++ b/rust_extension/tests/test_utils/fixtures.rs
@@ -1,6 +1,6 @@
-//! Test fixtures that provide `(SharedBuffer, FemtoStreamHandler)` pairs for
+//! Test fixtures that provide `(SharedBytes, FemtoStreamHandler)` pairs for
 //! integration and property tests. These helpers wrap a shared in-memory buffer
-//! so that handlers can be exercised without touching the filesystem.
+//! so that handlers can be exercised without touching the file system.
 
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -13,17 +13,18 @@ use rstest::fixture;
 
 use super::shared_buffer::std::SharedBuf;
 
-/// Convenience alias for the byte buffer shared between handlers.
-type SharedBuffer = Arc<Mutex<Vec<u8>>>;
+/// Shared in-memory byte buffer.
+type SharedBytes = Arc<Mutex<Vec<u8>>>;
 
-/// Return a new shared in-memory buffer wrapped in `SharedBuffer`.
-fn fresh_buffer() -> SharedBuffer {
+/// Return a new shared in-memory buffer wrapped in `SharedBytes`.
+#[must_use]
+fn fresh_buffer() -> SharedBytes {
     Arc::new(Mutex::new(Vec::new()))
 }
 
 /// Return a handler with a fresh in-memory buffer using the default configuration.
 #[fixture]
-pub fn handler_tuple() -> (SharedBuffer, FemtoStreamHandler) {
+pub fn handler_tuple() -> (SharedBytes, FemtoStreamHandler) {
     let buffer = fresh_buffer();
     let handler = FemtoStreamHandler::new(SharedBuf(Arc::clone(&buffer)), DefaultFormatter);
     (buffer, handler)
@@ -38,7 +39,7 @@ pub fn handler_tuple() -> (SharedBuffer, FemtoStreamHandler) {
 #[fixture]
 pub fn handler_tuple_custom(
     #[default(Duration::from_secs(5))] warn_interval: Duration,
-) -> (SharedBuffer, FemtoStreamHandler) {
+) -> (SharedBytes, FemtoStreamHandler) {
     let buffer = fresh_buffer();
     let handler = FemtoStreamHandler::with_test_config(
         SharedBuf(Arc::clone(&buffer)),

--- a/rust_extension/tests/test_utils/fixtures.rs
+++ b/rust_extension/tests/test_utils/fixtures.rs
@@ -5,13 +5,15 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use super::shared_buffer::std::SharedBuf;
 use _femtologging_rs::{
     rate_limited_warner::RateLimitedWarner, DefaultFormatter, FemtoStreamHandler,
     StreamHandlerConfig,
 };
 use rstest::fixture;
 
+use super::shared_buffer::std::SharedBuf;
+
+/// Return a new shared in-memory buffer wrapped in `Arc<Mutex<_>>`.
 fn fresh_buffer() -> Arc<Mutex<Vec<u8>>> {
     Arc::new(Mutex::new(Vec::new()))
 }

--- a/rust_extension/tests/test_utils/fixtures.rs
+++ b/rust_extension/tests/test_utils/fixtures.rs
@@ -2,31 +2,39 @@
 //! integration and property tests. These helpers wrap a shared in-memory buffer
 //! so that handlers can be exercised without touching the filesystem.
 
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
 use super::shared_buffer::std::SharedBuf;
 use _femtologging_rs::{
     rate_limited_warner::RateLimitedWarner, DefaultFormatter, FemtoStreamHandler,
     StreamHandlerConfig,
 };
 use rstest::fixture;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+
+fn fresh_buffer() -> Arc<Mutex<Vec<u8>>> {
+    Arc::new(Mutex::new(Vec::new()))
+}
 
 /// Return a handler with a fresh in-memory buffer using the default configuration.
 #[fixture]
 pub fn handler_tuple() -> (Arc<Mutex<Vec<u8>>>, FemtoStreamHandler) {
-    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let buffer = fresh_buffer();
     let handler = FemtoStreamHandler::new(SharedBuf(Arc::clone(&buffer)), DefaultFormatter);
     (buffer, handler)
 }
 
 /// Return a handler backed by a shared buffer with a small capacity and
-/// short timeout. The warn interval allows tests to tune rate-limited
-/// warnings.
+/// short timeout.
+///
+/// # Arguments
+/// * `warn_interval` – the minimum duration between successive rate-limited
+///   warnings emitted by the handler.
 #[fixture]
 pub fn handler_tuple_custom(
     #[default(Duration::from_secs(5))] warn_interval: Duration,
 ) -> (Arc<Mutex<Vec<u8>>>, FemtoStreamHandler) {
-    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let buffer = fresh_buffer();
     let handler = FemtoStreamHandler::with_test_config(
         SharedBuf(Arc::clone(&buffer)),
         DefaultFormatter,

--- a/rust_extension/tests/test_utils/fixtures.rs
+++ b/rust_extension/tests/test_utils/fixtures.rs
@@ -19,6 +19,9 @@ pub fn handler_tuple() -> (Arc<Mutex<Vec<u8>>>, FemtoStreamHandler) {
     (buffer, handler)
 }
 
+/// Return a handler backed by a shared buffer with a small capacity and
+/// short timeout. The warn interval allows tests to tune rate-limited
+/// warnings.
 #[fixture]
 pub fn handler_tuple_custom(
     #[default(Duration::from_secs(5))] warn_interval: Duration,

--- a/rust_extension/tests/test_utils/fixtures.rs
+++ b/rust_extension/tests/test_utils/fixtures.rs
@@ -1,4 +1,4 @@
-//! Test fixtures that provide `(Arc<Mutex<Vec<u8>>>, FemtoStreamHandler)` pairs for
+//! Test fixtures that provide `(SharedBuffer, FemtoStreamHandler)` pairs for
 //! integration and property tests. These helpers wrap a shared in-memory buffer
 //! so that handlers can be exercised without touching the filesystem.
 
@@ -13,14 +13,17 @@ use rstest::fixture;
 
 use super::shared_buffer::std::SharedBuf;
 
-/// Return a new shared in-memory buffer wrapped in `Arc<Mutex<_>>`.
-fn fresh_buffer() -> Arc<Mutex<Vec<u8>>> {
+/// Convenience alias for the byte buffer shared between handlers.
+type SharedBuffer = Arc<Mutex<Vec<u8>>>;
+
+/// Return a new shared in-memory buffer wrapped in `SharedBuffer`.
+fn fresh_buffer() -> SharedBuffer {
     Arc::new(Mutex::new(Vec::new()))
 }
 
 /// Return a handler with a fresh in-memory buffer using the default configuration.
 #[fixture]
-pub fn handler_tuple() -> (Arc<Mutex<Vec<u8>>>, FemtoStreamHandler) {
+pub fn handler_tuple() -> (SharedBuffer, FemtoStreamHandler) {
     let buffer = fresh_buffer();
     let handler = FemtoStreamHandler::new(SharedBuf(Arc::clone(&buffer)), DefaultFormatter);
     (buffer, handler)
@@ -35,7 +38,7 @@ pub fn handler_tuple() -> (Arc<Mutex<Vec<u8>>>, FemtoStreamHandler) {
 #[fixture]
 pub fn handler_tuple_custom(
     #[default(Duration::from_secs(5))] warn_interval: Duration,
-) -> (Arc<Mutex<Vec<u8>>>, FemtoStreamHandler) {
+) -> (SharedBuffer, FemtoStreamHandler) {
     let buffer = fresh_buffer();
     let handler = FemtoStreamHandler::with_test_config(
         SharedBuf(Arc::clone(&buffer)),

--- a/rust_extension/tests/test_utils/fixtures.rs
+++ b/rust_extension/tests/test_utils/fixtures.rs
@@ -1,25 +1,26 @@
-use super::shared_buffer::std::{Arc as StdArc, Mutex as StdMutex, SharedBuf};
+use super::shared_buffer::std::SharedBuf;
 use _femtologging_rs::{
     rate_limited_warner::RateLimitedWarner, DefaultFormatter, FemtoStreamHandler,
     StreamHandlerConfig,
 };
 use rstest::fixture;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 #[fixture]
-pub fn handler_tuple() -> (StdArc<StdMutex<Vec<u8>>>, FemtoStreamHandler) {
-    let buffer = StdArc::new(StdMutex::new(Vec::new()));
-    let handler = FemtoStreamHandler::new(SharedBuf(StdArc::clone(&buffer)), DefaultFormatter);
+pub fn handler_tuple() -> (Arc<Mutex<Vec<u8>>>, FemtoStreamHandler) {
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let handler = FemtoStreamHandler::new(SharedBuf(Arc::clone(&buffer)), DefaultFormatter);
     (buffer, handler)
 }
 
 #[fixture]
 pub fn handler_tuple_custom(
     #[default(Duration::from_secs(5))] warn_interval: Duration,
-) -> (StdArc<StdMutex<Vec<u8>>>, FemtoStreamHandler) {
-    let buffer = StdArc::new(StdMutex::new(Vec::new()));
+) -> (Arc<Mutex<Vec<u8>>>, FemtoStreamHandler) {
+    let buffer = Arc::new(Mutex::new(Vec::new()));
     let handler = FemtoStreamHandler::with_test_config(
-        SharedBuf(StdArc::clone(&buffer)),
+        SharedBuf(Arc::clone(&buffer)),
         DefaultFormatter,
         StreamHandlerConfig::default()
             .with_capacity(1)

--- a/rust_extension/tests/test_utils/mod.rs
+++ b/rust_extension/tests/test_utils/mod.rs
@@ -2,5 +2,5 @@ pub mod fixtures;
 pub mod shared_buffer;
 
 pub mod std {
-    pub use super::shared_buffer::std::{Arc as StdArc, Mutex as StdMutex, SharedBuf};
+    pub use super::shared_buffer::std::SharedBuf;
 }


### PR DESCRIPTION
## Summary
- use `std::sync` types in logger tests to match `shared_buffer`

Closes #99

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687fdc71f2a08322a21eeb813c1ebf32

## Summary by Sourcery

Fix incorrect type aliases in logger tests by using standard Arc and Mutex to match shared_buffer

Bug Fixes:
- Replace custom StdArc and StdMutex aliases in logger tests with std::sync Arc and Mutex for consistency

Tests:
- Update logger_tests.rs to import Arc and Mutex from std::sync instead of test_utils::std