### PR TITLE
Fix markdown line break in docs

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -2,9 +2,9 @@
 
 This document outlines a safe and thread‑aware design for moving formatting and
 handler components from Python to Rust. It complements the
-[roadmap](./roadmap.md) and expands on the design ideas described in
-[`rust-multithreaded-logging-framework-for-python-design.md`](./rust-multithreaded-logging-framework-for-python-design.md)
- .
+[roadmap](./roadmap.md) and expands on the design ideas described in <!--
+markdownlint-disable-next-line MD013 -->
+[`rust-multithreaded-logging-framework-for-python-design.md`](./rust-multithreaded-logging-framework-for-python-design.md).
 
 ## Goals
 


### PR DESCRIPTION
## Summary
- put the full-stop on the same line as the link in the Rust port guide
- add an inline MD013 disable to keep the link line length

## Testing
- `make fmt`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 make lint`
- `make markdownlint`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 make test`

------
https://chatgpt.com/codex/tasks/task_e_68880881e33083228e54324adf54a18a