### PR TITLE
Add file handler edge case tests

### DIFF
--- a/rust_extension/src/handlers/file/tests.rs
+++ b/rust_extension/src/handlers/file/tests.rs
@@ -4,7 +4,34 @@
 //! well as basic flushing behaviour.
 
 use super::*;
-use std::io::Write;
+use serial_test::serial;
+use std::io::{self, Write};
+use std::sync::{Arc, Barrier, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Default)]
+struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+impl SharedBuf {
+    fn new(buf: Arc<Mutex<Vec<u8>>>) -> Self {
+        Self(buf)
+    }
+
+    fn contents(buf: &Arc<Mutex<Vec<u8>>>) -> String {
+        String::from_utf8(buf.lock().expect("lock").clone()).expect("invalid UTF-8")
+    }
+}
+
+impl Write for SharedBuf {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().expect("lock").write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.lock().expect("lock").flush()
+    }
+}
 
 #[test]
 fn worker_config_from_handlerconfig_copies_values() {
@@ -21,27 +48,8 @@ fn worker_config_from_handlerconfig_copies_values() {
 
 #[test]
 fn build_from_worker_wires_handler_components() {
-    #[derive(Clone)]
-    struct Buf(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
-
-    impl Write for Buf {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            self.0
-                .lock()
-                .expect("failed to acquire buffer lock for write")
-                .write(buf)
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            self.0
-                .lock()
-                .expect("failed to acquire buffer lock for flush")
-                .flush()
-        }
-    }
-
-    let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-    let writer = Buf(std::sync::Arc::clone(&buffer));
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let writer = SharedBuf::new(Arc::clone(&buffer));
     let worker_cfg = WorkerConfig {
         capacity: 1,
         flush_interval: 1,
@@ -78,4 +86,96 @@ fn build_from_worker_wires_handler_components() {
     )
     .expect("buffer contained invalid UTF-8");
     assert_eq!(output, "core [INFO] test\n");
+}
+
+#[test]
+fn femto_file_handler_invalid_file_path() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("missing").join("out.log");
+    assert!(FemtoFileHandler::new(&path).is_err());
+}
+
+#[test]
+#[serial]
+fn femto_file_handler_queue_overflow_drop_policy() {
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let mut cfg = TestConfig::new(SharedBuf::new(Arc::clone(&buffer)), DefaultFormatter);
+    let barrier = Arc::new(Barrier::new(2));
+    cfg.capacity = 1;
+    cfg.flush_interval = 1;
+    cfg.overflow_policy = OverflowPolicy::Drop;
+    cfg.start_barrier = Some(Arc::clone(&barrier));
+    let handler = FemtoFileHandler::with_writer_for_test(cfg);
+
+    handler.handle(FemtoLogRecord::new("core", "INFO", "first"));
+    handler.handle(FemtoLogRecord::new("core", "INFO", "second"));
+    barrier.wait();
+    drop(handler);
+
+    assert_eq!(SharedBuf::contents(&buffer), "core [INFO] first\n");
+}
+
+#[test]
+fn femto_file_handler_queue_overflow_block_policy() {
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let mut cfg = TestConfig::new(SharedBuf::new(Arc::clone(&buffer)), DefaultFormatter);
+    let barrier = Arc::new(Barrier::new(2));
+    cfg.capacity = 1;
+    cfg.flush_interval = 1;
+    cfg.overflow_policy = OverflowPolicy::Block;
+    cfg.start_barrier = Some(Arc::clone(&barrier));
+    let handler = Arc::new(FemtoFileHandler::with_writer_for_test(cfg));
+
+    handler.handle(FemtoLogRecord::new("core", "INFO", "first"));
+    let h = Arc::clone(&handler);
+    let t = thread::spawn(move || {
+        h.handle(FemtoLogRecord::new("core", "INFO", "second"));
+    });
+    thread::sleep(Duration::from_millis(50));
+    assert!(!t.is_finished());
+    barrier.wait();
+    t.join().unwrap();
+    drop(handler);
+
+    let out = SharedBuf::contents(&buffer);
+    assert!(out.contains("core [INFO] first"));
+    assert!(out.contains("core [INFO] second"));
+}
+
+#[test]
+fn femto_file_handler_worker_thread_failure() {
+    #[derive(Clone)]
+    struct BlockingWriter {
+        buf: Arc<Mutex<Vec<u8>>>,
+        barrier: Arc<Barrier>,
+    }
+
+    impl Write for BlockingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.buf.lock().unwrap().write(buf)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.barrier.wait();
+            self.buf.lock().unwrap().flush()
+        }
+    }
+
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let barrier = Arc::new(Barrier::new(2));
+    let mut cfg = TestConfig::new(
+        BlockingWriter {
+            buf: Arc::clone(&buffer),
+            barrier: Arc::clone(&barrier),
+        },
+        DefaultFormatter,
+    );
+    cfg.capacity = 1;
+    cfg.flush_interval = 1;
+    let handler = FemtoFileHandler::with_writer_for_test(cfg);
+    handler.handle(FemtoLogRecord::new("core", "INFO", "slow"));
+    let start = Instant::now();
+    drop(handler);
+    assert!(start.elapsed() < Duration::from_millis(1500));
+    barrier.wait();
 }

--- a/rust_extension/src/handlers/file/worker.rs
+++ b/rust_extension/src/handlers/file/worker.rs
@@ -154,6 +154,7 @@ mod flush_tracker_tests {
     use super::*;
     use logtest::Logger;
     use rstest::*;
+    use serial_test::serial;
     use std::io::{self, Write};
 
     #[derive(Default)]
@@ -204,6 +205,7 @@ mod flush_tracker_tests {
     }
 
     #[rstest]
+    #[serial]
     fn record_write_logs_warning_on_error(#[with(true)] mut writer: DummyWriter) {
         let mut logger = Logger::start();
         let mut tracker = FlushTracker::new(1);


### PR DESCRIPTION
## Summary
- add more `FemtoFileHandler` unit tests covering invalid paths, queue overflows and worker failures
- serialize logger-based test in `flush_tracker_tests`

closes #111


------
https://chatgpt.com/codex/tasks/task_e_688be8aac6f48322ba6ec2f0a60e31c7

## Summary by Sourcery

Add edge-case unit tests for FemtoFileHandler, including invalid file paths, queue overflow behaviors, and worker thread failures, introduce a SharedBuf helper for in-memory testing, and serialize relevant tests to avoid concurrency issues.

Enhancements:
- Introduce SharedBuf helper type to simplify in-memory write and flush behavior in tests
- Annotate logger-based and related tests with serial attribute to prevent concurrent execution issues

Tests:
- Add test for error on invalid file path
- Add queue overflow tests for Drop and Block policies in FemtoFileHandler
- Add test to verify handler cleanup on worker thread failure under slow flush conditions