### PR TITLE
Simplify Python handler validation

### DIFF
--- a/rust_extension/src/handlers/file/worker.rs
+++ b/rust_extension/src/handlers/file/worker.rs
@@ -82,7 +82,9 @@ impl FlushTracker {
     }
 
     fn should_flush(&self) -> bool {
-        self.flush_interval != 0 && self.writes > 0 && self.writes % self.flush_interval == 0
+        self.flush_interval != 0
+            && self.writes > 0
+            && self.writes.is_multiple_of(self.flush_interval)
     }
 
     fn flush_if_due<W: Write>(&self, writer: &mut W) -> io::Result<()> {

--- a/rust_extension/src/logger.rs
+++ b/rust_extension/src/logger.rs
@@ -32,6 +32,35 @@ pub struct QueuedRecord {
     pub handlers: Vec<Arc<dyn FemtoHandlerTrait>>,
 }
 
+fn validate_handler(obj: &Bound<'_, PyAny>) -> PyResult<()> {
+    let py = obj.py();
+    let handle = obj.getattr("handle").map_err(|err| {
+        if err.is_instance_of::<pyo3::exceptions::PyAttributeError>(py) {
+            pyo3::exceptions::PyTypeError::new_err(
+                "handler must implement a callable 'handle' method",
+            )
+        } else {
+            err
+        }
+    })?;
+    if handle.is_callable() {
+        Ok(())
+    } else {
+        let attr_type = handle
+            .get_type()
+            .name()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|_| "<unknown>".to_string());
+        let handler_repr = obj
+            .repr()
+            .map(|r| r.to_string())
+            .unwrap_or_else(|_| "<unrepresentable>".to_string());
+        Err(pyo3::exceptions::PyTypeError::new_err(format!(
+            "'handler.handle' is not callable (type: {attr_type}, handler: {handler_repr})",
+        )))
+    }
+}
+
 /// Wrapper allowing Python handler objects to be used by the logger.
 struct PyHandler {
     obj: Py<PyAny>,
@@ -117,36 +146,7 @@ impl FemtoLogger {
     pub fn py_add_handler(&self, handler: Py<PyAny>) -> PyResult<()> {
         Python::with_gil(|py| {
             let obj = handler.bind(py);
-            obj
-                .getattr("handle")
-                .map_err(|err| {
-                    if err.is_instance_of::<pyo3::exceptions::PyAttributeError>(py) {
-                        pyo3::exceptions::PyTypeError::new_err(
-                            "handler must implement a callable 'handle' method",
-                        )
-                    } else {
-                        err
-                    }
-                })
-                .and_then(|attr| {
-                    if attr.is_callable() {
-                        Ok(())
-                    } else {
-                        let attr_type = attr
-                            .get_type()
-                            .name()
-                            .map(|s| s.to_string())
-                            .unwrap_or_else(|_| "<unknown>".to_string());
-                        let handler_repr = obj
-                            .repr()
-                            .map(|r| r.to_string())
-                            .unwrap_or_else(|_| "<unrepresentable>".to_string());
-                        Err(pyo3::exceptions::PyTypeError::new_err(format!(
-                            "'handler.handle' is not callable (type: {attr_type}, handler: {handler_repr})"
-                        )))
-                    }
-                })?;
-
+            validate_handler(obj)?;
             self.add_handler(Arc::new(PyHandler { obj: handler }) as Arc<dyn FemtoHandlerTrait>);
             Ok(())
         })


### PR DESCRIPTION
## Summary
- extract `validate_handler` to handle Python handler checks
- call the helper from `py_add_handler`
- fix clippy warning in file worker by using `is_multiple_of`

## Testing
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68812d3ab84c8322934b3ea5da675a3e

## Summary by Sourcery

Centralize Python handler validation into a helper function and apply it in py_add_handler, and replace modulo-based flush interval check with is_multiple_of in file worker

Enhancements:
- Extract validate_handler helper for Python handler validation and replace inline checks in py_add_handler
- Use is_multiple_of for flush interval check in file worker to address clippy warning