### PR TITLE
Add integration test for Python handlers

### DIFF
--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -112,3 +112,17 @@ def test_python_handler_invocation() -> None:
     logger.log("INFO", "ok")
     del logger
     assert collector.records == [("core", "INFO", "ok")]
+
+
+def test_python_handler_invocation_multiple_messages() -> None:
+    """Python handlers should receive every emitted record."""
+    logger = FemtoLogger("core")
+    collector = CollectingHandler()
+    logger.add_handler(collector)
+    logger.log("INFO", "first")
+    logger.log("ERROR", "second")
+    del logger
+    assert collector.records == [
+        ("core", "INFO", "first"),
+        ("core", "ERROR", "second"),
+    ]


### PR DESCRIPTION
## Summary
- test Python handler invocation with multiple messages

closes #86

## Testing
- `RUSTC_WRAPPER= make lint`
- `RUSTC_WRAPPER= make test`


------
https://chatgpt.com/codex/tasks/task_e_6886bdd460c483228037dd9cff0f1627

## Summary by Sourcery

Tests:
- Add integration test verifying Python handlers receive every emitted record when multiple messages are logged.