### PR TITLE
Refactor PyHandlerConfig validation

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -2,9 +2,10 @@
 
 This document outlines a safe and thread‑aware design for moving formatting and
 handler components from Python to Rust. It complements the
-[roadmap](./roadmap.md) and expands on the design ideas described in
-<!-- markdownlint-disable-next-line MD013 -->
-[`rust-multithreaded-logging-framework-for-python-design.md`](./rust-multithreaded-logging-framework-for-python-design.md).
+[roadmap](./roadmap.md) and expands on the design ideas described in <!--
+markdownlint-disable-next-line MD013 -->
+[`rust-multithreaded-logging-framework-for-python-design.md`](./rust-multithreaded-logging-framework-for-python-design.md)
+.
 
 ## Goals
 
@@ -97,6 +98,12 @@ config = PyHandlerConfig(
 )
 handler = FemtoFileHandler.with_capacity_flush_policy("app.log", config)
 ```
+
+`PyHandlerConfig` enforces several invariants:
+
+- ``capacity`` and ``flush_interval`` must be greater than zero.
+- ``policy`` must be ``"drop"``, ``"block"`` or ``"timeout"``.
+- ``timeout_ms`` may only be set when ``policy`` is ``"timeout"``.
 
 ### StreamHandler
 

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -257,3 +257,22 @@ def test_py_handler_config_mutation(tmp_path: Path) -> None:
     handler.handle("core", "INFO", "third")  # dropped due to capacity 2
     handler.close()
     assert path.read_text() == "core [INFO] first\ncore [INFO] second\n"
+
+
+def test_py_handler_config_invalid_capacity() -> None:
+    """Capacity must be greater than zero."""
+    with pytest.raises(ValueError):
+        PyHandlerConfig(0, 1, OverflowPolicy.DROP.value, None)
+
+
+def test_py_handler_config_invalid_flush_interval() -> None:
+    """Flush interval must be greater than zero."""
+    with pytest.raises(ValueError):
+        PyHandlerConfig(1, 0, OverflowPolicy.DROP.value, None)
+
+
+def test_py_handler_config_set_policy_invalid() -> None:
+    """Setting an invalid policy raises ``ValueError``."""
+    cfg = PyHandlerConfig(1, 1, OverflowPolicy.DROP.value, None)
+    with pytest.raises(ValueError):
+        cfg.policy = "bogus"


### PR DESCRIPTION
## Summary
- extract repeated configuration checks into a `validate_config` helper
- use the helper from `new` and `set_policy`
- document validation behaviour in the file handler guide
- test validation of `PyHandlerConfig` values

closes #110


------
https://chatgpt.com/codex/tasks/task_e_6888f4137bac8322a13019ed3f58c612

## Summary by Sourcery

Centralize and enforce consistent validation for PyHandlerConfig parameters

Enhancements:
- Extract repeated capacity, flush interval, policy, and timeout_ms checks into a shared validate_config helper
- Update the constructor and set_policy setter to use validate_config

Documentation:
- Document capacity, flush interval, overflow policy, and timeout_ms invariants in the file handler guide

Tests:
- Add tests for invalid capacity, flush interval, and overflow policy settings