### PR TITLE
Refactor overflow policy validation

### DIFF
--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -261,8 +261,9 @@ def test_py_handler_config_mutation(tmp_path: Path) -> None:
 
 def test_py_handler_config_invalid_capacity() -> None:
     """Capacity must be greater than zero."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc_info:
         PyHandlerConfig(0, 1, OverflowPolicy.DROP.value, None)
+    assert "capacity must be greater than zero" in str(exc_info.value)
 
 
 def test_py_handler_config_invalid_flush_interval() -> None:

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -268,8 +268,25 @@ def test_py_handler_config_invalid_capacity() -> None:
 
 def test_py_handler_config_invalid_flush_interval() -> None:
     """Flush interval must be greater than zero."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc_info:
         PyHandlerConfig(1, 0, OverflowPolicy.DROP.value, None)
+    assert "flush_interval must be greater than zero" in str(exc_info.value)
+
+
+def test_py_handler_config_set_capacity_invalid() -> None:
+    """Setting capacity to zero raises ``ValueError``."""
+    cfg = PyHandlerConfig(1, 1, OverflowPolicy.DROP.value, None)
+    with pytest.raises(ValueError) as exc_info:
+        cfg.capacity = 0
+    assert "capacity must be greater than zero" in str(exc_info.value)
+
+
+def test_py_handler_config_set_flush_interval_invalid() -> None:
+    """Setting flush_interval to zero raises ``ValueError``."""
+    cfg = PyHandlerConfig(1, 1, OverflowPolicy.DROP.value, None)
+    with pytest.raises(ValueError) as exc_info:
+        cfg.flush_interval = 0
+    assert "flush_interval must be greater than zero" in str(exc_info.value)
 
 
 def test_py_handler_config_set_policy_invalid() -> None:


### PR DESCRIPTION
## Summary
- normalize the policy string in `PyHandlerConfig`
- validate capacity and flush interval directly in the constructor
- expose a helper `validate_policy` for policy and timeout checks
- assert the error message when capacity is invalid

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688970800dd483229bb2a8622ffc753c

## Summary by Sourcery

Refactor overflow policy validation in PyHandlerConfig by moving capacity and flush interval checks into the constructor, replacing the old validate_config with a new static validate_policy helper for policy and timeout validation, and strengthen tests by asserting error messages.

New Features:
- Add a static validate_policy method to normalize and validate overflow policy and timeout settings.

Enhancements:
- Inline capacity and flush interval validations directly in the PyHandlerConfig constructor and remove the deprecated validate_config method.
- Consistently lowercase policy strings for normalization during validation.

Tests:
- Assert specific error message for invalid capacity in the PyHandlerConfig tests.