### PR TITLE
Refactor file handler tests for determinism

### DIFF
--- a/rust_extension/src/handlers/file/tests.rs
+++ b/rust_extension/src/handlers/file/tests.rs
@@ -34,14 +34,30 @@ impl Write for SharedBuf {
 
 fn setup_overflow_test(policy: OverflowPolicy) -> (SharedBuf, Arc<Barrier>, FemtoFileHandler) {
     let buffer = SharedBuf::default();
-    let barrier = Arc::new(Barrier::new(2));
+    let start_barrier = Arc::new(Barrier::new(2));
     let mut cfg = TestConfig::new(buffer.clone(), DefaultFormatter);
     cfg.capacity = 1;
     cfg.flush_interval = 1;
     cfg.overflow_policy = policy;
-    cfg.start_barrier = Some(Arc::clone(&barrier));
+    cfg.start_barrier = Some(Arc::clone(&start_barrier));
     let handler = FemtoFileHandler::with_writer_for_test(cfg);
-    (buffer, barrier, handler)
+    (buffer, start_barrier, handler)
+}
+
+fn spawn_record_thread(
+    handler: Arc<FemtoFileHandler>,
+    record: FemtoLogRecord,
+) -> (Arc<Barrier>, mpsc::Receiver<()>, thread::JoinHandle<()>) {
+    let (done_tx, done_rx) = mpsc::channel();
+    let send_barrier = Arc::new(Barrier::new(2));
+    let h = Arc::clone(&handler);
+    let sb = Arc::clone(&send_barrier);
+    let handle = thread::spawn(move || {
+        sb.wait();
+        h.handle(record);
+        done_tx.send(()).expect("send done");
+    });
+    (send_barrier, done_rx, handle)
 }
 
 #[test]
@@ -102,11 +118,11 @@ fn femto_file_handler_invalid_file_path() {
 #[test]
 #[serial]
 fn femto_file_handler_queue_overflow_drop_policy() {
-    let (buffer, barrier, handler) = setup_overflow_test(OverflowPolicy::Drop);
+    let (buffer, start_barrier, handler) = setup_overflow_test(OverflowPolicy::Drop);
 
     handler.handle(FemtoLogRecord::new("core", "INFO", "first"));
     handler.handle(FemtoLogRecord::new("core", "INFO", "second"));
-    barrier.wait();
+    start_barrier.wait();
     drop(handler);
 
     assert_eq!(buffer.contents(), "core [INFO] first\n");
@@ -114,23 +130,18 @@ fn femto_file_handler_queue_overflow_drop_policy() {
 
 #[test]
 fn femto_file_handler_queue_overflow_block_policy() {
-    let (buffer, barrier, handler) = setup_overflow_test(OverflowPolicy::Block);
+    let (buffer, start_barrier, handler) = setup_overflow_test(OverflowPolicy::Block);
     handler.handle(FemtoLogRecord::new("core", "INFO", "first"));
 
     let handler = Arc::new(handler);
-    let (done_tx, done_rx) = mpsc::channel();
-    let send_barrier = Arc::new(Barrier::new(2));
-    let h = Arc::clone(&handler);
-    let sb = Arc::clone(&send_barrier);
-    let t = thread::spawn(move || {
-        sb.wait();
-        h.handle(FemtoLogRecord::new("core", "INFO", "second"));
-        done_tx.send(()).expect("send done");
-    });
+    let (send_barrier, done_rx, t) = spawn_record_thread(
+        Arc::clone(&handler),
+        FemtoLogRecord::new("core", "INFO", "second"),
+    );
 
     send_barrier.wait();
     assert!(done_rx.try_recv().is_err());
-    barrier.wait();
+    start_barrier.wait();
     done_rx
         .recv_timeout(Duration::from_secs(2))
         .expect("worker did not finish");
@@ -140,6 +151,14 @@ fn femto_file_handler_queue_overflow_block_policy() {
     let out = buffer.contents();
     assert!(out.contains("core [INFO] first"));
     assert!(out.contains("core [INFO] second"));
+    let first_idx = out.find("core [INFO] first").expect("first log not found");
+    let second_idx = out
+        .find("core [INFO] second")
+        .expect("second log not found");
+    assert!(
+        first_idx < second_idx,
+        "\"core [INFO] first\" does not appear before \"core [INFO] second\" in output",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `SharedBuf::contents` accessor
- deduplicate file handler test setup
- replace sleeps with barrier and channel in overflow tests

## Testing
- `make fmt`
- `RUSTC_WRAPPER= make lint`
- `RUSTC_WRAPPER= make test`


------
https://chatgpt.com/codex/tasks/task_e_688f7f596b588322a7649904e84db488

## Summary by Sourcery

Refactor file handler tests to improve determinism and reduce duplication.

Tests:
- Introduce SharedBuf.contents accessor and update tests to use it for reading buffer contents
- Add setup_overflow_test helper to consolidate overflow test initialization
- Replace thread::sleep-based synchronization in queue overflow tests with Barrier and mpsc channel to achieve deterministic coordination