### PR TITLE
Fix SharedBuf encapsulation

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-06-10"
+channel = "nightly-2025-07-22"
 components = ["rustfmt", "clippy"]

--- a/rust_extension/src/handlers/file/worker.rs
+++ b/rust_extension/src/handlers/file/worker.rs
@@ -82,7 +82,9 @@ impl FlushTracker {
     }
 
     fn should_flush(&self) -> bool {
-        self.flush_interval != 0 && self.writes > 0 && self.writes % self.flush_interval == 0
+        self.flush_interval != 0
+            && self.writes > 0
+            && self.writes.is_multiple_of(self.flush_interval)
     }
 
     fn flush_if_due<W: Write>(&self, writer: &mut W) -> io::Result<()> {

--- a/rust_extension/tests/file_handler_tests.rs
+++ b/rust_extension/tests/file_handler_tests.rs
@@ -81,7 +81,7 @@ fn multiple_records_are_serialised() {
 fn queue_overflow_drops_excess_records() {
     let buffer = Arc::new(Mutex::new(Vec::new()));
     let start = Arc::new(Barrier::new(2));
-    let mut cfg = TestConfig::new(SharedBuf(Arc::clone(&buffer)), DefaultFormatter);
+    let mut cfg = TestConfig::new(SharedBuf::new(Arc::clone(&buffer)), DefaultFormatter);
     cfg.capacity = 3;
     cfg.flush_interval = 1;
     cfg.overflow_policy = OverflowPolicy::Drop;
@@ -168,7 +168,7 @@ fn file_handler_flush_interval_one() {
 fn blocking_policy_waits_for_space() {
     let buffer = Arc::new(Mutex::new(Vec::new()));
     let start = Arc::new(Barrier::new(2));
-    let mut cfg = TestConfig::new(SharedBuf(Arc::clone(&buffer)), DefaultFormatter);
+    let mut cfg = TestConfig::new(SharedBuf::new(Arc::clone(&buffer)), DefaultFormatter);
     cfg.capacity = 1;
     cfg.flush_interval = 1;
     cfg.overflow_policy = OverflowPolicy::Block;
@@ -199,7 +199,7 @@ fn blocking_policy_waits_for_space() {
 fn timeout_policy_gives_up() {
     let buffer = Arc::new(Mutex::new(Vec::new()));
     let start = Arc::new(Barrier::new(2));
-    let mut cfg = TestConfig::new(SharedBuf(Arc::clone(&buffer)), DefaultFormatter);
+    let mut cfg = TestConfig::new(SharedBuf::new(Arc::clone(&buffer)), DefaultFormatter);
     cfg.capacity = 1;
     cfg.flush_interval = 1;
     cfg.overflow_policy = OverflowPolicy::Timeout(Duration::from_millis(50));

--- a/rust_extension/tests/heavy/loom_push.rs
+++ b/rust_extension/tests/heavy/loom_push.rs
@@ -18,7 +18,7 @@ fn loom_stream_push_delivery() {
     loom::model(|| {
         let buffer = Arc::new(Mutex::new(Vec::new()));
         let handler = Arc::new(FemtoStreamHandler::new(
-            LoomBuf(Arc::clone(&buffer)),
+            LoomBuf::new(Arc::clone(&buffer)),
             DefaultFormatter,
         ));
         let h = Arc::clone(&handler);

--- a/rust_extension/tests/heavy/loom_topologies.rs
+++ b/rust_extension/tests/heavy/loom_topologies.rs
@@ -22,11 +22,11 @@ fn loom_single_logger_multi_handlers() {
         let buf1 = Arc::new(Mutex::new(Vec::new()));
         let buf2 = Arc::new(Mutex::new(Vec::new()));
         let h1 = Arc::new(FemtoStreamHandler::new(
-            LoomBuf(Arc::clone(&buf1)),
+            LoomBuf::new(Arc::clone(&buf1)),
             DefaultFormatter,
         ));
         let h2 = Arc::new(FemtoStreamHandler::new(
-            LoomBuf(Arc::clone(&buf2)),
+            LoomBuf::new(Arc::clone(&buf2)),
             DefaultFormatter,
         ));
         let logger = FemtoLogger::new("core".to_string());
@@ -57,7 +57,7 @@ fn loom_shared_handler_multi_loggers() {
     loom::model(|| {
         let buffer = Arc::new(Mutex::new(Vec::new()));
         let handler = Arc::new(FemtoStreamHandler::new(
-            LoomBuf(Arc::clone(&buffer)),
+            LoomBuf::new(Arc::clone(&buffer)),
             DefaultFormatter,
         ));
         let l1 = FemtoLogger::new("a".to_string());
@@ -91,15 +91,15 @@ fn loom_multiple_loggers_multiple_handlers() {
         let buf1 = Arc::new(Mutex::new(Vec::new()));
         let buf2 = Arc::new(Mutex::new(Vec::new()));
         let shared_handler = Arc::new(FemtoStreamHandler::new(
-            LoomBuf(Arc::clone(&shared_buf)),
+            LoomBuf::new(Arc::clone(&shared_buf)),
             DefaultFormatter,
         ));
         let h1 = Arc::new(FemtoStreamHandler::new(
-            LoomBuf(Arc::clone(&buf1)),
+            LoomBuf::new(Arc::clone(&buf1)),
             DefaultFormatter,
         ));
         let h2 = Arc::new(FemtoStreamHandler::new(
-            LoomBuf(Arc::clone(&buf2)),
+            LoomBuf::new(Arc::clone(&buf2)),
             DefaultFormatter,
         ));
         let l1 = FemtoLogger::new("l1".to_string());
@@ -139,15 +139,15 @@ fn loom_concurrent_handler_addition() {
         let buf2 = Arc::new(Mutex::new(Vec::new()));
         let buf3 = Arc::new(Mutex::new(Vec::new()));
         let h1 = Arc::new(FemtoStreamHandler::new(
-            LoomBuf(Arc::clone(&buf1)),
+            LoomBuf::new(Arc::clone(&buf1)),
             DefaultFormatter,
         ));
         let h2 = Arc::new(FemtoStreamHandler::new(
-            LoomBuf(Arc::clone(&buf2)),
+            LoomBuf::new(Arc::clone(&buf2)),
             DefaultFormatter,
         ));
         let h3 = Arc::new(FemtoStreamHandler::new(
-            LoomBuf(Arc::clone(&buf3)),
+            LoomBuf::new(Arc::clone(&buf3)),
             DefaultFormatter,
         ));
         let logger = Arc::new(FemtoLogger::new("core".to_string()));

--- a/rust_extension/tests/heavy/prop_stream_handler.rs
+++ b/rust_extension/tests/heavy/prop_stream_handler.rs
@@ -28,7 +28,7 @@ proptest! {
         ], 1..3)
     ) {
         let buffer = Arc::new(Mutex::new(Vec::new()));
-        let handler = FemtoStreamHandler::new(SharedBuf(Arc::clone(&buffer)), DefaultFormatter);
+        let handler = FemtoStreamHandler::new(SharedBuf::new(Arc::clone(&buffer)), DefaultFormatter);
 
         let mut expected = String::new();
         for (logger, level, msg) in iproduct!(logger_names, log_levels, messages) {

--- a/rust_extension/tests/logger_tests.rs
+++ b/rust_extension/tests/logger_tests.rs
@@ -20,11 +20,11 @@ fn dual_handler_setup() -> (
     let buf1 = Arc::new(Mutex::new(Vec::new()));
     let buf2 = Arc::new(Mutex::new(Vec::new()));
     let handler1: Arc<dyn FemtoHandlerTrait> = Arc::new(FemtoStreamHandler::new(
-        SharedBuf(Arc::clone(&buf1)),
+        SharedBuf::new(Arc::clone(&buf1)),
         DefaultFormatter,
     ));
     let handler2: Arc<dyn FemtoHandlerTrait> = Arc::new(FemtoStreamHandler::new(
-        SharedBuf(Arc::clone(&buf2)),
+        SharedBuf::new(Arc::clone(&buf2)),
         DefaultFormatter,
     ));
     let logger = FemtoLogger::new("core".to_string());
@@ -121,7 +121,7 @@ fn logger_routes_to_multiple_handlers(
 fn shared_handler_across_loggers() {
     let buffer = Arc::new(Mutex::new(Vec::new()));
     let handler = Arc::new(FemtoStreamHandler::new(
-        SharedBuf(Arc::clone(&buffer)),
+        SharedBuf::new(Arc::clone(&buffer)),
         DefaultFormatter,
     ));
     let l1 = FemtoLogger::new("a".to_string());
@@ -142,7 +142,7 @@ fn shared_handler_across_loggers() {
 fn adding_same_handler_multiple_times_duplicates_output() {
     let buffer = Arc::new(Mutex::new(Vec::new()));
     let handler: Arc<dyn FemtoHandlerTrait> = Arc::new(FemtoStreamHandler::new(
-        SharedBuf(Arc::clone(&buffer)),
+        SharedBuf::new(Arc::clone(&buffer)),
         DefaultFormatter,
     ));
     let logger = FemtoLogger::new("dup".to_string());
@@ -181,7 +181,7 @@ fn handler_added_after_logging_only_sees_future_records(
 fn handler_can_be_removed() {
     let buffer = Arc::new(Mutex::new(Vec::new()));
     let handler: Arc<dyn FemtoHandlerTrait> = Arc::new(FemtoStreamHandler::new(
-        SharedBuf(Arc::clone(&buffer)),
+        SharedBuf::new(Arc::clone(&buffer)),
         DefaultFormatter,
     ));
     let logger = FemtoLogger::new("core".to_string());
@@ -226,7 +226,7 @@ fn drop_with_sender_clone_exits() {
 fn logger_drains_records_on_drop() {
     let buffer = Arc::new(Mutex::new(Vec::new()));
     let handler = Arc::new(FemtoStreamHandler::new(
-        SharedBuf(Arc::clone(&buffer)),
+        SharedBuf::new(Arc::clone(&buffer)),
         DefaultFormatter,
     ));
     let logger = FemtoLogger::new("core".to_string());
@@ -249,7 +249,7 @@ fn add_handler_is_thread_safe() {
     let new_handlers: Vec<_> = (0..4)
         .map(|_| {
             Arc::new(FemtoStreamHandler::new(
-                SharedBuf(Arc::clone(&buffer)),
+                SharedBuf::new(Arc::clone(&buffer)),
                 DefaultFormatter,
             )) as Arc<dyn FemtoHandlerTrait>
         })

--- a/rust_extension/tests/stream_handler_tests.rs
+++ b/rust_extension/tests/stream_handler_tests.rs
@@ -179,7 +179,7 @@ fn stream_handler_reports_dropped_records() {
     let logger = logtest::start();
     let buffer = Arc::new(Mutex::new(Vec::new()));
     let handler = FemtoStreamHandler::with_capacity_timeout(
-        SharedBuf(Arc::clone(&buffer)),
+        SharedBuf::new(Arc::clone(&buffer)),
         DefaultFormatter,
         1,
         Duration::from_millis(50),

--- a/rust_extension/tests/test_utils/fixtures.rs
+++ b/rust_extension/tests/test_utils/fixtures.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 #[fixture]
 pub fn handler_tuple() -> (StdArc<StdMutex<Vec<u8>>>, FemtoStreamHandler) {
     let buffer = StdArc::new(StdMutex::new(Vec::new()));
-    let handler = FemtoStreamHandler::new(SharedBuf(StdArc::clone(&buffer)), DefaultFormatter);
+    let handler = FemtoStreamHandler::new(SharedBuf::new(StdArc::clone(&buffer)), DefaultFormatter);
     (buffer, handler)
 }
 
@@ -19,7 +19,7 @@ pub fn handler_tuple_custom(
 ) -> (StdArc<StdMutex<Vec<u8>>>, FemtoStreamHandler) {
     let buffer = StdArc::new(StdMutex::new(Vec::new()));
     let handler = FemtoStreamHandler::with_test_config(
-        SharedBuf(StdArc::clone(&buffer)),
+        SharedBuf::new(StdArc::clone(&buffer)),
         DefaultFormatter,
         StreamHandlerConfig::default()
             .with_capacity(1)

--- a/rust_extension/tests/test_utils/shared_buffer.rs
+++ b/rust_extension/tests/test_utils/shared_buffer.rs
@@ -3,7 +3,7 @@
 //! Provides thread-safe buffer types and helpers for capturing log output in
 //! both standard and loom-based scenarios.
 //!
-//! Use [`SharedBuf::new`] to construct instances whilst keeping the internal
+//! Use [`SharedBuf::new`] to construct instances while keeping the internal
 //! `Arc<Mutex<Vec<u8>>>` hidden so callers must access it through a lock.
 
 macro_rules! shared_buf_mod {
@@ -46,6 +46,15 @@ macro_rules! shared_buf_mod {
             }
 
             /// Returns the current contents of the buffer as a UTF-8 string.
+            ///
+            /// # Arguments
+            ///
+            /// * `buffer` - Reference to the buffer to read from.
+            ///
+            /// # Panics
+            ///
+            /// Panics if the mutex is poisoned or if the buffer contains invalid
+            /// UTF-8.
             pub fn read_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
                 String::from_utf8(buffer.lock().expect("Buffer mutex poisoned").clone())
                     .expect("Buffer contains invalid UTF-8")

--- a/rust_extension/tests/test_utils/shared_buffer.rs
+++ b/rust_extension/tests/test_utils/shared_buffer.rs
@@ -8,7 +8,7 @@
 
 macro_rules! shared_buf_mod {
     ($name:ident, $arc:path, $mutex:path) => {
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         pub mod $name {
             use std::io::{self, Write};
 

--- a/rust_extension/tests/test_utils/shared_buffer.rs
+++ b/rust_extension/tests/test_utils/shared_buffer.rs
@@ -4,10 +4,11 @@
 //! both standard and loom-based scenarios.
 //!
 //! Use [`SharedBuf::new`] to construct instances while keeping the internal
-//! `Arc<Mutex<Vec<u8>>>` hidden so callers must access it through a lock.
+//! `Arc<Mutex<Vec<u8>>>` hidden, requiring callers to lock before access.
 
 macro_rules! shared_buf_mod {
     ($name:ident, $arc:path, $mutex:path) => {
+        #[allow(dead_code)]
         pub mod $name {
             use std::io::{self, Write};
 
@@ -47,13 +48,13 @@ macro_rules! shared_buf_mod {
 
             /// Returns the current contents of the buffer as a UTF-8 string.
             ///
-            /// # Arguments
-            ///
-            /// * `buffer` - Reference to the buffer to read from.
+            /// The `buffer` parameter is an `Arc`-wrapped `Mutex` guarding a
+            /// `Vec<u8>`. The mutex is locked before the bytes are cloned and
+            /// converted into UTF-8.
             ///
             /// # Panics
             ///
-            /// Panics if the mutex is poisoned or if the buffer contains invalid
+            /// Panics if locking the mutex fails or if the bytes are not valid
             /// UTF-8.
             pub fn read_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
                 String::from_utf8(buffer.lock().expect("Buffer mutex poisoned").clone())

--- a/rust_extension/tests/test_utils/shared_buffer.rs
+++ b/rust_extension/tests/test_utils/shared_buffer.rs
@@ -9,7 +9,6 @@
 macro_rules! shared_buf_mod {
     ($name:ident, $arc:path, $mutex:path) => {
         #[expect(dead_code)]
-        #[allow(unfulfilled_lint_expectations)]
         pub mod $name {
             use std::io::{self, Write};
 
@@ -27,7 +26,7 @@ macro_rules! shared_buf_mod {
             impl SharedBuf {
                 /// Creates a new `SharedBuf` wrapping the provided buffer.
                 ///
-                /// # Parameters
+                /// # Arguments
                 /// - `buffer`: An `Arc<Mutex<Vec<u8>>>` representing the shared
                 ///   byte buffer to wrap.
                 pub fn new(buffer: Arc<Mutex<Vec<u8>>>) -> Self {

--- a/rust_extension/tests/test_utils/shared_buffer.rs
+++ b/rust_extension/tests/test_utils/shared_buffer.rs
@@ -8,7 +8,6 @@
 
 macro_rules! shared_buf_mod {
     ($name:ident, $arc:path, $mutex:path) => {
-        #[expect(dead_code)]
         pub mod $name {
             use std::io::{self, Write};
 

--- a/rust_extension/tests/test_utils/shared_buffer.rs
+++ b/rust_extension/tests/test_utils/shared_buffer.rs
@@ -8,6 +8,7 @@
 
 macro_rules! shared_buf_mod {
     ($name:ident, $arc:path, $mutex:path) => {
+        #[expect(dead_code)]
         pub mod $name {
             use std::io::{self, Write};
 

--- a/rust_extension/tests/test_utils/shared_buffer.rs
+++ b/rust_extension/tests/test_utils/shared_buffer.rs
@@ -59,6 +59,10 @@ macro_rules! shared_buf_mod {
             ///
             /// Panics if locking the mutex fails or if the bytes are not valid
             /// UTF-8.
+            ///
+            /// This helper is widely used by tests such as
+            /// `stream_handler_tests` and `logger_tests` to verify buffered
+            /// output.
             #[cfg(test)]
             pub fn read_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
                 String::from_utf8(buffer.lock().expect("Buffer mutex poisoned").clone())

--- a/rust_extension/tests/test_utils/shared_buffer.rs
+++ b/rust_extension/tests/test_utils/shared_buffer.rs
@@ -8,6 +8,8 @@
 
 macro_rules! shared_buf_mod {
     ($name:ident, $arc:path, $mutex:path) => {
+        #[expect(dead_code)]
+        #[allow(unfulfilled_lint_expectations)]
         pub mod $name {
             use std::io::{self, Write};
 
@@ -24,6 +26,10 @@ macro_rules! shared_buf_mod {
 
             impl SharedBuf {
                 /// Creates a new `SharedBuf` wrapping the provided buffer.
+                ///
+                /// # Parameters
+                /// - `buffer`: An `Arc<Mutex<Vec<u8>>>` representing the shared
+                ///   byte buffer to wrap.
                 pub fn new(buffer: Arc<Mutex<Vec<u8>>>) -> Self {
                     Self { buffer }
                 }
@@ -55,6 +61,7 @@ macro_rules! shared_buf_mod {
             ///
             /// Panics if locking the mutex fails or if the bytes are not valid
             /// UTF-8.
+            #[cfg(test)]
             pub fn read_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
                 String::from_utf8(buffer.lock().expect("Buffer mutex poisoned").clone())
                     .expect("Buffer contains invalid UTF-8")

--- a/rust_extension/tests/test_utils/shared_buffer.rs
+++ b/rust_extension/tests/test_utils/shared_buffer.rs
@@ -1,107 +1,58 @@
 //! Shared buffer utilities for concurrency tests.
 //!
-//! Provides thread-safe buffer types and helpers for capturing
-//! log output in both standard and loom-based scenarios. Construct
-//! `SharedBuf` using [`SharedBuf::new`] to keep the underlying
-//! `Arc<Mutex<Vec<u8>>>` encapsulated.
+//! Provides thread-safe buffer types and helpers for capturing log output in
+//! both standard and loom-based scenarios.
+//!
+//! Use [`SharedBuf::new`] to construct instances whilst keeping the internal
+//! `Arc<Mutex<Vec<u8>>>` hidden so callers must access it through a lock.
 
-pub mod std {
-    use std::io::{self, Write};
+macro_rules! shared_buf_mod {
+    ($name:ident, $arc:path, $mutex:path) => {
+        pub mod $name {
+            use std::io::{self, Write};
 
-    pub type Arc<T> = std::sync::Arc<T>;
-    pub type Mutex<T> = std::sync::Mutex<T>;
+            pub use $arc as Arc;
+            pub use $mutex as Mutex;
 
-    /// Thread-safe buffer wrapper used in tests.
-    ///
-    /// The inner `Arc<Mutex<Vec<u8>>>` is private to prevent
-    /// direct mutation without locking. Use `new` to create and
-    /// `buffer` to access the underlying data.
-    /// Thread-safe buffer wrapper used in `loom` tests.
-    ///
-    /// Like the `std` variant, the inner buffer is private to
-    /// enforce locking discipline. Use `new` and `buffer()` to
-    /// create and access it.
-    #[derive(Clone)]
-    pub struct SharedBuf {
-        buffer: Arc<Mutex<Vec<u8>>>,
-    }
+            /// Thread-safe buffer wrapper used in tests.
+            ///
+            /// The inner `Arc<Mutex<Vec<u8>>>` is private to enforce locking.
+            #[derive(Clone)]
+            pub struct SharedBuf {
+                buffer: Arc<Mutex<Vec<u8>>>,
+            }
 
-    impl SharedBuf {
-        pub fn new(buffer: Arc<Mutex<Vec<u8>>>) -> Self {
-            Self { buffer }
+            impl SharedBuf {
+                /// Creates a new `SharedBuf` wrapping the provided buffer.
+                pub fn new(buffer: Arc<Mutex<Vec<u8>>>) -> Self {
+                    Self { buffer }
+                }
+            }
+
+            impl Write for SharedBuf {
+                fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                    self.buffer
+                        .lock()
+                        .expect("SharedBuf mutex poisoned")
+                        .write(buf)
+                }
+
+                fn flush(&mut self) -> io::Result<()> {
+                    self.buffer
+                        .lock()
+                        .expect("SharedBuf mutex poisoned")
+                        .flush()
+                }
+            }
+
+            /// Returns the current contents of the buffer as a UTF-8 string.
+            pub fn read_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
+                String::from_utf8(buffer.lock().expect("Buffer mutex poisoned").clone())
+                    .expect("Buffer contains invalid UTF-8")
+            }
         }
-
-        #[allow(dead_code)]
-        pub fn buffer(&self) -> &Arc<Mutex<Vec<u8>>> {
-            &self.buffer
-        }
-    }
-
-    impl Write for SharedBuf {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.buffer
-                .lock()
-                .expect("SharedBuf mutex poisoned")
-                .write(buf)
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            self.buffer
-                .lock()
-                .expect("SharedBuf mutex poisoned")
-                .flush()
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn read_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
-        String::from_utf8(buffer.lock().expect("Buffer mutex poisoned").clone())
-            .expect("Buffer contains invalid UTF-8")
-    }
+    };
 }
 
-#[allow(dead_code)]
-pub mod loom {
-    use std::io::{self, Write};
-
-    pub type Arc<T> = loom::sync::Arc<T>;
-    pub type Mutex<T> = loom::sync::Mutex<T>;
-
-    #[derive(Clone)]
-    pub struct SharedBuf {
-        buffer: Arc<Mutex<Vec<u8>>>,
-    }
-
-    impl SharedBuf {
-        pub fn new(buffer: Arc<Mutex<Vec<u8>>>) -> Self {
-            Self { buffer }
-        }
-
-        #[allow(dead_code)]
-        pub fn buffer(&self) -> &Arc<Mutex<Vec<u8>>> {
-            &self.buffer
-        }
-    }
-
-    impl Write for SharedBuf {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.buffer
-                .lock()
-                .expect("SharedBuf mutex poisoned")
-                .write(buf)
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            self.buffer
-                .lock()
-                .expect("SharedBuf mutex poisoned")
-                .flush()
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn read_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
-        String::from_utf8(buffer.lock().expect("Buffer mutex poisoned").clone())
-            .expect("Buffer contains invalid UTF-8")
-    }
-}
+shared_buf_mod!(std, std::sync::Arc, std::sync::Mutex);
+shared_buf_mod!(loom, loom::sync::Arc, loom::sync::Mutex);

--- a/rust_extension/tests/test_utils/shared_buffer.rs
+++ b/rust_extension/tests/test_utils/shared_buffer.rs
@@ -69,4 +69,6 @@ macro_rules! shared_buf_mod {
 }
 
 shared_buf_mod!(std, std::sync::Arc, std::sync::Mutex);
+
+#[cfg(test)]
 shared_buf_mod!(loom, loom::sync::Arc, loom::sync::Mutex);


### PR DESCRIPTION
## Summary
- hide internal buffer of `SharedBuf`
- add `SharedBuf::new` constructor and update test calls
- update docs for the new API

closes #100


------
https://chatgpt.com/codex/tasks/task_e_687fdd48e51c8322aa1a5943d1e22e9c

## Summary by Sourcery

Encapsulate the internal buffer of SharedBuf and LoomBuf by making it private and require instantiation via a new constructor, then update documentation and tests to use the new API

Enhancements:
- Make the underlying Arc<Mutex<Vec<u8>>> private in SharedBuf and LoomBuf and introduce a new `new` constructor with a `buffer()` accessor

Documentation:
- Revise documentation comments to guide users to construct SharedBuf via `SharedBuf::new` for proper encapsulation

Tests:
- Update all test modules to replace direct SharedBuf/LoomBuf tuple-style instantiation with the new constructor across std and loom variants