### PR TITLE
Document flush interval > 0

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -4,7 +4,7 @@ This document outlines a safe and thread‑aware design for moving formatting an
 handler components from Python to Rust. It complements the
 [roadmap](./roadmap.md) and expands on the design ideas described in
 [`rust-multithreaded-logging-framework-for-python-design.md`](./rust-multithreaded-logging-framework-for-python-design.md)
-.
+ .
 
 ## Goals
 
@@ -157,8 +157,8 @@ By default, the file handler flushes the underlying file after every record to
 maximize durability. To reduce syscall overhead in high-volume scenarios,
 `FemtoFileHandler.with_capacity_flush()` accepts a `flush_interval` parameter
 controlling how many records are written before the worker thread flushes. The
-value must be greater than zero, so periodic flushing always occurs. Use higher
-values to reduce syscall overhead in high-volume scenarios.
+value must be greater than zero, so periodic flushing always occurs. Higher
+values reduce syscall overhead in high-volume scenarios.
 
 The worker thread begins processing records as soon as the handler is created.
 Production code therefore leaves the optional `start_barrier` field unset. Unit

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -1,9 +1,10 @@
 # Porting Formatters and Handlers to Rust
 
-This document outlines a safe and thread‑aware design for moving formatting
-and handler components from Python to Rust. It complements the
+This document outlines a safe and thread‑aware design for moving formatting and
+handler components from Python to Rust. It complements the
 [roadmap](./roadmap.md) and expands on the design ideas described in
-[`rust-multithreaded-logging-framework-for-python-design.md`](./rust-multithreaded-logging-framework-for-python-design.md).
+[`rust-multithreaded-logging-framework-for-python-design.md`](./rust-multithreaded-logging-framework-for-python-design.md)
+.
 
 ## Goals
 
@@ -155,9 +156,9 @@ handler still performs this cleanup if the methods aren't invoked.
 By default, the file handler flushes the underlying file after every record to
 maximize durability. To reduce syscall overhead in high-volume scenarios,
 `FemtoFileHandler.with_capacity_flush()` accepts a `flush_interval` parameter
-controlling how many records are written before the worker thread flushes.
-Passing `0` disables periodic flushing and flushes only when the handler shuts
-down.
+controlling how many records are written before the worker thread flushes. The
+value must be greater than zero, so periodic flushing always occurs. Use higher
+values to reduce syscall overhead in high-volume scenarios.
 
 The worker thread begins processing records as soon as the handler is created.
 Production code therefore leaves the optional `start_barrier` field unset. Unit
@@ -211,4 +212,3 @@ and thread termination.
 
 [cmhp-log]:
 ./concurrency-models-in-high-performance-logging.md#1-the-picologging-concurrency-model-a-hybrid-approach
- [design doc]: ./rust-multithreaded-logging-framework-for-python-design.md

--- a/rust_extension/src/handlers/file/worker.rs
+++ b/rust_extension/src/handlers/file/worker.rs
@@ -81,6 +81,10 @@ impl FlushTracker {
         self.writes = 0;
     }
 
+    /// Determines whether a flush should occur.
+    ///
+    /// A flush is due when the interval is positive, at least one write has
+    /// occurred, and the write count is a multiple of the interval.
     fn should_flush(&self) -> bool {
         self.flush_interval != 0
             && self.writes > 0


### PR DESCRIPTION
## Summary
- note that `flush_interval` must be greater than zero
- include a doc comment explaining when a flush occurs

Closes #109

## Testing
- `make check-fmt`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 make lint`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 make test`


------
https://chatgpt.com/codex/tasks/task_e_6886befcea588322b46d200c8f305623

## Summary by Sourcery

Clarify the requirements and behavior of the flush_interval setting by updating documentation and adding explanatory comments.

Enhancements:
- Document that flush_interval must be greater than zero to ensure periodic flushing in FileHandlerBuilder
- Add a doc comment to the should_flush method to explain when flush operations occur
- Reflow and renumber markdown documentation for consistency and readability