### PR TITLE
Simplify file handler constructors via config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ project:
   stability and reproducibility.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
   open-ended inequality (`>=`) version requirements is strictly forbidden, as
-  they introduce unacceptable risk and unpredictability. Tilde requirements
+  it introduces unacceptable risk and unpredictability. Tilde requirements
   (`~`) should only be used where a dependency must be locked to patch-level
   updates for a specific, documented reason.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,8 +202,8 @@ directory:
   practices for context managers
 - [Python Generators](.rules/python-generators.mdc) — Generator and iterator
   patterns
-- [Python Project Configuration](.rules/python-pyproject.mdc) — pyproject
-  toml and packaging
+- [Python Project Configuration](.rules/python-pyproject.mdc) — pyproject.toml
+  and packaging
 - [Python Return Patterns](.rules/python-return.mdc) — Function return
   conventions
 - [Python Typing](.rules/python-typing.mdc) — Type annotation best practices

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,15 +24,14 @@
 - **Use consistent spelling and grammar.** Comments must use en-GB-oxendict
   ("-ize" / "-yse" / "-our") spelling and grammar, with the exception of
   references to external APIs.
-- **Illustrate with clear examples.** Function documentation must include clear
-  examples demonstrating the usage and outcome of the function. Test
+- **Illustrate with clear examples.** Function documentation must include
+  clear examples demonstrating the usage and outcome of the function. Test
   documentation should omit examples where the example serves only to reiterate
   the test logic.
-- **Keep file size managable.** No single code file may be longer than 400
-  lines.
-  Long switch statements or dispatch tables should be broken up by feature and
-  constituents colocated with targets. Large blocks of test data should be
-  moved to external data files.
+- **Keep file size manageable.** No single code file may be longer than 400
+  lines. Long switch statements or dispatch tables should be broken up by
+  feature and constituents colocated with targets. Large blocks of test data
+  should be moved to external data files.
 
 ## Documentation Maintenance
 
@@ -158,7 +157,7 @@ project:
   changes from new major versions. This approach is critical for ensuring build
   stability and reproducibility.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
-  open-ended inequality (`>=`) version requirements is strictly forbidden as
+  open-ended inequality (`>=`) version requirements is strictly forbidden, as
   they introduce unacceptable risk and unpredictability. Tilde requirements
   (`~`) should only be used where a dependency must be locked to patch-level
   updates for a specific, documented reason.
@@ -186,13 +185,11 @@ project:
   `pyerr.set_cause(py, Some(inner_pyerr))` to attach a cause to a raised
   exception. This enables chained tracebacks in Python.
 - **Use structured Python exceptions only when required.** If additional data
-  must
-  be exposed in exceptions, define `#[pyclass(extends=PyException)]` types and
-  expose relevant fields using `#[pyo3(get)]`. Avoid unnecessary complexity.
+  must be exposed in exceptions, define `#[pyclass(extends=PyException)]` types
+  and expose relevant fields using `#[pyo3(get)]`. Avoid unnecessary complexity.
 - **Prevent panics across the FFI boundary.** Ensure Rust panics do not cross
-  into
-  Python. Handle all expected failures using error returns. Treat any panic as
-  a logic bug to be resolved internally.
+  into Python. Handle all expected failures using error returns. Treat any
+  panic as a logic bug to be resolved internally.
 
 ## Python Development Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@
 - **Clarity over cleverness.** Be concise, but favour explicit over terse or
   obscure idioms. Prefer code that's easy to follow.
 - **Use functions and composition.** Avoid repetition by extracting reusable
-  logic. Prefer generators or comprehensions, and declarative code to imperative
-  repetition when readable.
+  logic. Prefer generators or comprehensions, and declarative code to
+  imperative repetition when readable.
 - **Small, meaningful functions.** Functions must be small, clear in purpose,
   single responsibility, and obey command/query segregation.
 - **Clear commit messages.** Commit messages should be descriptive, explaining
@@ -25,12 +25,14 @@
   ("-ize" / "-yse" / "-our") spelling and grammar, with the exception of
   references to external APIs.
 - **Illustrate with clear examples.** Function documentation must include clear
-  examples demonstrating the usage and outcome of the function. Test documentation
-  should omit examples where the example serves only to reiterate the test logic.
-- **Keep file size managable.** No single code file may be longer than 400 lines.
+  examples demonstrating the usage and outcome of the function. Test
+  documentation should omit examples where the example serves only to reiterate
+  the test logic.
+- **Keep file size managable.** No single code file may be longer than 400
+  lines.
   Long switch statements or dispatch tables should be broken up by feature and
-  constituents colocated with targets. Large blocks of test data should be moved
-  to external data files.
+  constituents colocated with targets. Large blocks of test data should be
+  moved to external data files.
 
 ## Documentation Maintenance
 
@@ -42,8 +44,8 @@
   relevant file(s) in the `docs/` directory to reflect the latest state.
   **Ensure the documentation remains accurate and current.**
 - Documentation must use en-GB-oxendict ("-ize" / "-yse" / "-our") spelling
-  and grammar. (EXCEPTION: the naming of the "LICENSE" file, which
-  is to be left unchanged for community consistency.)
+  and grammar. (EXCEPTION: the naming of the "LICENSE" file, which is to be
+  left unchanged for community consistency.)
 
 ## Change Quality & Committing
 
@@ -153,11 +155,11 @@ project:
   specified in `Cargo.toml` must use SemVer-compatible caret requirements
   (e.g., `some-crate = "1.2.3"`). This is Cargo's default and allows for safe,
   non-breaking updates to minor and patch versions while preventing breaking
-  changes from new major versions. This approach is critical for ensuring
-  build stability and reproducibility.
+  changes from new major versions. This approach is critical for ensuring build
+  stability and reproducibility.
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
-  open-ended inequality (`>=`) version requirements is strictly forbidden
-  as they introduce unacceptable risk and unpredictability. Tilde requirements
+  open-ended inequality (`>=`) version requirements is strictly forbidden as
+  they introduce unacceptable risk and unpredictability. Tilde requirements
   (`~`) should only be used where a dependency must be locked to patch-level
   updates for a specific, documented reason.
 
@@ -170,41 +172,44 @@ project:
 - **Define and export Python exceptions.** Use `create_exception!` to define
   module-level Python exception types. Map domain errors to these using
   `From<DomainError> for PyErr`. Prefer built-in Python exceptions where
-  appropriate; otherwise define and expose custom exceptions for domain-specific
-  cases.
+  appropriate; otherwise define and expose custom exceptions for
+  domain-specific cases.
 - **Avoid opaque error types in public APIs.** Do not expose `anyhow::Error`,
-  `eyre::Report`, or similar from PyO3 functions. Use these only in binary crates
-  or application-level code. Convert to domain enums before returning from any
-  `#[pyfunction]` or `#[pymethod]`.
+  `eyre::Report`, or similar from PyO3 functions. Use these only in binary
+  crates or application-level code. Convert to domain enums before returning
+  from any `#[pyfunction]` or `#[pymethod]`.
 - **Return `PyResult<T>` from exposed functions.** Ensure all exposed functions
-  return `PyResult<T>` or `Result<T, E>` with a `From<E> for PyErr` implementation.
-  Export exception classes from the module for explicit Python-side error handling.
+  return `PyResult<T>` or `Result<T, E>` with a `From<E> for PyErr`
+  implementation. Export exception classes from the module for explicit
+  Python-side error handling.
 - **Preserve error context for debugging.** Where necessary, use
-  `pyerr.set_cause(py, Some(inner_pyerr))` to attach a cause to a raised exception.
-  This enables chained tracebacks in Python.
-- **Use structured Python exceptions only when required.** If additional data must
+  `pyerr.set_cause(py, Some(inner_pyerr))` to attach a cause to a raised
+  exception. This enables chained tracebacks in Python.
+- **Use structured Python exceptions only when required.** If additional data
+  must
   be exposed in exceptions, define `#[pyclass(extends=PyException)]` types and
   expose relevant fields using `#[pyo3(get)]`. Avoid unnecessary complexity.
-- **Prevent panics across the FFI boundary.** Ensure Rust panics do not cross into
-  Python. Handle all expected failures using error returns. Treat any panic as a
-  logic bug to be resolved internally.
+- **Prevent panics across the FFI boundary.** Ensure Rust panics do not cross
+  into
+  Python. Handle all expected failures using error returns. Treat any panic as
+  a logic bug to be resolved internally.
 
 ## Python Development Guidelines
 
 For Python development, refer to the detailed guidelines in the `.rules/`
 directory:
 
-- [Python Code Style Guidelines](.rules/python-00.mdc) - Core Python style
+- [Python Code Style Guidelines](.rules/python-00.mdc) — Core Python style
   conventions
-- [Python Context Managers](.rules/python-context-managers.mdc) - Best practices
-  for context managers
-- [Python Generators](.rules/python-generators.mdc) - Generator and iterator
+- [Python Context Managers](.rules/python-context-managers.mdc) — Best
+  practices for context managers
+- [Python Generators](.rules/python-generators.mdc) — Generator and iterator
   patterns
-- [Python Project Configuration](.rules/python-pyproject.mdc) - pyproject.toml
-  and packaging
-- [Python Return Patterns](.rules/python-return.mdc) - Function return
+- [Python Project Configuration](.rules/python-pyproject.mdc) — pyproject
+  toml and packaging
+- [Python Return Patterns](.rules/python-return.mdc) — Function return
   conventions
-- [Python Typing](.rules/python-typing.mdc) - Type annotation best practices
+- [Python Typing](.rules/python-typing.mdc) — Type annotation best practices
 
 ## Markdown Guidance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,17 +194,17 @@ project:
 For Python development, refer to the detailed guidelines in the `.rules/`
 directory:
 
-* [Python Code Style Guidelines](.rules/python-00.mdc) - Core Python style
+- [Python Code Style Guidelines](.rules/python-00.mdc) - Core Python style
   conventions
-* [Python Context Managers](.rules/python-context-managers.mdc) - Best practices
+- [Python Context Managers](.rules/python-context-managers.mdc) - Best practices
   for context managers
-* [Python Generators](.rules/python-generators.mdc) - Generator and iterator
+- [Python Generators](.rules/python-generators.mdc) - Generator and iterator
   patterns
-* [Python Project Configuration](.rules/python-pyproject.mdc) - pyproject.toml
+- [Python Project Configuration](.rules/python-pyproject.mdc) - pyproject.toml
   and packaging
-* [Python Return Patterns](.rules/python-return.mdc) - Function return
+- [Python Return Patterns](.rules/python-return.mdc) - Function return
   conventions
-* [Python Typing](.rules/python-typing.mdc) - Type annotation best practices
+- [Python Typing](.rules/python-typing.mdc) - Type annotation best practices
 
 ## Markdown Guidance
 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test: build ## Run tests
 	cargo fmt --manifest-path $(RUST_MANIFEST) -- --check
 	$(CARGO_BUILD_ENV) cargo clippy --manifest-path $(RUST_MANIFEST) --no-default-features -- -D warnings
 	$(CARGO_BUILD_ENV) cargo test --manifest-path $(RUST_MANIFEST) --no-default-features
-	uv run pytest -v
+	PYTHONPATH=$(PWD) uv run pytest -v
 
 typecheck: build ## Static type analysis
 	ty check

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test: build ## Run tests
 	cargo fmt --manifest-path $(RUST_MANIFEST) -- --check
 	$(CARGO_BUILD_ENV) cargo clippy --manifest-path $(RUST_MANIFEST) --no-default-features -- -D warnings
 	$(CARGO_BUILD_ENV) cargo test --manifest-path $(RUST_MANIFEST) --no-default-features
-	PYTHONPATH=$(PWD) uv run pytest -v
+	PYTHONPATH="$(CURDIR)$${PYTHONPATH:+:$$PYTHONPATH}" uv run pytest -v
 
 typecheck: build ## Static type analysis
 	ty check

--- a/docs/concurrency-models-in-high-performance-logging.md
+++ b/docs/concurrency-models-in-high-performance-logging.md
@@ -40,7 +40,7 @@ locking.
 
 A crucial detail of this implementation is the sequence of operations within
 the `handle` method: filtering occurs *before* the lock is acquired. This is an
-important optimisation, as it prevents the cost of filtering out a message from
+important optimization, as it prevents the cost of filtering out a message from
 contributing to lock contention. However, the work of formatting the message
 via the `Formatter` occurs *inside* the locked region, as it is part of the
 `emit` call chain.
@@ -63,7 +63,7 @@ Lock (GIL)**.
   during application start-up in a single-threaded context. By avoiding an
   explicit global lock, `picologging` eliminates a potential point of
   contention for the far more frequent operation of emitting log messages,
-  thereby prioritising runtime performance[^1].
+  thereby prioritizing runtime performance[^1].
 
 ## 2. A Rust Implementation: The Power of Compile-Time Safety
 

--- a/docs/concurrency-models-in-high-performance-logging.md
+++ b/docs/concurrency-models-in-high-performance-logging.md
@@ -11,10 +11,10 @@ throughput applications.
 
 ## 1. The `picologging` Concurrency Model: A Hybrid Approach
 
-`picologging` achieves its performance by implementing critical paths in C++ and
-making deliberate trade-offs in its concurrency strategy. It eschews the single,
-global module lock found in CPython's standard `logging` library in favour of a
-more granular approach.
+`picologging` achieves its performance by implementing critical paths in C++
+and making deliberate trade-offs in its concurrency strategy. It eschews the
+single, global module lock found in CPython's standard `logging` library in
+favour of a more granular approach.
 
 ### Fine-Grained Locking at the Handler Level
 
@@ -24,26 +24,26 @@ multiple threads can write log messages without corrupting the output stream
 locking.
 
 - **Mechanism**: Each `Handler` instance contains its own C++
-  `std::recursive_mutex`. This lock is acquired at the beginning of the `handle`
-  method and released upon completion.
+  `std::recursive_mutex`. This lock is acquired at the beginning of the
+  `handle` method and released upon completion.
 
 - **Implementation**: The `Handler` struct definition in
-  `src/picologging/handler.hxx` includes the `lock` member. The `Handler_handle`
-  function in `src/picologging/handler.cxx` orchestrates the lock acquisition
-  and release around the call to the `emit` method.
+  `src/picologging/handler.hxx` includes the `lock` member. The
+  `Handler_handle` function in `src/picologging/handler.cxx` orchestrates the
+  lock acquisition and release around the call to the `emit` method.
 
 - **Rationale**: This ensures that the process of formatting a log record and
   writing it to its destination is an atomic operation for each handler. By
-  keeping the locks fine-grained (one per handler), threads writing to different
-  destinations (e.g., one to a file, another to the console) do not contend with
-  each other.
+  keeping the locks fine-grained (one per handler), threads writing to
+  different destinations (e.g., one to a file, another to the console) do not
+  contend with each other.
 
 A crucial detail of this implementation is the sequence of operations within
 the `handle` method: filtering occurs *before* the lock is acquired. This is an
 important optimisation, as it prevents the cost of filtering out a message from
-contributing to lock contention. However, the work of formatting the message via
-the `Formatter` occurs *inside* the locked region, as it is part of the `emit`
-call chain.
+contributing to lock contention. However, the work of formatting the message
+via the `Formatter` occurs *inside* the locked region, as it is part of the
+`emit` call chain.
 
 ### Reliance on the GIL for Global State
 
@@ -53,28 +53,28 @@ Instead, it relies on the protection afforded by Python's **Global Interpreter
 Lock (GIL)**.
 
 - **Mechanism**: Operations that modify the shared logger hierarchy, such as
-  `getLogger` creating a new logger instance or `_fixupParents` linking it
-  into the tree, are not guarded by a specific lock within `picologging`. Their
+  `getLogger` creating a new logger instance or `_fixupParents` linking it into
+  the tree, are not guarded by a specific lock within `picologging`. Their
   thread safety is a consequence of the GIL ensuring that only one thread can
   execute Python bytecode at any given time.
 
 - **Rationale**: This design decision is predicated on the assumption that
   logger configuration is a relatively infrequent operation, often performed
   during application start-up in a single-threaded context. By avoiding an
-  explicit global lock, `picologging` eliminates a potential point of contention
-  for the far more frequent operation of emitting log messages, thereby
-  prioritising runtime performance[^1].
+  explicit global lock, `picologging` eliminates a potential point of
+  contention for the far more frequent operation of emitting log messages,
+  thereby prioritising runtime performance[^1].
 
 ## 2. A Rust Implementation: The Power of Compile-Time Safety
 
-Translating this architecture to Rust highlights the profound difference between
-runtime concurrency checks (mutexes, GIL) and compile-time guarantees provided
-by an ownership model and borrow checker.
+Translating this architecture to Rust highlights the profound difference
+between runtime concurrency checks (mutexes, GIL) and compile-time guarantees
+provided by an ownership model and borrow checker.
 
 ### Guaranteed Handler Safety with `Mutex`
 
-In a Rust version, the handler's shared mutable state (the output stream)
-would be wrapped in `std::sync::Mutex` and shared across threads using an `Arc`
+In a Rust version, the handler's shared mutable state (the output stream) would
+be wrapped in `std::sync::Mutex` and shared across threads using an `Arc`
 (Atomic Reference Counter).
 
 ```rust
@@ -194,14 +194,15 @@ This pattern is the definitive solution for this use case:
   handlers **without any locks whatsoever**. The channel's design guarantees
   serial, thread-safe delivery to this single consumer.
 
-This architecture achieves the ultimate goal: the hot path (log creation)
-is parallel and minimally contentious, while the cold path (I/O) is handled
+This architecture achieves the ultimate goal: the hot path (log creation) is
+parallel and minimally contentious, while the cold path (I/O) is handled
 serially by a dedicated worker, eliminating lock contention where it is most
 expensive.[^1][^2]
 
-[^1]: See [logging-cpython-picologging-comparison.md](logging-cpython-picologging-comparison.md)
-<!-- markdownlint-disable-next-line MD039 -->
-[^2]: Source: [`microsoft/picologging/picologging-dc110b52c9f2e209f97a6fe80d286afb73a8437e/src/picologging/handlers.py`][handlers-source]
+[^1]: See
+      [logging-cpython-picologging-comparison.md](logging-cpython-picologging-comparison.md)
+[^2]: Source: [`handlers.py`][handlers-source]
 
 <!-- markdownlint-disable-next-line MD013 -->
-[handlers-source]: microsoft/picologging/picologging-dc110b52c9f2e209f97a6fe80d286afb73a8437e/src/picologging/handlers.py
+[handlers-source]:
+microsoft/picologging/picologging-dc110b52c9f2e209f97a6fe80d286afb73a8437e/src/picologging/handlers.py

--- a/docs/concurrency-models-in-high-performance-logging.md
+++ b/docs/concurrency-models-in-high-performance-logging.md
@@ -205,4 +205,4 @@ expensive.[^1][^2]
 
 <!-- markdownlint-disable-next-line MD013 -->
 [handlers-source]:
-microsoft/picologging/picologging-dc110b52c9f2e209f97a6fe80d286afb73a8437e/src/picologging/handlers.py
+https://github.com/microsoft/picologging/blob/dc110b52c9f2e209f97a6fe80d286afb73a8437e/src/picologging/handlers.py

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -165,7 +165,7 @@ drain pending records and stop the background thread explicitly. Dropping the
 handler still performs this cleanup if the methods aren't invoked.
 
 By default, the file handler flushes the underlying file after every record to
-maximise durability. To batch writes, pass a custom configuration via
+maximize durability. To batch writes, pass a custom configuration via
 `FemtoFileHandler::with_capacity_flush_policy()` (Rust) or
 `FemtoFileHandler.with_capacity_flush_policy()` (Python). Setting the
 `flush_interval` in `HandlerConfig` or `PyHandlerConfig` defers flushing until

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -4,8 +4,7 @@ This document outlines a safe and thread‑aware design for moving formatting an
 handler components from Python to Rust. It complements the
 [roadmap](./roadmap.md) and expands on the design ideas described in <!--
 markdownlint-disable-next-line MD013 -->
-[`rust-multithreaded-logging-framework-for-python-design.md`](./rust-multithreaded-logging-framework-for-python-design.md)
- .
+[`rust-multithreaded-logging-framework-for-python-design.md`](./rust-multithreaded-logging-framework-for-python-design.md).
 
 ## Goals
 
@@ -107,7 +106,8 @@ Legacy constructors like ``with_capacity_flush_blocking`` and
 
 - ``capacity`` and ``flush_interval`` must be greater than zero.
 - ``policy`` must be ``"drop"``, ``"block"`` or ``"timeout"``.
-- ``timeout_ms`` may only be set when ``policy`` is ``"timeout"``.
+- ``timeout_ms`` must be greater than zero and may only be set when ``policy``
+  is ``"timeout"``.
 
 ### StreamHandler
 

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -165,12 +165,13 @@ drain pending records and stop the background thread explicitly. Dropping the
 handler still performs this cleanup if the methods aren't invoked.
 
 By default, the file handler flushes the underlying file after every record to
-maximise durability. To batch writes, pass a custom configuration to
-`with_capacity_flush_policy()` (Rust) or `with_capacity_flush_policy()` on the
-Python side. Setting the `flush_interval` in `HandlerConfig` or
-`PyHandlerConfig` defers flushing until the specified number of records have
-been written. The value must be greater than zero, so periodic flushing always
-occurs. Higher values reduce syscall overhead in high-volume scenarios.
+maximise durability. To batch writes, pass a custom configuration via
+`FemtoFileHandler::with_capacity_flush_policy()` (Rust) or
+`FemtoFileHandler.with_capacity_flush_policy()` (Python). Setting the
+`flush_interval` in `HandlerConfig` or `PyHandlerConfig` defers flushing until
+the specified number of records have been written. The value must be greater
+than zero, so periodic flushing always occurs. Higher values reduce syscall
+overhead in high-volume scenarios.
 
 The worker thread begins processing records as soon as the handler is created.
 Production code therefore leaves the optional `start_barrier` field unset. Unit

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -5,7 +5,7 @@ handler components from Python to Rust. It complements the
 [roadmap](./roadmap.md) and expands on the design ideas described in <!--
 markdownlint-disable-next-line MD013 -->
 [`rust-multithreaded-logging-framework-for-python-design.md`](./rust-multithreaded-logging-framework-for-python-design.md)
-.
+ .
 
 ## Goals
 
@@ -99,6 +99,10 @@ config = PyHandlerConfig(
 handler = FemtoFileHandler.with_capacity_flush_policy("app.log", config)
 ```
 
+Legacy constructors like ``with_capacity_flush_blocking`` and
+``with_capacity_flush_timeout`` have been removed. Use
+``with_capacity_flush_policy`` with an appropriate configuration instead.
+
 `PyHandlerConfig` enforces several invariants:
 
 - ``capacity`` and ``flush_interval`` must be greater than zero.
@@ -161,11 +165,12 @@ drain pending records and stop the background thread explicitly. Dropping the
 handler still performs this cleanup if the methods aren't invoked.
 
 By default, the file handler flushes the underlying file after every record to
-maximize durability. To reduce syscall overhead in high-volume scenarios,
-`FemtoFileHandler.with_capacity_flush()` accepts a `flush_interval` parameter
-controlling how many records are written before the worker thread flushes. The
-value must be greater than zero, so periodic flushing always occurs. Higher
-values reduce syscall overhead in high-volume scenarios.
+maximise durability. To batch writes, pass a custom configuration to
+`with_capacity_flush_policy()` (Rust) or `with_capacity_flush_policy()` on the
+Python side. Setting the `flush_interval` in `HandlerConfig` or
+`PyHandlerConfig` defers flushing until the specified number of records have
+been written. The value must be greater than zero, so periodic flushing always
+occurs. Higher values reduce syscall overhead in high-volume scenarios.
 
 The worker thread begins processing records as soon as the handler is created.
 Production code therefore leaves the optional `start_barrier` field unset. Unit

--- a/rust_extension/src/handlers/file/mod.rs
+++ b/rust_extension/src/handlers/file/mod.rs
@@ -179,7 +179,10 @@ impl FemtoFileHandler {
         F: FemtoFormatter + Send + 'static,
     {
         if config.flush_interval == 0 {
-            panic!("flush_interval must be greater than zero");
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "flush_interval must be greater than zero",
+            ));
         }
         let file = OpenOptions::new().create(true).append(true).open(path)?;
         Ok(Self::from_file(file, formatter, config))

--- a/rust_extension/src/handlers/file/mod.rs
+++ b/rust_extension/src/handlers/file/mod.rs
@@ -3,6 +3,11 @@
 //! `FemtoFileHandler` spawns a dedicated worker thread that writes formatted
 //! log records to disk. Configuration types and the worker implementation live
 //! in submodules and are re-exported here for external use.
+//!
+//! Construct the handler with [`new`] for defaults, [`with_capacity`] to tune
+//! the queue size, or [`with_capacity_flush_policy`] for full control. Python
+//! callers use ``FemtoFileHandler.with_capacity_flush_policy`` with a
+//! [`PyHandlerConfig`](PyHandlerConfig) to access the same options.
 
 mod config;
 mod worker;
@@ -66,65 +71,13 @@ impl FemtoFileHandler {
         Self::new(path).map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))
     }
 
-    #[staticmethod]
-    #[pyo3(name = "with_capacity")]
-    fn py_with_capacity(path: String, capacity: usize) -> PyResult<Self> {
-        Self::build_py_handler(path, capacity, None, OverflowPolicy::Drop)
-    }
-
-    #[staticmethod]
-    #[pyo3(name = "with_capacity_blocking")]
-    fn py_with_capacity_blocking(path: String, capacity: usize) -> PyResult<Self> {
-        Self::build_py_handler(path, capacity, None, OverflowPolicy::Block)
-    }
-
-    #[staticmethod]
-    #[pyo3(name = "with_capacity_timeout")]
-    fn py_with_capacity_timeout(path: String, capacity: usize, timeout_ms: u64) -> PyResult<Self> {
-        Self::build_py_handler(
-            path,
-            capacity,
-            None,
-            OverflowPolicy::Timeout(Duration::from_millis(timeout_ms)),
-        )
-    }
-
-    #[staticmethod]
-    #[pyo3(name = "with_capacity_flush")]
-    fn py_with_capacity_flush(
-        path: String,
-        capacity: usize,
-        flush_interval: usize,
-    ) -> PyResult<Self> {
-        Self::build_py_handler(path, capacity, Some(flush_interval), OverflowPolicy::Drop)
-    }
-
-    #[staticmethod]
-    #[pyo3(name = "with_capacity_flush_blocking")]
-    fn py_with_capacity_flush_blocking(
-        path: String,
-        capacity: usize,
-        flush_interval: usize,
-    ) -> PyResult<Self> {
-        Self::build_py_handler(path, capacity, Some(flush_interval), OverflowPolicy::Block)
-    }
-
-    #[staticmethod]
-    #[pyo3(name = "with_capacity_flush_timeout")]
-    fn py_with_capacity_flush_timeout(
-        path: String,
-        capacity: usize,
-        flush_interval: usize,
-        timeout_ms: u64,
-    ) -> PyResult<Self> {
-        Self::build_py_handler(
-            path,
-            capacity,
-            Some(flush_interval),
-            OverflowPolicy::Timeout(Duration::from_millis(timeout_ms)),
-        )
-    }
-
+    /// Construct a handler using a [`PyHandlerConfig`].
+    ///
+    /// ```python
+    /// from femtologging import FemtoFileHandler, OverflowPolicy, PyHandlerConfig
+    /// cfg = PyHandlerConfig(1024, 1, OverflowPolicy.DROP.value, None)
+    /// handler = FemtoFileHandler.with_capacity_flush_policy("app.log", cfg)
+    /// ```
     #[staticmethod]
     #[pyo3(name = "with_capacity_flush_policy")]
     fn py_with_capacity_flush_policy(path: String, config: PyHandlerConfig) -> PyResult<Self> {
@@ -195,10 +148,14 @@ impl FemtoFileHandler {
         Self::with_capacity_flush_policy(path, DefaultFormatter, cfg)
     }
 
+    /// Create a handler writing to `path` with default settings.
     pub fn new<P: AsRef<Path>>(path: P) -> io::Result<Self> {
         Self::with_capacity(path, DefaultFormatter, DEFAULT_CHANNEL_CAPACITY)
     }
 
+    /// Create a handler with a custom queue `capacity` and default drop policy.
+    ///
+    /// The handler flushes the file after every record.
     pub fn with_capacity<P, F>(path: P, formatter: F, capacity: usize) -> io::Result<Self>
     where
         P: AsRef<Path>,
@@ -208,20 +165,10 @@ impl FemtoFileHandler {
         Self::with_capacity_flush_policy(path, formatter, cfg)
     }
 
-    pub fn with_capacity_flush_interval<P, F>(
-        path: P,
-        formatter: F,
-        capacity: usize,
-        flush_interval: usize,
-    ) -> io::Result<Self>
-    where
-        P: AsRef<Path>,
-        F: FemtoFormatter + Send + 'static,
-    {
-        let cfg = Self::build_config(capacity, Some(flush_interval), OverflowPolicy::Drop);
-        Self::with_capacity_flush_policy(path, formatter, cfg)
-    }
-
+    /// Create a handler using an explicit [`HandlerConfig`].
+    ///
+    /// This allows callers to override the queue capacity, flush interval and
+    /// overflow policy in a single place.
     pub fn with_capacity_flush_policy<P, F>(
         path: P,
         formatter: F,

--- a/rust_extension/src/handlers/file/mod.rs
+++ b/rust_extension/src/handlers/file/mod.rs
@@ -178,6 +178,9 @@ impl FemtoFileHandler {
         P: AsRef<Path>,
         F: FemtoFormatter + Send + 'static,
     {
+        if config.flush_interval == 0 {
+            panic!("flush_interval must be greater than zero");
+        }
         let file = OpenOptions::new().create(true).append(true).open(path)?;
         Ok(Self::from_file(file, formatter, config))
     }

--- a/rust_extension/tests/file_handler_tests.rs
+++ b/rust_extension/tests/file_handler_tests.rs
@@ -4,6 +4,7 @@
 //! handling and concurrent usage from multiple threads.
 
 use std::fs;
+use std::io;
 use std::sync::Barrier;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -158,7 +159,12 @@ fn file_handler_flush_interval_zero() {
     };
     let tmp = NamedTempFile::new().expect("failed to create temp file");
     let result = FemtoFileHandler::with_capacity_flush_policy(tmp.path(), DefaultFormatter, cfg);
-    assert!(result.is_err());
+    let err = match result {
+        Ok(_) => panic!("expected invalid flush_interval"),
+        Err(e) => e,
+    };
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(err.to_string(), "flush_interval must be greater than zero");
 }
 
 #[test]

--- a/rust_extension/tests/file_handler_tests.rs
+++ b/rust_extension/tests/file_handler_tests.rs
@@ -9,8 +9,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use _femtologging_rs::{
-    DefaultFormatter, FemtoFileHandler, FemtoHandlerTrait, FemtoLogRecord, OverflowPolicy,
-    TestConfig,
+    DefaultFormatter, FemtoFileHandler, FemtoHandlerTrait, FemtoLogRecord, HandlerConfig,
+    OverflowPolicy, TestConfig,
 };
 use tempfile::NamedTempFile;
 
@@ -29,13 +29,13 @@ where
     let tmp = NamedTempFile::new().expect("failed to create temp file");
     let path = tmp.path().to_path_buf();
     {
-        let handler = FemtoFileHandler::with_capacity_flush_interval(
-            &path,
-            DefaultFormatter,
+        let cfg = HandlerConfig {
             capacity,
             flush_interval,
-        )
-        .expect("failed to create file handler");
+            overflow_policy: OverflowPolicy::Drop,
+        };
+        let handler = FemtoFileHandler::with_capacity_flush_policy(&path, DefaultFormatter, cfg)
+            .expect("failed to create file handler");
         f(&handler);
     }
     fs::read_to_string(&path).expect("failed to read log output")

--- a/rust_extension/tests/file_handler_tests.rs
+++ b/rust_extension/tests/file_handler_tests.rs
@@ -150,11 +150,15 @@ fn file_handler_custom_flush_interval() {
 }
 
 #[test]
-#[should_panic(expected = "flush_interval must be greater than zero")]
 fn file_handler_flush_interval_zero() {
-    with_temp_file_handler_flush(8, 0, |h| {
-        h.handle(FemtoLogRecord::new("core", "INFO", "message"));
-    });
+    let cfg = HandlerConfig {
+        capacity: 8,
+        flush_interval: 0,
+        overflow_policy: OverflowPolicy::Drop,
+    };
+    let tmp = NamedTempFile::new().expect("failed to create temp file");
+    let result = FemtoFileHandler::with_capacity_flush_policy(tmp.path(), DefaultFormatter, cfg);
+    assert!(result.is_err());
 }
 
 #[test]

--- a/rust_extension/tests/file_handler_tests.rs
+++ b/rust_extension/tests/file_handler_tests.rs
@@ -150,11 +150,11 @@ fn file_handler_custom_flush_interval() {
 }
 
 #[test]
+#[should_panic(expected = "flush_interval must be greater than zero")]
 fn file_handler_flush_interval_zero() {
-    let output = with_temp_file_handler_flush(8, 0, |h| {
+    with_temp_file_handler_flush(8, 0, |h| {
         h.handle(FemtoLogRecord::new("core", "INFO", "message"));
     });
-    assert_eq!(output, "core [INFO] message\n");
 }
 
 #[test]

--- a/rust_extension/tests/heavy/loom_file_flush.rs
+++ b/rust_extension/tests/heavy/loom_file_flush.rs
@@ -7,7 +7,9 @@ use loom::sync::Arc;
 use loom::thread;
 use tempfile::NamedTempFile;
 
-use _femtologging_rs::{DefaultFormatter, FemtoFileHandler, FemtoLogRecord};
+use _femtologging_rs::{
+    DefaultFormatter, FemtoFileHandler, FemtoLogRecord, HandlerConfig, OverflowPolicy,
+};
 
 #[test]
 #[ignore]
@@ -15,14 +17,14 @@ fn loom_file_handler_flush_concurrent() {
     loom::model(|| {
         let tmp = NamedTempFile::new().expect("create temp file");
         let path = tmp.path().to_path_buf();
+        let cfg = HandlerConfig {
+            capacity: 8,
+            flush_interval: 1,
+            overflow_policy: OverflowPolicy::Drop,
+        };
         let handler = Arc::new(
-            FemtoFileHandler::with_capacity_flush_interval(
-                &path,
-                DefaultFormatter,
-                8,
-                1,
-            )
-            .expect("create handler"),
+            FemtoFileHandler::with_capacity_flush_policy(&path, DefaultFormatter, cfg)
+                .expect("create handler"),
         );
 
         let mut threads = vec![];

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import sys
 # Add project root to sys.path so femtologging can be imported without hacks.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from femtologging import FemtoFileHandler
+from femtologging import FemtoFileHandler, OverflowPolicy, PyHandlerConfig
 import pytest  # pyright: ignore[reportMissingImports]
 
 
@@ -26,9 +26,8 @@ def file_handler_factory():
     def factory(
         path: Path, capacity: int, flush_interval: int
     ) -> Iterator[FemtoFileHandler]:
-        handler = FemtoFileHandler.with_capacity_flush(
-            str(path), capacity, flush_interval
-        )
+        cfg = PyHandlerConfig(capacity, flush_interval, OverflowPolicy.DROP.value, None)
+        handler = FemtoFileHandler.with_capacity_flush_policy(str(path), cfg)
         try:
             yield handler
         finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator
+from typing import Callable, ContextManager, Iterator
 import gc
 import sys
 
@@ -14,7 +14,9 @@ import pytest  # pyright: ignore[reportMissingImports]
 
 
 @pytest.fixture()
-def file_handler_factory():
+def file_handler_factory() -> Callable[
+    [Path, int, int], ContextManager[FemtoFileHandler]
+]:
     """Return a context manager creating a ``FemtoFileHandler``.
 
     The factory yields a handler that flushes every ``flush_interval`` records.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,13 +5,13 @@ from pathlib import Path
 from typing import Callable, ContextManager, Generator
 
 from femtologging import FemtoFileHandler, OverflowPolicy, PyHandlerConfig
-import pytest  # pyright: ignore[reportMissingImports]  # FIXME: Add pytest types in dev env and remove this suppression
+import pytest
 
-HandlerFactory = Callable[[Path, int, int], ContextManager[FemtoFileHandler]]
+FileHandlerFactory = Callable[[Path, int, int], ContextManager[FemtoFileHandler]]
 
 
 @pytest.fixture()
-def file_handler_factory() -> HandlerFactory:
+def file_handler_factory() -> FileHandlerFactory:
     """Return a context manager creating a ``FemtoFileHandler``.
 
     The factory yields a handler that flushes every ``flush_interval`` records.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,19 +3,15 @@ from __future__ import annotations
 from contextlib import closing, contextmanager
 from pathlib import Path
 from typing import Callable, ContextManager, Generator
-import sys
-
-# Add project root to sys.path so femtologging can be imported without hacks.
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from femtologging import FemtoFileHandler, OverflowPolicy, PyHandlerConfig
 import pytest  # pyright: ignore[reportMissingImports]
 
+HandlerFactory = Callable[[Path, int, int], ContextManager[FemtoFileHandler]]
+
 
 @pytest.fixture()
-def file_handler_factory() -> Callable[
-    [Path, int, int], ContextManager[FemtoFileHandler]
-]:
+def file_handler_factory() -> HandlerFactory:
     """Return a context manager creating a ``FemtoFileHandler``.
 
     The factory yields a handler that flushes every ``flush_interval`` records.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,12 @@ def file_handler_factory():
     def factory(
         path: Path, capacity: int, flush_interval: int
     ) -> Iterator[FemtoFileHandler]:
-        cfg = PyHandlerConfig(capacity, flush_interval, OverflowPolicy.DROP.value, None)
+        cfg = PyHandlerConfig(
+            capacity,
+            flush_interval,
+            OverflowPolicy.DROP.value,
+            timeout_ms=None,
+        )
         handler = FemtoFileHandler.with_capacity_flush_policy(str(path), cfg)
         try:
             yield handler

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Callable, ContextManager, Generator
 
 from femtologging import FemtoFileHandler, OverflowPolicy, PyHandlerConfig
-import pytest  # pyright: ignore[reportMissingImports]
+import pytest  # pyright: ignore[reportMissingImports]  # FIXME: Add pytest types in dev env and remove this suppression
 
 HandlerFactory = Callable[[Path, int, int], ContextManager[FemtoFileHandler]]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Callable, ContextManager, Iterator
+from typing import Callable, ContextManager, Generator
 import gc
 import sys
 
@@ -27,7 +27,7 @@ def file_handler_factory() -> Callable[
     @contextmanager
     def factory(
         path: Path, capacity: int, flush_interval: int
-    ) -> Iterator[FemtoFileHandler]:
+    ) -> Generator[FemtoFileHandler, None, None]:
         cfg = PyHandlerConfig(
             capacity,
             flush_interval,

--- a/tests/test_config_builder.py
+++ b/tests/test_config_builder.py
@@ -125,4 +125,6 @@ def test_root_logger_last_assignment_wins(
     builder.with_root_logger(LoggerConfigBuilder().with_level(first))
     builder.with_root_logger(LoggerConfigBuilder().with_level(second))
     config = builder.as_dict()
-    assert config["root"]["level"] == expected, f"Last root logger assignment wins: {first}→{second}"
+    assert config["root"]["level"] == expected, (
+        f"Last root logger assignment wins: {first}→{second}"
+    )

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -9,7 +9,7 @@ import typing
 from contextlib import closing
 
 from femtologging import FemtoFileHandler, OverflowPolicy, PyHandlerConfig
-import pytest  # pyright: ignore[reportMissingImports]
+import pytest  # pyright: ignore[reportMissingImports]  # FIXME: Add pytest types in dev env and remove this suppression
 
 FileHandlerFactory = cabc.Callable[
     [Path, int, int], typing.ContextManager[FemtoFileHandler]
@@ -140,6 +140,8 @@ def test_file_handler_flush_interval_large(tmp_path: Path) -> None:
     ) as handler:
         for i in range(5):
             handler.handle("core", "INFO", f"msg {i}")
+        # No flush should occur before close when flush_interval is large
+        assert path.read_text() == ""
     expected = "".join(f"core [INFO] msg {i}\n" for i in range(5))
     assert path.read_text() == expected
 

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -122,12 +122,6 @@ def test_file_handler_custom_flush_interval(
     )
 
 
-def test_file_handler_flush_interval_zero(tmp_path: Path) -> None:
-    """Zero flush interval is rejected."""
-    with pytest.raises(ValueError):
-        PyHandlerConfig(8, 0, OverflowPolicy.DROP.value, timeout_ms=None)
-
-
 def test_file_handler_flush_interval_one(
     tmp_path: Path, file_handler_factory: FileHandlerFactory
 ) -> None:

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -9,7 +9,7 @@ import typing
 from contextlib import closing
 
 from femtologging import FemtoFileHandler, OverflowPolicy, PyHandlerConfig
-import pytest  # pyright: ignore[reportMissingImports]  # FIXME: Add pytest types in dev env and remove this suppression
+import pytest
 
 FileHandlerFactory = cabc.Callable[
     [Path, int, int], typing.ContextManager[FemtoFileHandler]

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -197,7 +197,7 @@ def test_timeout_policy_over_capacity(tmp_path: Path) -> None:
 
 def test_timeout_policy_invalid_timeout_ms(tmp_path: Path) -> None:
     """timeout_ms must be greater than zero."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="timeout_ms must be greater than zero"):
         PyHandlerConfig(1, 1, OverflowPolicy.TIMEOUT.value, timeout_ms=0)
     with pytest.raises(OverflowError):
         PyHandlerConfig(1, 1, OverflowPolicy.TIMEOUT.value, timeout_ms=-1)  # type: ignore[arg-type]
@@ -312,5 +312,5 @@ def test_py_handler_config_set_flush_interval_invalid() -> None:
 def test_py_handler_config_set_policy_invalid() -> None:
     """Setting an invalid policy raises ``ValueError``."""
     cfg = PyHandlerConfig(1, 1, OverflowPolicy.DROP.value, timeout_ms=None)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="invalid overflow policy"):
         cfg.policy = "bogus"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,9 +1,8 @@
-# pyright: reportMissingImports=false
 """Tests for :class:`FemtoLogger`."""
 
 from __future__ import annotations
 
-import pytest  # pyright: ignore[reportMissingImports]  # FIXME: Add pytest types in dev env and remove this suppression
+import pytest
 import collections.abc as cabc
 from pathlib import Path
 import typing

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-import pytest  # pyright: ignore[reportMissingImports]
+import pytest  # pyright: ignore[reportMissingImports]  # FIXME: Add pytest types in dev env and remove this suppression
 import collections.abc as cabc
 from pathlib import Path
 import typing


### PR DESCRIPTION
## Summary
- remove redundant `FemtoFileHandler` constructors and route Python API through `with_capacity_flush_policy`
- document config-based construction and drop legacy examples
- update tests for new API and enforce validation of `flush_interval`

closes #115

## Testing
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689687905d8883229f519b06fb7b47c0

## Summary by Sourcery

Simplify and centralize file handler construction by consolidating multiple constructors into a single config-based method, update documentation and tests to the new API, and enforce validation on flush intervals.

New Features:
- Unify Python file handler creation under a single with_capacity_flush_policy method driven by PyHandlerConfig.

Bug Fixes:
- Reject zero flush_interval values in PyHandlerConfig with a ValueError.

Enhancements:
- Remove legacy with_capacity* constructors and streamline Rust API doc comments to promote config-based setup.
- Update Rust and Python examples in documentation to drop outdated constructors and highlight the config approach.

Documentation:
- Revise concurrency and formatter handler docs to remove legacy examples and adjust minor formatting.

Tests:
- Refactor Python and Rust tests to use with_capacity_flush_policy and PyHandlerConfig/HandlerConfig.
- Add test coverage for invalid flush_interval validation.