### PR TITLE
Add handler builders

### DIFF
--- a/docs/concurrency-models-in-high-performance-logging.md
+++ b/docs/concurrency-models-in-high-performance-logging.md
@@ -197,10 +197,11 @@ This pattern is the definitive solution for this use case:
 This architecture achieves the ultimate goal: the hot path (log creation) is
 parallel and minimally contentious, while the cold path (I/O) is handled
 serially by a dedicated worker, eliminating lock contention where it is most
-expensive.[^1]
+expensive.[^1][^2]
 
 [^1]: See
       [logging-cpython-picologging-comparison.md](logging-cpython-picologging-comparison.md)
+[^2]: Source: [`handlers.py`][handlers-source]
 
 [^2]: Source:
       <!-- markdownlint-disable-next-line MD013 -->

--- a/docs/concurrency-models-in-high-performance-logging.md
+++ b/docs/concurrency-models-in-high-performance-logging.md
@@ -195,9 +195,11 @@ This pattern is the definitive solution for this use case:
   serial, thread-safe delivery to this single consumer.
 
 This architecture achieves the ultimate goal: the hot path (log creation) is
-parallel and minimally contentious, while the cold path (I/O) is handled
-serially by a dedicated worker, eliminating lock contention where it is most
-expensive.[^1][^2]
+parallel and minimally contentious. Records are queued on bounded MPSC
+channels, forming a producer–consumer pipeline. Each builder sets the channel
+capacity and overflow policy, providing predictable back-pressure. The cold
+path (I/O) is handled serially by a dedicated worker, eliminating lock
+contention where it is most expensive.[^1][^2]
 
 [^1]: See
       [logging-cpython-picologging-comparison.md](logging-cpython-picologging-comparison.md)

--- a/docs/concurrency-models-in-high-performance-logging.md
+++ b/docs/concurrency-models-in-high-performance-logging.md
@@ -197,7 +197,7 @@ This pattern is the definitive solution for this use case:
 This architecture achieves the ultimate goal: the hot path (log creation) is
 parallel and minimally contentious, while the cold path (I/O) is handled
 serially by a dedicated worker, eliminating lock contention where it is most
-expensive.[^1][^2]
+expensive.[^1]
 
 [^1]: See
       [logging-cpython-picologging-comparison.md](logging-cpython-picologging-comparison.md)

--- a/docs/configuration-design.md
+++ b/docs/configuration-design.md
@@ -315,12 +315,12 @@ class StreamHandlerBuilder(HandlerBuilder):
 ### 1.3. Implemented handler builders
 
 The initial implementation provides `FileHandlerBuilder` and
-`StreamHandlerBuilder` as thin wrappers over the existing handler types. Both
-builders support basic configuration (path and queue settings for file
-handlers, stream target for stream handlers) and expose `build()` methods
-returning ready‑to‑use handlers. Advanced options such as file encoding or
-custom writers are deferred until the corresponding handler features are ported
-from picologging.
+`StreamHandlerBuilder` as thin wrappers over the existing handler types.
+`FileHandlerBuilder` supports capacity, flush interval, and overflow policy,
+while `StreamHandlerBuilder` configures the stream target and capacity. Both
+builders expose `build()` methods returning ready‑to‑use handlers. Advanced
+options such as file encoding or custom writers are deferred until the
+corresponding handler features are ported from picologging.
 
 ## 2. Backwards Compatibility APIs
 
@@ -532,6 +532,6 @@ switch their logging calls.
 
 The initial implementation introduces `ConfigBuilder`, `LoggerConfigBuilder`,
 `FormatterBuilder`, `FileHandlerBuilder`, and `StreamHandlerBuilder` with
-fluent, chainable methods exposed to Python via `PyO3`. Further handler types
-will be added iteratively. `build_and_init` currently validates only the
-configuration version and does not yet wire the builders into the runtime.
+fluent, chainable methods exposed to Python via `PyO3`. `build_and_init`
+currently validates only the configuration version and does not yet wire the
+builders into the runtime.

--- a/docs/configuration-design.md
+++ b/docs/configuration-design.md
@@ -246,8 +246,10 @@ impl HandlerBuilderTrait for StreamHandlerBuilder { /* ... */ }
 
 ```
 
-The file builder uses a `flush_record_interval` measured in records, whereas
-the stream builder's `flush_timeout_ms` is a duration in milliseconds. Their
+The file builder uses a `flush_record_interval` measured in records, while the
+stream builder's `flush_timeout_ms` is a duration in milliseconds. These
+semantics intentionally differ: file handlers flush after a set number of
+records, whereas stream handlers flush after a period of inactivity. Their
 dictionary representations mirror these names to avoid ambiguity.
 
 ### 1.2. Python Builder API Design (Congruent with Rust and Python Schemas)

--- a/docs/configuration-design.md
+++ b/docs/configuration-design.md
@@ -291,6 +291,16 @@ class StreamHandlerBuilder(HandlerBuilder):
 # ... Other handler builders (RotatingFileHandlerBuilder, SocketHandlerBuilder etc.)
 ```
 
+### 1.3. Implemented handler builders
+
+The initial implementation provides `FileHandlerBuilder` and
+`StreamHandlerBuilder` as thin wrappers over the existing handler types. Both
+builders support basic configuration (path and queue settings for file
+handlers, stream target for stream handlers) and expose `build()` methods
+returning ready‑to‑use handlers. Advanced options such as file encoding or
+custom writers are deferred until the corresponding handler features are ported
+from picologging.
+
 ## 2. Backwards Compatibility APIs
 
 `femtologging` will provide functions in the Python package to ensure backwards

--- a/docs/configuration-design.md
+++ b/docs/configuration-design.md
@@ -147,6 +147,10 @@ pub trait HandlerBuilderTrait: Send + Sync {
     }
 }
 
+// Builders capture any required context directly. The earlier
+// `build_handler(&ConfigContext)` design has been dropped; shared state is
+// injected through builder fields instead of a dedicated context object.
+
 // Example: In femtologging::handlers::FileHandlerBuilder
 pub struct FileHandlerBuilder {
     path: String,
@@ -156,7 +160,7 @@ pub struct FileHandlerBuilder {
     formatter_id: Option<String>,
     filters: Vec<String>,
     capacity: Option<usize>,
-    flush_interval: Option<usize>,
+    flush_record_interval: Option<usize>,
 }
 
 impl FileHandlerBuilder {
@@ -189,7 +193,7 @@ impl FileHandlerBuilder {
 
     /// Sets how often the worker thread flushes the file. Must be greater
     /// than zero so periodic flushing always occurs.
-    pub fn flush_interval(mut self, interval: usize) -> Self { /* ... */ }
+    pub fn flush_record_interval(mut self, interval: usize) -> Self { /* ... */ }
 }
 
 impl HandlerBuilderTrait for FileHandlerBuilder { /* ... */ }
@@ -285,7 +289,7 @@ class FileHandlerBuilder(HandlerBuilder):
     def __init__(self, path: str) -> None: ...
     def mode(self, mode: str) -> "FileHandlerBuilder": ...
     def encoding(self, encoding: str) -> "FileHandlerBuilder": ...
-    def flush_interval(self, interval: int) -> "FileHandlerBuilder": ...
+    def flush_record_interval(self, interval: int) -> "FileHandlerBuilder": ...
 
 class StreamHandlerBuilder(HandlerBuilder):
     @classmethod

--- a/docs/configuration-design.md
+++ b/docs/configuration-design.md
@@ -510,6 +510,7 @@ switch their logging calls.
 ## 5. Implementation Notes
 
 The initial implementation introduces `ConfigBuilder`, `LoggerConfigBuilder`,
-and `FormatterBuilder` with fluent, chainable methods. Handler builders remain
-future work. `build_and_init` currently validates only the configuration
-version and does not yet wire the builders into the runtime.
+`FormatterBuilder`, `FileHandlerBuilder`, and `StreamHandlerBuilder` with
+fluent, chainable methods exposed to Python via `PyO3`. Further handler types
+will be added iteratively. `build_and_init` currently validates only the
+configuration version and does not yet wire the builders into the runtime.

--- a/docs/configuration-design.md
+++ b/docs/configuration-design.md
@@ -160,7 +160,7 @@ pub struct FileHandlerBuilder {
     formatter_id: Option<String>,
     filters: Vec<String>,
     capacity: Option<usize>,
-    flush_record_interval: Option<usize>,
+    flush_record_interval: Option<usize>, // records
 }
 
 impl FileHandlerBuilder {
@@ -191,8 +191,9 @@ impl FileHandlerBuilder {
     /// Sets the internal channel capacity for the handler.
     pub fn with_capacity(mut self, capacity: usize) -> Self { /* ... */ }
 
-    /// Sets how often the worker thread flushes the file. Must be greater
-    /// than zero so periodic flushing always occurs.
+    /// Sets how often the worker thread flushes the file. Measured in
+    /// records and must be greater than zero so periodic flushing always
+    /// occurs.
     pub fn flush_record_interval(mut self, interval: usize) -> Self { /* ... */ }
 }
 
@@ -206,6 +207,7 @@ pub struct StreamHandlerBuilder {
     formatter_id: Option<String>,
     filters: Vec<String>,
     capacity: Option<usize>,
+    flush_timeout_ms: Option<i64>, // milliseconds
 }
 
 impl StreamHandlerBuilder {
@@ -235,11 +237,18 @@ impl StreamHandlerBuilder {
 
     /// Sets the internal channel capacity for the handler.
     pub fn with_capacity(mut self, capacity: usize) -> Self { /* ... */ }
+
+    /// Sets the flush timeout in milliseconds. Must be greater than zero.
+    pub fn with_flush_timeout_ms(mut self, timeout_ms: i64) -> Self { /* ... */ }
 }
 
 impl HandlerBuilderTrait for StreamHandlerBuilder { /* ... */ }
 
 ```
+
+The file builder uses a `flush_record_interval` measured in records, whereas
+the stream builder's `flush_timeout_ms` is a duration in milliseconds. Their
+dictionary representations mirror these names to avoid ambiguity.
 
 ### 1.2. Python Builder API Design (Congruent with Rust and Python Schemas)
 

--- a/docs/configuration-design.md
+++ b/docs/configuration-design.md
@@ -137,8 +137,14 @@ impl FormatterBuilder {
 
 // In femtologging::handlers::HandlerBuilderTrait (and specific builders)
 pub trait HandlerBuilderTrait: Send + Sync {
-    // Marker trait for handler builders
-    fn build_handler(&self, config_context: &ConfigContext) -> Result<Box<dyn FemtoHandlerTrait>, HandlerBuildError>;
+    type Handler: FemtoHandlerTrait;
+
+    fn build_inner(&self) -> Result<Self::Handler, HandlerBuildError>;
+
+    fn build(&self) -> Result<Box<dyn FemtoHandlerTrait>, HandlerBuildError> {
+        let handler = self.build_inner()?;
+        Ok(Box::new(handler))
+    }
 }
 
 // Example: In femtologging::handlers::FileHandlerBuilder

--- a/docs/configuration-roadmap.md
+++ b/docs/configuration-roadmap.md
@@ -11,7 +11,7 @@ expanded with specifics for the configuration design.
 
 - [x] **Implement** `femtologging::config::FormatterBuilder` **in Rust.**
 
-- [ ] **Implement** `femtologging::handlers::FileHandlerBuilder` **and**
+- [x] **Implement** `femtologging::handlers::FileHandlerBuilder` **and**
   `femtologging::handlers::StreamHandlerBuilder` **in Rust, implementing**
   `HandlerBuilderTrait`**.**
 
@@ -30,8 +30,8 @@ expanded with specifics for the configuration design.
 - [ ] **Expose mirroring Python builders via** `PyO3` **bindings.**
   - [x] `LoggerConfigBuilder`
   - [x] `FormatterBuilder`
-  - [ ] `FileHandlerBuilder`
-  - [ ] `StreamHandlerBuilder`
+  - [x] `FileHandlerBuilder`
+  - [x] `StreamHandlerBuilder`
 
 - [ ] Add compile‑time log level filtering via Cargo features.
 

--- a/docs/configuration-roadmap.md
+++ b/docs/configuration-roadmap.md
@@ -14,6 +14,10 @@ expanded with specifics for the configuration design.
 - [x] **Implement** `femtologging::handlers::FileHandlerBuilder` **and**
   `femtologging::handlers::StreamHandlerBuilder` **in Rust, implementing**
   `HandlerBuilderTrait`**.**
+  - `HandlerBuilderTrait` defines an associated `Handler` type and a
+    `build_inner`/`build` pattern. Builders capture any environmental context
+    via explicit fields; the previously proposed `ConfigContext` has been
+    dropped.
 
 - [ ] **Enable multiple handler IDs to be attached to a single logger in the
   builder API.**

--- a/docs/configuration-roadmap.md
+++ b/docs/configuration-roadmap.md
@@ -27,7 +27,7 @@ expanded with specifics for the configuration design.
 - [x] **Expose a mirroring** `femtologging.ConfigBuilder` **in Python via**
   `PyO3` **bindings.**
 
-- [ ] **Expose mirroring Python builders via** `PyO3` **bindings.**
+- [x] **Expose mirroring Python builders via** `PyO3` **bindings.**
   - [x] `LoggerConfigBuilder`
   - [x] `FormatterBuilder`
   - [x] `FileHandlerBuilder`

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -117,7 +117,8 @@ formatter into the worker thread, and writes directly without locking. This
 mirrors the design in
 [`concurrency-models-in-high-performance- logging.md`][cmhp-log]. The default
 bounded queue size is 1024 records, but `FemtoStreamHandler::with_capacity`
-lets callers configure a custom capacity when needed.
+lets callers configure a custom capacity when needed. Flushing is driven by a
+timeout measured in milliseconds.
 
 Dropping a handler closes its channel and waits briefly for the worker thread
 to finish flushing. If the thread does not exit within the configured flush

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -91,7 +91,7 @@ from femtologging import FemtoFileHandler, OverflowPolicy, PyHandlerConfig
 # Waiting ensures no log messages are lost if the queue becomes full.
 config = PyHandlerConfig(
     capacity=4096,
-    flush_interval=1,
+    flush_record_interval=1,
     policy=OverflowPolicy.BLOCK.value,
     timeout_ms=None,
 )
@@ -104,7 +104,7 @@ Legacy constructors like ``with_capacity_flush_blocking`` and
 
 `PyHandlerConfig` enforces several invariants:
 
-- ``capacity`` and ``flush_interval`` must be greater than zero.
+- ``capacity`` and ``flush_record_interval`` must be greater than zero.
 - ``policy`` must be ``"drop"``, ``"block"`` or ``"timeout"``.
 - ``timeout_ms`` must be greater than zero and may only be set when ``policy``
   is ``"timeout"``.

--- a/femtologging/__init__.py
+++ b/femtologging/__init__.py
@@ -15,6 +15,8 @@ reset_manager = rust.reset_manager_py  # type: ignore[attr-defined]
 FemtoHandler = rust.FemtoHandler  # type: ignore[attr-defined]
 FemtoStreamHandler = rust.FemtoStreamHandler  # type: ignore[attr-defined]
 FemtoFileHandler = rust.FemtoFileHandler  # type: ignore[attr-defined]
+StreamHandlerBuilder = rust.StreamHandlerBuilder  # type: ignore[attr-defined]
+FileHandlerBuilder = rust.FileHandlerBuilder  # type: ignore[attr-defined]
 PyHandlerConfig = rust.PyHandlerConfig  # type: ignore[attr-defined]
 ConfigBuilder = rust.ConfigBuilder  # type: ignore[attr-defined]
 LoggerConfigBuilder = rust.LoggerConfigBuilder  # type: ignore[attr-defined]
@@ -27,6 +29,8 @@ __all__ = [
     "reset_manager",
     "FemtoStreamHandler",
     "FemtoFileHandler",
+    "StreamHandlerBuilder",
+    "FileHandlerBuilder",
     "PyHandlerConfig",
     "ConfigBuilder",
     "LoggerConfigBuilder",

--- a/femtologging/__init__.py
+++ b/femtologging/__init__.py
@@ -21,6 +21,8 @@ PyHandlerConfig = rust.PyHandlerConfig  # type: ignore[attr-defined]
 ConfigBuilder = rust.ConfigBuilder  # type: ignore[attr-defined]
 LoggerConfigBuilder = rust.LoggerConfigBuilder  # type: ignore[attr-defined]
 FormatterBuilder = rust.FormatterBuilder  # type: ignore[attr-defined]
+HandlerConfigError = rust.HandlerConfigError  # type: ignore[attr-defined]
+HandlerIOError = rust.HandlerIOError  # type: ignore[attr-defined]
 
 __all__ = [
     "FemtoHandler",
@@ -35,6 +37,8 @@ __all__ = [
     "ConfigBuilder",
     "LoggerConfigBuilder",
     "FormatterBuilder",
+    "HandlerConfigError",
+    "HandlerIOError",
     "OverflowPolicy",
     "hello",
 ]

--- a/rust_extension/src/handlers/common.rs
+++ b/rust_extension/src/handlers/common.rs
@@ -8,7 +8,6 @@ use std::num::NonZeroUsize;
 pub struct CommonBuilder {
     pub(crate) capacity: Option<NonZeroUsize>,
     pub(crate) capacity_set: bool,
-    pub(crate) formatter_id: Option<String>,
 }
 
 impl CommonBuilder {

--- a/rust_extension/src/handlers/common.rs
+++ b/rust_extension/src/handlers/common.rs
@@ -1,0 +1,19 @@
+//! Shared builder options.
+//!
+//! Stores fields common to multiple handler builders.
+
+#[derive(Clone, Debug, Default)]
+pub struct CommonBuilder {
+    pub(crate) capacity: Option<usize>,
+}
+
+impl CommonBuilder {
+    pub(crate) fn is_capacity_valid(&self) -> Result<(), super::HandlerBuildError> {
+        match self.capacity {
+            Some(0) => Err(super::HandlerBuildError::InvalidConfig(
+                "capacity must be greater than zero".to_string(),
+            )),
+            _ => Ok(()),
+        }
+    }
+}

--- a/rust_extension/src/handlers/common.rs
+++ b/rust_extension/src/handlers/common.rs
@@ -2,9 +2,12 @@
 //!
 //! Stores fields common to multiple handler builders.
 
+use std::num::NonZeroUsize;
+
 #[derive(Clone, Debug, Default)]
 pub struct CommonBuilder {
-    pub(crate) capacity: Option<usize>,
+    pub(crate) capacity: Option<NonZeroUsize>,
+    pub(crate) capacity_set: bool,
 }
 
 impl CommonBuilder {
@@ -20,7 +23,20 @@ impl CommonBuilder {
         }
     }
 
+    pub(crate) fn ensure_non_zero_u64(
+        field: &str,
+        value: Option<u64>,
+    ) -> Result<(), super::HandlerBuildError> {
+        Self::ensure_non_zero(field, value)
+    }
+
     pub(crate) fn is_capacity_valid(&self) -> Result<(), super::HandlerBuildError> {
-        Self::ensure_non_zero("capacity", self.capacity.map(|v| v as u64))
+        if self.capacity.is_none() && self.capacity_set {
+            Err(super::HandlerBuildError::InvalidConfig(
+                "capacity must be greater than zero".into(),
+            ))
+        } else {
+            Ok(())
+        }
     }
 }

--- a/rust_extension/src/handlers/common.rs
+++ b/rust_extension/src/handlers/common.rs
@@ -11,18 +11,27 @@ pub struct CommonBuilder {
 }
 
 impl CommonBuilder {
+    /// Validate that an optional numeric field (if provided) is greater than zero.
+    ///
+    /// Returns `InvalidConfig("{field} must be greater than zero")` when `value`
+    /// is `Some(0)`.
     pub(crate) fn ensure_non_zero(
         field: &str,
         value: Option<u64>,
     ) -> Result<(), super::HandlerBuildError> {
         match value {
             Some(0) => Err(super::HandlerBuildError::InvalidConfig(format!(
-                "{field} must be greater than zero",
+                "{field} must be greater than zero"
             ))),
             _ => Ok(()),
         }
     }
 
+    /// Validate capacity semantics.
+    ///
+    /// When `capacity_set` is true and `capacity` is `None`, the caller
+    /// attempted to set zero; return
+    /// `InvalidConfig("capacity must be greater than zero")` in this case.
     pub(crate) fn is_capacity_valid(&self) -> Result<(), super::HandlerBuildError> {
         if self.capacity.is_none() && self.capacity_set {
             Err(super::HandlerBuildError::InvalidConfig(

--- a/rust_extension/src/handlers/common.rs
+++ b/rust_extension/src/handlers/common.rs
@@ -8,12 +8,19 @@ pub struct CommonBuilder {
 }
 
 impl CommonBuilder {
-    pub(crate) fn is_capacity_valid(&self) -> Result<(), super::HandlerBuildError> {
-        match self.capacity {
-            Some(0) => Err(super::HandlerBuildError::InvalidConfig(
-                "capacity must be greater than zero".to_string(),
-            )),
+    pub(crate) fn ensure_non_zero(
+        field: &str,
+        value: Option<u64>,
+    ) -> Result<(), super::HandlerBuildError> {
+        match value {
+            Some(0) => Err(super::HandlerBuildError::InvalidConfig(format!(
+                "{field} must be greater than zero",
+            ))),
             _ => Ok(()),
         }
+    }
+
+    pub(crate) fn is_capacity_valid(&self) -> Result<(), super::HandlerBuildError> {
+        Self::ensure_non_zero("capacity", self.capacity.map(|v| v as u64))
     }
 }

--- a/rust_extension/src/handlers/common.rs
+++ b/rust_extension/src/handlers/common.rs
@@ -8,6 +8,7 @@ use std::num::NonZeroUsize;
 pub struct CommonBuilder {
     pub(crate) capacity: Option<NonZeroUsize>,
     pub(crate) capacity_set: bool,
+    pub(crate) formatter_id: Option<String>,
 }
 
 impl CommonBuilder {

--- a/rust_extension/src/handlers/common.rs
+++ b/rust_extension/src/handlers/common.rs
@@ -23,13 +23,6 @@ impl CommonBuilder {
         }
     }
 
-    pub(crate) fn ensure_non_zero_u64(
-        field: &str,
-        value: Option<u64>,
-    ) -> Result<(), super::HandlerBuildError> {
-        Self::ensure_non_zero(field, value)
-    }
-
     pub(crate) fn is_capacity_valid(&self) -> Result<(), super::HandlerBuildError> {
         if self.capacity.is_none() && self.capacity_set {
             Err(super::HandlerBuildError::InvalidConfig(

--- a/rust_extension/src/handlers/file_builder.rs
+++ b/rust_extension/src/handlers/file_builder.rs
@@ -54,12 +54,7 @@ impl FileHandlerBuilder {
     }
 
     fn is_flush_interval_valid(&self) -> Result<(), HandlerBuildError> {
-        match self.flush_interval {
-            Some(0) => Err(HandlerBuildError::InvalidConfig(
-                "flush_interval must be greater than zero".to_string(),
-            )),
-            _ => Ok(()),
-        }
+        CommonBuilder::ensure_non_zero("flush_interval", self.flush_interval.map(|v| v as u64))
     }
 
     fn validate(&self) -> Result<(), HandlerBuildError> {

--- a/rust_extension/src/handlers/file_builder.rs
+++ b/rust_extension/src/handlers/file_builder.rs
@@ -96,7 +96,6 @@ impl FileHandlerBuilder {
     fn py_new(path: String) -> Self {
         Self::new(path)
     }
-
     #[pyo3(name = "with_capacity")]
     fn py_with_capacity<'py>(mut slf: PyRefMut<'py, Self>, capacity: usize) -> PyRefMut<'py, Self> {
         slf.common.capacity = NonZeroUsize::new(capacity);

--- a/rust_extension/src/handlers/file_builder.rs
+++ b/rust_extension/src/handlers/file_builder.rs
@@ -126,7 +126,10 @@ impl FileHandlerBuilder {
         let policy = match self.overflow_policy {
             OverflowPolicy::Drop => "drop",
             OverflowPolicy::Block => "block",
-            OverflowPolicy::Timeout(_) => "timeout",
+            OverflowPolicy::Timeout(dur) => {
+                d.set_item("timeout_ms", dur.as_millis() as u64)?;
+                "timeout"
+            }
         };
         d.set_item("overflow_policy", policy)?;
         Ok(d.into())
@@ -181,12 +184,12 @@ mod tests {
     #[rstest]
     fn reject_zero_capacity() {
         let builder = FileHandlerBuilder::new("log.txt").with_capacity(0);
-        assert_build_err(builder, "build_inner must fail for zero capacity");
+        assert_build_err(&builder, "build_inner must fail for zero capacity");
     }
 
     #[rstest]
     fn reject_zero_flush_interval() {
         let builder = FileHandlerBuilder::new("log.txt").with_flush_interval(0);
-        assert_build_err(builder, "build_inner must fail for zero flush interval");
+        assert_build_err(&builder, "build_inner must fail for zero flush interval");
     }
 }

--- a/rust_extension/src/handlers/file_builder.rs
+++ b/rust_extension/src/handlers/file_builder.rs
@@ -49,21 +49,27 @@ impl FileHandlerBuilder {
         self
     }
 
+    fn is_capacity_valid(&self) -> Result<(), HandlerBuildError> {
+        match self.capacity {
+            Some(0) => Err(HandlerBuildError::InvalidConfig(
+                "capacity must be greater than zero".to_string(),
+            )),
+            _ => Ok(()),
+        }
+    }
+
+    fn is_flush_interval_valid(&self) -> Result<(), HandlerBuildError> {
+        match self.flush_interval {
+            Some(0) => Err(HandlerBuildError::InvalidConfig(
+                "flush_interval must be greater than zero".to_string(),
+            )),
+            _ => Ok(()),
+        }
+    }
+
     fn validate(&self) -> Result<(), HandlerBuildError> {
-        if let Some(cap) = self.capacity {
-            if cap == 0 {
-                return Err(HandlerBuildError::InvalidConfig(
-                    "capacity must be greater than zero".to_string(),
-                ));
-            }
-        }
-        if let Some(flush) = self.flush_interval {
-            if flush == 0 {
-                return Err(HandlerBuildError::InvalidConfig(
-                    "flush_interval must be greater than zero".to_string(),
-                ));
-            }
-        }
+        self.is_capacity_valid()?;
+        self.is_flush_interval_valid()?;
         Ok(())
     }
 
@@ -184,6 +190,12 @@ mod tests {
     #[rstest]
     fn reject_zero_capacity() {
         let builder = FileHandlerBuilder::new("log.txt").with_capacity(0);
+        assert!(builder.build_inner().is_err());
+    }
+
+    #[rstest]
+    fn reject_zero_flush_interval() {
+        let builder = FileHandlerBuilder::new("log.txt").with_flush_interval(0);
         assert!(builder.build_inner().is_err());
     }
 }

--- a/rust_extension/src/handlers/file_builder.rs
+++ b/rust_extension/src/handlers/file_builder.rs
@@ -1,0 +1,189 @@
+//! Builder for [`FemtoFileHandler`].
+//!
+//! Provides a fluent API for configuring a file based logging handler.
+//! Only a subset of options are currently supported; additional
+//! parameters such as encoding and mode will be added as the project
+//! evolves.
+
+use pyo3::prelude::*;
+
+use super::{file::*, HandlerBuildError, HandlerBuilderTrait};
+use crate::{formatter::DefaultFormatter, handler::FemtoHandlerTrait};
+
+/// Builder for constructing [`FemtoFileHandler`] instances.
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct FileHandlerBuilder {
+    path: String,
+    capacity: Option<usize>,
+    flush_interval: Option<usize>,
+    overflow_policy: OverflowPolicy,
+}
+
+impl FileHandlerBuilder {
+    /// Create a builder targeting the specified file path.
+    pub fn new(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            capacity: None,
+            flush_interval: None,
+            overflow_policy: OverflowPolicy::Drop,
+        }
+    }
+
+    /// Set the bounded channel capacity.
+    pub fn with_capacity(mut self, capacity: usize) -> Self {
+        self.capacity = Some(capacity);
+        self
+    }
+
+    /// Set the periodic flush interval.
+    pub fn with_flush_interval(mut self, interval: usize) -> Self {
+        self.flush_interval = Some(interval);
+        self
+    }
+
+    /// Set the overflow policy for the handler.
+    pub fn with_overflow_policy(mut self, policy: OverflowPolicy) -> Self {
+        self.overflow_policy = policy;
+        self
+    }
+
+    fn validate(&self) -> Result<(), HandlerBuildError> {
+        if let Some(cap) = self.capacity {
+            if cap == 0 {
+                return Err(HandlerBuildError::InvalidConfig(
+                    "capacity must be greater than zero".to_string(),
+                ));
+            }
+        }
+        if let Some(flush) = self.flush_interval {
+            if flush == 0 {
+                return Err(HandlerBuildError::InvalidConfig(
+                    "flush_interval must be greater than zero".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn build_inner(&self) -> Result<FemtoFileHandler, HandlerBuildError> {
+        self.validate()?;
+        let mut cfg = HandlerConfig::default();
+        if let Some(cap) = self.capacity {
+            cfg.capacity = cap;
+        }
+        if let Some(flush) = self.flush_interval {
+            cfg.flush_interval = flush;
+        }
+        cfg.overflow_policy = self.overflow_policy;
+        let handler =
+            FemtoFileHandler::with_capacity_flush_policy(&self.path, DefaultFormatter, cfg)?;
+        Ok(handler)
+    }
+}
+
+#[pymethods]
+impl FileHandlerBuilder {
+    #[new]
+    fn py_new(path: String) -> Self {
+        Self::new(path)
+    }
+
+    #[pyo3(name = "with_capacity")]
+    fn py_with_capacity<'py>(mut slf: PyRefMut<'py, Self>, capacity: usize) -> PyRefMut<'py, Self> {
+        slf.capacity = Some(capacity);
+        slf
+    }
+
+    #[pyo3(name = "with_flush_interval")]
+    fn py_with_flush_interval<'py>(
+        mut slf: PyRefMut<'py, Self>,
+        interval: usize,
+    ) -> PyRefMut<'py, Self> {
+        slf.flush_interval = Some(interval);
+        slf
+    }
+
+    #[pyo3(name = "with_overflow_policy")]
+    fn py_with_overflow_policy<'py>(
+        mut slf: PyRefMut<'py, Self>,
+        policy: &str,
+        timeout_ms: Option<u64>,
+    ) -> PyResult<PyRefMut<'py, Self>> {
+        slf.overflow_policy = match policy.to_ascii_lowercase().as_str() {
+            "drop" => OverflowPolicy::Drop,
+            "block" => OverflowPolicy::Block,
+            "timeout" => {
+                let ms = timeout_ms.ok_or_else(|| {
+                    PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                        "timeout_ms required for timeout policy",
+                    )
+                })?;
+                OverflowPolicy::Timeout(std::time::Duration::from_millis(ms))
+            }
+            other => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "invalid overflow policy: {other}",
+                )));
+            }
+        };
+        Ok(slf)
+    }
+
+    /// Return a dictionary describing the builder configuration.
+    fn as_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
+        use pyo3::types::PyDict;
+        let d = PyDict::new(py);
+        d.set_item("path", &self.path)?;
+        if let Some(cap) = self.capacity {
+            d.set_item("capacity", cap)?;
+        }
+        if let Some(flush) = self.flush_interval {
+            d.set_item("flush_interval", flush)?;
+        }
+        let policy = match self.overflow_policy {
+            OverflowPolicy::Drop => "drop",
+            OverflowPolicy::Block => "block",
+            OverflowPolicy::Timeout(_) => "timeout",
+        };
+        d.set_item("overflow_policy", policy)?;
+        Ok(d.into())
+    }
+
+    /// Build the handler, raising ``ValueError`` or ``OSError`` on failure.
+    fn build(&self) -> PyResult<FemtoFileHandler> {
+        self.build_inner().map_err(PyErr::from)
+    }
+}
+
+impl HandlerBuilderTrait for FileHandlerBuilder {
+    fn build(&self) -> Result<Box<dyn FemtoHandlerTrait>, HandlerBuildError> {
+        let handler = self.build_inner()?;
+        Ok(Box::new(handler))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use tempfile::tempdir;
+
+    #[rstest]
+    fn build_file_handler() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.log");
+        let builder = FileHandlerBuilder::new(path.to_string_lossy())
+            .with_capacity(16)
+            .with_flush_interval(1);
+        let handler = builder.build_inner().unwrap();
+        handler.flush();
+    }
+
+    #[rstest]
+    fn reject_zero_capacity() {
+        let builder = FileHandlerBuilder::new("log.txt").with_capacity(0);
+        assert!(builder.build_inner().is_err());
+    }
+}

--- a/rust_extension/src/handlers/mod.rs
+++ b/rust_extension/src/handlers/mod.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 
 use crate::handler::FemtoHandlerTrait;
 
+mod common;
 pub mod file;
 pub mod file_builder;
 pub mod stream_builder;

--- a/rust_extension/src/handlers/mod.rs
+++ b/rust_extension/src/handlers/mod.rs
@@ -1,0 +1,49 @@
+//! Handler builders and associated traits.
+//!
+//! Provides a minimal builder API for constructing handlers in a
+//! type‑safe manner. Each builder implements [`HandlerBuilderTrait`]
+//! which returns a boxed [`FemtoHandlerTrait`] ready for registration
+//! with a logger.
+
+use std::io;
+
+use thiserror::Error;
+
+use crate::handler::FemtoHandlerTrait;
+
+pub mod file;
+pub mod file_builder;
+pub mod stream_builder;
+
+pub use file_builder::FileHandlerBuilder;
+pub use stream_builder::StreamHandlerBuilder;
+
+/// Errors that may occur while building a handler.
+#[derive(Debug, Error)]
+pub enum HandlerBuildError {
+    /// Invalid user supplied configuration.
+    #[error("invalid handler configuration: {0}")]
+    InvalidConfig(String),
+    /// Underlying I/O error whilst creating the handler.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+impl From<HandlerBuildError> for pyo3::PyErr {
+    fn from(err: HandlerBuildError) -> Self {
+        use pyo3::exceptions::{PyIOError, PyValueError};
+        match err {
+            HandlerBuildError::InvalidConfig(msg) => PyValueError::new_err(msg),
+            HandlerBuildError::Io(ioe) => PyIOError::new_err(ioe.to_string()),
+        }
+    }
+}
+
+/// Trait implemented by all handler builders.
+///
+/// Builders return boxed [`FemtoHandlerTrait`] objects so the caller can
+/// register them without knowing the concrete handler type.
+pub trait HandlerBuilderTrait: Send + Sync {
+    /// Build the handler instance.
+    fn build(&self) -> Result<Box<dyn FemtoHandlerTrait>, HandlerBuildError>;
+}

--- a/rust_extension/src/handlers/mod.rs
+++ b/rust_extension/src/handlers/mod.rs
@@ -7,6 +7,7 @@
 
 use std::io;
 
+use pyo3::create_exception;
 use thiserror::Error;
 
 use crate::handler::FemtoHandlerTrait;
@@ -15,9 +16,23 @@ mod common;
 pub mod file;
 pub mod file_builder;
 pub mod stream_builder;
+#[cfg(test)]
+pub mod test_helpers;
 
 pub use file_builder::FileHandlerBuilder;
 pub use stream_builder::StreamHandlerBuilder;
+
+// Define module-level Python exceptions for explicit handling on the Python side.
+create_exception!(
+    _femtologging_rs,
+    HandlerConfigError,
+    pyo3::exceptions::PyException
+);
+create_exception!(
+    _femtologging_rs,
+    HandlerIOError,
+    pyo3::exceptions::PyException
+);
 
 /// Errors that may occur while building a handler.
 #[derive(Debug, Error)]
@@ -32,10 +47,9 @@ pub enum HandlerBuildError {
 
 impl From<HandlerBuildError> for pyo3::PyErr {
     fn from(err: HandlerBuildError) -> Self {
-        use pyo3::exceptions::{PyIOError, PyValueError};
         match err {
-            HandlerBuildError::InvalidConfig(msg) => PyValueError::new_err(msg),
-            HandlerBuildError::Io(ioe) => PyIOError::new_err(ioe.to_string()),
+            HandlerBuildError::InvalidConfig(msg) => HandlerConfigError::new_err(msg),
+            HandlerBuildError::Io(ioe) => HandlerIOError::new_err(ioe.to_string()),
         }
     }
 }
@@ -45,6 +59,13 @@ impl From<HandlerBuildError> for pyo3::PyErr {
 /// Builders return boxed [`FemtoHandlerTrait`] objects so the caller can
 /// register them without knowing the concrete handler type.
 pub trait HandlerBuilderTrait: Send + Sync {
-    /// Build the handler instance.
-    fn build(&self) -> Result<Box<dyn FemtoHandlerTrait>, HandlerBuildError>;
+    type Handler: FemtoHandlerTrait;
+
+    fn build_inner(&self) -> Result<Self::Handler, HandlerBuildError>;
+
+    /// Build the handler instance, returning a boxed trait object.
+    fn build(&self) -> Result<Box<dyn FemtoHandlerTrait>, HandlerBuildError> {
+        let handler = self.build_inner()?;
+        Ok(Box::new(handler))
+    }
 }

--- a/rust_extension/src/handlers/stream_builder.rs
+++ b/rust_extension/src/handlers/stream_builder.rs
@@ -176,12 +176,12 @@ mod tests {
     #[rstest]
     fn reject_zero_capacity() {
         let builder = StreamHandlerBuilder::stderr().with_capacity(0);
-        assert_build_err(builder, "build_inner must fail for zero capacity");
+        assert_build_err(&builder, "build_inner must fail for zero capacity");
     }
 
     #[rstest]
     fn reject_zero_flush_timeout() {
         let builder = StreamHandlerBuilder::stdout().with_flush_timeout_ms(0);
-        assert_build_err(builder, "build_inner must fail for zero flush timeout");
+        assert_build_err(&builder, "build_inner must fail for zero flush timeout");
     }
 }

--- a/rust_extension/src/handlers/stream_builder.rs
+++ b/rust_extension/src/handlers/stream_builder.rs
@@ -1,0 +1,179 @@
+//! Builder for [`FemtoStreamHandler`].
+//!
+//! Allows configuration of stream based handlers writing to `stdout` or
+//! `stderr`. The builder exposes basic tuning for channel capacity and
+//! flush timeout.
+
+use std::time::Duration;
+
+use pyo3::prelude::*;
+
+use super::{HandlerBuildError, HandlerBuilderTrait};
+use crate::{
+    formatter::DefaultFormatter, handler::FemtoHandlerTrait, stream_handler::FemtoStreamHandler,
+};
+
+#[derive(Clone, Copy, Debug)]
+enum StreamTarget {
+    Stdout,
+    Stderr,
+}
+
+/// Builder for constructing [`FemtoStreamHandler`] instances.
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct StreamHandlerBuilder {
+    target: StreamTarget,
+    capacity: Option<usize>,
+    flush_timeout_ms: Option<u64>,
+}
+
+impl StreamHandlerBuilder {
+    /// Create a builder targeting `stdout`.
+    pub fn stdout() -> Self {
+        Self {
+            target: StreamTarget::Stdout,
+            capacity: None,
+            flush_timeout_ms: None,
+        }
+    }
+
+    /// Create a builder targeting `stderr`.
+    pub fn stderr() -> Self {
+        Self {
+            target: StreamTarget::Stderr,
+            capacity: None,
+            flush_timeout_ms: None,
+        }
+    }
+
+    /// Set the bounded channel capacity.
+    pub fn with_capacity(mut self, capacity: usize) -> Self {
+        self.capacity = Some(capacity);
+        self
+    }
+
+    /// Set the flush timeout in milliseconds.
+    pub fn with_flush_timeout(mut self, timeout_ms: u64) -> Self {
+        self.flush_timeout_ms = Some(timeout_ms);
+        self
+    }
+
+    fn validate(&self) -> Result<(), HandlerBuildError> {
+        if let Some(cap) = self.capacity {
+            if cap == 0 {
+                return Err(HandlerBuildError::InvalidConfig(
+                    "capacity must be greater than zero".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn build_inner(&self) -> Result<FemtoStreamHandler, HandlerBuildError> {
+        self.validate()?;
+        let capacity = self.capacity.unwrap_or(1024);
+        let timeout = Duration::from_millis(self.flush_timeout_ms.unwrap_or(1000));
+        let handler = match self.target {
+            StreamTarget::Stdout => FemtoStreamHandler::with_capacity_timeout(
+                std::io::stdout(),
+                DefaultFormatter,
+                capacity,
+                timeout,
+            ),
+            StreamTarget::Stderr => FemtoStreamHandler::with_capacity_timeout(
+                std::io::stderr(),
+                DefaultFormatter,
+                capacity,
+                timeout,
+            ),
+        };
+        Ok(handler)
+    }
+}
+
+#[pymethods]
+impl StreamHandlerBuilder {
+    #[new]
+    fn py_new() -> Self {
+        Self::stderr()
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "stdout")]
+    fn py_stdout() -> Self {
+        Self::stdout()
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "stderr")]
+    fn py_stderr() -> Self {
+        Self::stderr()
+    }
+
+    #[pyo3(name = "with_capacity")]
+    fn py_with_capacity<'py>(mut slf: PyRefMut<'py, Self>, capacity: usize) -> PyRefMut<'py, Self> {
+        slf.capacity = Some(capacity);
+        slf
+    }
+
+    #[pyo3(name = "with_flush_timeout_ms")]
+    fn py_with_flush_timeout<'py>(
+        mut slf: PyRefMut<'py, Self>,
+        timeout_ms: u64,
+    ) -> PyRefMut<'py, Self> {
+        slf.flush_timeout_ms = Some(timeout_ms);
+        slf
+    }
+
+    /// Return a dictionary describing the builder configuration.
+    fn as_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
+        use pyo3::types::PyDict;
+        let d = PyDict::new(py);
+        d.set_item(
+            "target",
+            match self.target {
+                StreamTarget::Stdout => "stdout",
+                StreamTarget::Stderr => "stderr",
+            },
+        )?;
+        if let Some(cap) = self.capacity {
+            d.set_item("capacity", cap)?;
+        }
+        if let Some(ms) = self.flush_timeout_ms {
+            d.set_item("flush_timeout_ms", ms)?;
+        }
+        Ok(d.into())
+    }
+
+    /// Build the handler, raising ``ValueError`` on failure.
+    fn build(&self) -> PyResult<FemtoStreamHandler> {
+        self.build_inner().map_err(PyErr::from)
+    }
+}
+
+impl HandlerBuilderTrait for StreamHandlerBuilder {
+    fn build(&self) -> Result<Box<dyn FemtoHandlerTrait>, HandlerBuildError> {
+        let handler = self.build_inner()?;
+        Ok(Box::new(handler))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    fn build_stream_handler_stdout() {
+        let builder = StreamHandlerBuilder::stdout().with_capacity(8);
+        let handler = builder.build_inner().unwrap();
+        handler.flush();
+    }
+
+    #[rstest]
+    fn reject_zero_capacity() {
+        let builder = StreamHandlerBuilder::stderr().with_capacity(0);
+        assert!(builder.build_inner().is_err());
+    }
+}

--- a/rust_extension/src/handlers/stream_builder.rs
+++ b/rust_extension/src/handlers/stream_builder.rs
@@ -63,7 +63,7 @@ impl StreamHandlerBuilder {
     }
 
     fn is_flush_timeout_valid(&self) -> Result<(), HandlerBuildError> {
-        CommonBuilder::ensure_non_zero_u64("flush_timeout_ms", self.flush_timeout_ms)
+        CommonBuilder::ensure_non_zero("flush_timeout_ms", self.flush_timeout_ms)
     }
 
     fn validate(&self) -> Result<(), HandlerBuildError> {
@@ -167,24 +167,30 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    fn build_stream_handler_stdout() {
-        let builder = StreamHandlerBuilder::stdout().with_capacity(8);
+    #[case(StreamHandlerBuilder::stdout())]
+    #[case(StreamHandlerBuilder::stderr())]
+    fn build_stream_handler_with_capacity(#[case] builder: StreamHandlerBuilder) {
+        let builder = builder.with_capacity(8);
         let mut handler = builder
             .build_inner()
-            .expect("build_inner must succeed for a valid stdout builder");
+            .expect("build_inner must succeed for a valid builder");
         handler.flush();
         handler.close();
     }
 
     #[rstest]
-    fn reject_zero_capacity() {
-        let builder = StreamHandlerBuilder::stderr().with_capacity(0);
+    #[case(StreamHandlerBuilder::stdout())]
+    #[case(StreamHandlerBuilder::stderr())]
+    fn reject_zero_capacity(#[case] builder: StreamHandlerBuilder) {
+        let builder = builder.with_capacity(0);
         assert_build_err(&builder, "build_inner must fail for zero capacity");
     }
 
     #[rstest]
-    fn reject_zero_flush_timeout() {
-        let builder = StreamHandlerBuilder::stdout().with_flush_timeout_ms(0);
+    #[case(StreamHandlerBuilder::stdout())]
+    #[case(StreamHandlerBuilder::stderr())]
+    fn reject_zero_flush_timeout(#[case] builder: StreamHandlerBuilder) {
+        let builder = builder.with_flush_timeout_ms(0);
         assert_build_err(&builder, "build_inner must fail for zero flush timeout");
     }
 }

--- a/rust_extension/src/handlers/stream_builder.rs
+++ b/rust_extension/src/handlers/stream_builder.rs
@@ -64,12 +64,7 @@ impl StreamHandlerBuilder {
     }
 
     fn is_flush_timeout_valid(&self) -> Result<(), HandlerBuildError> {
-        match self.flush_timeout_ms {
-            Some(0) => Err(HandlerBuildError::InvalidConfig(
-                "flush_timeout_ms must be greater than zero".to_string(),
-            )),
-            _ => Ok(()),
-        }
+        CommonBuilder::ensure_non_zero("flush_timeout_ms", self.flush_timeout_ms)
     }
 
     fn validate(&self) -> Result<(), HandlerBuildError> {

--- a/rust_extension/src/handlers/test_helpers.rs
+++ b/rust_extension/src/handlers/test_helpers.rs
@@ -1,0 +1,17 @@
+#![cfg(test)]
+//! Test helpers for handler builders.
+//!
+//! This module centralises repeated assertions used across builder tests.
+
+use super::HandlerBuilderTrait;
+
+/// Assert that building a handler fails.
+///
+/// Reduces duplication by wrapping the common assertion that
+/// `build_inner` returns an error for invalid configurations.
+pub fn assert_build_err<B>(builder: B, msg: &str)
+where
+    B: HandlerBuilderTrait,
+{
+    assert!(builder.build_inner().is_err(), "{msg}");
+}

--- a/rust_extension/src/handlers/test_helpers.rs
+++ b/rust_extension/src/handlers/test_helpers.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 //! Test helpers for handler builders.
 //!
-//! This module centralises repeated assertions used across builder tests.
+//! This module centralizes repeated assertions used across builder tests.
 
 use super::HandlerBuilderTrait;
 

--- a/rust_extension/src/handlers/test_helpers.rs
+++ b/rust_extension/src/handlers/test_helpers.rs
@@ -9,9 +9,9 @@ use super::HandlerBuilderTrait;
 ///
 /// Reduces duplication by wrapping the common assertion that
 /// `build_inner` returns an error for invalid configurations.
-pub fn assert_build_err<B>(builder: B, msg: &str)
+pub fn assert_build_err<B>(builder: &B, msg: &str)
 where
-    B: HandlerBuilderTrait,
+    B: HandlerBuilderTrait + ?Sized,
 {
     assert!(builder.build_inner().is_err(), "{msg}");
 }

--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -1,11 +1,9 @@
 use pyo3::prelude::*;
 
-mod handlers {
-    pub mod file;
-}
 mod config;
 mod formatter;
 mod handler;
+mod handlers;
 mod level;
 mod log_record;
 mod logger;
@@ -20,8 +18,9 @@ mod stream_handler;
 pub use config::{ConfigBuilder, FormatterBuilder, LoggerConfigBuilder};
 pub use formatter::{DefaultFormatter, FemtoFormatter};
 pub use handler::{FemtoHandler, FemtoHandlerTrait};
-pub use handlers::file::{
-    FemtoFileHandler, HandlerConfig, OverflowPolicy, PyHandlerConfig, TestConfig,
+pub use handlers::{
+    file::{FemtoFileHandler, HandlerConfig, OverflowPolicy, PyHandlerConfig, TestConfig},
+    FileHandlerBuilder, HandlerBuilderTrait, StreamHandlerBuilder,
 };
 pub use level::FemtoLevel;
 pub use log_record::{FemtoLogRecord, RecordMetadata};
@@ -50,6 +49,8 @@ fn _femtologging_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<FemtoHandler>()?;
     m.add_class::<FemtoStreamHandler>()?;
     m.add_class::<FemtoFileHandler>()?;
+    m.add_class::<StreamHandlerBuilder>()?;
+    m.add_class::<FileHandlerBuilder>()?;
     m.add_class::<PyHandlerConfig>()?;
     m.add_class::<ConfigBuilder>()?;
     m.add_class::<LoggerConfigBuilder>()?;

--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -20,7 +20,8 @@ pub use formatter::{DefaultFormatter, FemtoFormatter};
 pub use handler::{FemtoHandler, FemtoHandlerTrait};
 pub use handlers::{
     file::{FemtoFileHandler, HandlerConfig, OverflowPolicy, PyHandlerConfig, TestConfig},
-    FileHandlerBuilder, HandlerBuilderTrait, StreamHandlerBuilder,
+    FileHandlerBuilder, HandlerBuilderTrait, HandlerConfigError, HandlerIOError,
+    StreamHandlerBuilder,
 };
 pub use level::FemtoLevel;
 pub use log_record::{FemtoLogRecord, RecordMetadata};
@@ -45,12 +46,15 @@ fn reset_manager_py() {
 
 #[pymodule]
 fn _femtologging_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    let py = m.py();
     m.add_class::<FemtoLogger>()?;
     m.add_class::<FemtoHandler>()?;
     m.add_class::<FemtoStreamHandler>()?;
     m.add_class::<FemtoFileHandler>()?;
     m.add_class::<StreamHandlerBuilder>()?;
     m.add_class::<FileHandlerBuilder>()?;
+    m.add("HandlerConfigError", py.get_type::<HandlerConfigError>())?;
+    m.add("HandlerIOError", py.get_type::<HandlerIOError>())?;
     m.add_class::<PyHandlerConfig>()?;
     m.add_class::<ConfigBuilder>()?;
     m.add_class::<LoggerConfigBuilder>()?;

--- a/tests/__snapshots__/test_handler_builders.ambr
+++ b/tests/__snapshots__/test_handler_builders.ambr
@@ -2,7 +2,7 @@
 # name: test_build_file_handler_builder
   dict({
     'capacity': 10,
-    'flush_interval': 2,
+    'flush_record_interval': 2,
     'overflow_policy': 'drop',
     'path': 'test.log',
   })

--- a/tests/__snapshots__/test_handler_builders.ambr
+++ b/tests/__snapshots__/test_handler_builders.ambr
@@ -13,6 +13,12 @@
     'target': 'stdout',
   })
 # ---
+# name: test_build_stream_handler_builder_with_flush_timeout
+  dict({
+    'flush_timeout_ms': 250,
+    'target': 'stdout',
+  })
+# ---
 # name: test_file_handler_builder_with_timeout_overflow_policy
   dict({
     'overflow_policy': 'timeout',

--- a/tests/__snapshots__/test_handler_builders.ambr
+++ b/tests/__snapshots__/test_handler_builders.ambr
@@ -3,6 +3,7 @@
   dict({
     'capacity': 10,
     'flush_record_interval': 2,
+    'formatter_id': 'default',
     'overflow_policy': 'drop',
     'path': 'test.log',
   })
@@ -10,12 +11,14 @@
 # name: test_build_stream_handler_builder
   dict({
     'capacity': 8,
+    'formatter_id': 'default',
     'target': 'stdout',
   })
 # ---
 # name: test_build_stream_handler_builder_with_flush_timeout
   dict({
     'flush_timeout_ms': 250,
+    'formatter_id': 'default',
     'target': 'stdout',
   })
 # ---

--- a/tests/__snapshots__/test_handler_builders.ambr
+++ b/tests/__snapshots__/test_handler_builders.ambr
@@ -13,3 +13,10 @@
     'target': 'stdout',
   })
 # ---
+# name: test_file_handler_builder_with_timeout_overflow_policy
+  dict({
+    'overflow_policy': 'timeout',
+    'path': 'test.log',
+    'timeout_ms': 500,
+  })
+# ---

--- a/tests/__snapshots__/test_handler_builders.ambr
+++ b/tests/__snapshots__/test_handler_builders.ambr
@@ -1,0 +1,15 @@
+# serializer version: 1
+# name: test_build_file_handler_builder
+  dict({
+    'capacity': 10,
+    'flush_interval': 2,
+    'overflow_policy': 'drop',
+    'path': 'test.log',
+  })
+# ---
+# name: test_build_stream_handler_builder
+  dict({
+    'capacity': 8,
+    'target': 'stdout',
+  })
+# ---

--- a/tests/features/handler_builders.feature
+++ b/tests/features/handler_builders.feature
@@ -34,3 +34,8 @@ Feature: Handler builders
     Given a StreamHandlerBuilder targeting stdout
     When I set stream flush timeout 0
     Then building the stream handler fails
+
+  Scenario: build stream handler builder with flush timeout
+    Given a StreamHandlerBuilder targeting stdout
+    When I set stream flush timeout 250
+    Then the stream handler builder matches snapshot

--- a/tests/features/handler_builders.feature
+++ b/tests/features/handler_builders.feature
@@ -19,3 +19,8 @@ Feature: Handler builders
     Given a StreamHandlerBuilder targeting stderr
     When I set stream capacity 0
     Then building the stream handler fails
+
+  Scenario: invalid stream handler flush timeout
+    Given a StreamHandlerBuilder targeting stdout
+    When I set stream flush timeout 0
+    Then building the stream handler fails

--- a/tests/features/handler_builders.feature
+++ b/tests/features/handler_builders.feature
@@ -1,0 +1,21 @@
+Feature: Handler builders
+  Scenario: build file handler builder
+    Given a FileHandlerBuilder for path "test.log"
+    When I set file capacity 10
+    And I set flush interval 2
+    Then the file handler builder matches snapshot
+
+  Scenario: invalid file handler capacity
+    Given a FileHandlerBuilder for path "test.log"
+    When I set file capacity 0
+    Then building the file handler fails
+
+  Scenario: build stream handler builder
+    Given a StreamHandlerBuilder targeting stdout
+    When I set stream capacity 8
+    Then the stream handler builder matches snapshot
+
+  Scenario: invalid stream handler capacity
+    Given a StreamHandlerBuilder targeting stderr
+    When I set stream capacity 0
+    Then building the stream handler fails

--- a/tests/features/handler_builders.feature
+++ b/tests/features/handler_builders.feature
@@ -45,5 +45,4 @@ Feature: Handler builders
 
   Scenario: invalid stream handler negative flush timeout
     Given a StreamHandlerBuilder targeting stdout
-    When I set stream flush timeout -1
-    Then building the stream handler fails
+    Then setting stream flush timeout -1 fails

--- a/tests/features/handler_builders.feature
+++ b/tests/features/handler_builders.feature
@@ -5,9 +5,19 @@ Feature: Handler builders
     And I set flush interval 2
     Then the file handler builder matches snapshot
 
+  Scenario: file handler builder with timeout overflow policy
+    Given a FileHandlerBuilder for path "test.log"
+    When I set overflow policy to timeout with 500ms
+    Then the file handler builder with timeout overflow matches snapshot
+
   Scenario: invalid file handler capacity
     Given a FileHandlerBuilder for path "test.log"
     When I set file capacity 0
+    Then building the file handler fails
+
+  Scenario: invalid file handler flush interval
+    Given a FileHandlerBuilder for path "test.log"
+    When I set flush interval 0
     Then building the file handler fails
 
   Scenario: build stream handler builder

--- a/tests/features/handler_builders.feature
+++ b/tests/features/handler_builders.feature
@@ -3,6 +3,7 @@ Feature: Handler builders
     Given a FileHandlerBuilder for path "test.log"
     When I set file capacity 10
     And I set flush record interval 2
+    And I set file formatter "default"
     Then the file handler builder matches snapshot
 
   Scenario: file handler builder with timeout overflow policy
@@ -23,6 +24,7 @@ Feature: Handler builders
   Scenario: build stream handler builder
     Given a StreamHandlerBuilder targeting stdout
     When I set stream capacity 8
+    And I set stream formatter "default"
     Then the stream handler builder matches snapshot
 
   Scenario: invalid stream handler capacity
@@ -38,4 +40,10 @@ Feature: Handler builders
   Scenario: build stream handler builder with flush timeout
     Given a StreamHandlerBuilder targeting stdout
     When I set stream flush timeout 250
+    And I set stream formatter "default"
     Then the stream handler builder matches snapshot
+
+  Scenario: invalid stream handler negative flush timeout
+    Given a StreamHandlerBuilder targeting stdout
+    When I set stream flush timeout -1
+    Then building the stream handler fails

--- a/tests/features/handler_builders.feature
+++ b/tests/features/handler_builders.feature
@@ -2,7 +2,7 @@ Feature: Handler builders
   Scenario: build file handler builder
     Given a FileHandlerBuilder for path "test.log"
     When I set file capacity 10
-    And I set flush interval 2
+    And I set flush record interval 2
     Then the file handler builder matches snapshot
 
   Scenario: file handler builder with timeout overflow policy
@@ -15,9 +15,9 @@ Feature: Handler builders
     When I set file capacity 0
     Then building the file handler fails
 
-  Scenario: invalid file handler flush interval
+  Scenario: invalid file handler flush record interval
     Given a FileHandlerBuilder for path "test.log"
-    When I set flush interval 0
+    When I set flush record interval 0
     Then building the file handler fails
 
   Scenario: build stream handler builder

--- a/tests/test_handler_builders.py
+++ b/tests/test_handler_builders.py
@@ -55,9 +55,11 @@ def when_set_stream_flush_timeout(
     stream_builder.with_flush_timeout_ms(timeout)
 
 
-@when(parsers.parse("I set flush interval {interval:d}"))
-def when_set_flush_interval(file_builder: FileHandlerBuilder, interval: int) -> None:
-    file_builder.with_flush_interval(interval)
+@when(parsers.parse("I set flush record interval {interval:d}"))
+def when_set_flush_record_interval(
+    file_builder: FileHandlerBuilder, interval: int
+) -> None:
+    file_builder.with_flush_record_interval(interval)
 
 
 @when("I set overflow policy to timeout with 500ms")

--- a/tests/test_handler_builders.py
+++ b/tests/test_handler_builders.py
@@ -37,34 +37,52 @@ def given_stream_stderr() -> StreamHandlerBuilder:
 
 
 @when(parsers.parse("I set file capacity {capacity:d}"))
-def when_set_file_capacity(file_builder: FileHandlerBuilder, capacity: int) -> None:
-    file_builder.with_capacity(capacity)
+def when_set_file_capacity(
+    file_builder: FileHandlerBuilder, capacity: int
+) -> FileHandlerBuilder:
+    return file_builder.with_capacity(capacity)
 
 
 @when(parsers.parse("I set stream capacity {capacity:d}"))
 def when_set_stream_capacity(
     stream_builder: StreamHandlerBuilder, capacity: int
-) -> None:
-    stream_builder.with_capacity(capacity)
+) -> StreamHandlerBuilder:
+    return stream_builder.with_capacity(capacity)
 
 
 @when(parsers.parse("I set stream flush timeout {timeout:d}"))
 def when_set_stream_flush_timeout(
     stream_builder: StreamHandlerBuilder, timeout: int
-) -> None:
-    stream_builder.with_flush_timeout_ms(timeout)
+) -> StreamHandlerBuilder:
+    return stream_builder.with_flush_timeout_ms(timeout)
 
 
 @when(parsers.parse("I set flush record interval {interval:d}"))
 def when_set_flush_record_interval(
     file_builder: FileHandlerBuilder, interval: int
-) -> None:
-    file_builder.with_flush_record_interval(interval)
+) -> FileHandlerBuilder:
+    return file_builder.with_flush_record_interval(interval)
 
 
 @when("I set overflow policy to timeout with 500ms")
-def when_set_overflow_policy_timeout(file_builder: FileHandlerBuilder) -> None:
-    file_builder.with_overflow_policy("timeout", timeout_ms=500)
+def when_set_overflow_policy_timeout(
+    file_builder: FileHandlerBuilder,
+) -> FileHandlerBuilder:
+    return file_builder.with_overflow_policy("timeout", timeout_ms=500)
+
+
+@when(parsers.parse('I set file formatter "{formatter_id}"'))
+def when_set_file_formatter(
+    file_builder: FileHandlerBuilder, formatter_id: str
+) -> FileHandlerBuilder:
+    return file_builder.with_formatter(formatter_id)
+
+
+@when(parsers.parse('I set stream formatter "{formatter_id}"'))
+def when_set_stream_formatter(
+    stream_builder: StreamHandlerBuilder, formatter_id: str
+) -> StreamHandlerBuilder:
+    return stream_builder.with_formatter(formatter_id)
 
 
 @then("the file handler builder matches snapshot")

--- a/tests/test_handler_builders.py
+++ b/tests/test_handler_builders.py
@@ -1,3 +1,9 @@
+"""Behaviour-driven tests for FileHandlerBuilder and StreamHandlerBuilder.
+
+Scenarios cover capacity and interval configuration, dictionary snapshots,
+and build-time failures.
+"""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/test_handler_builders.py
+++ b/tests/test_handler_builders.py
@@ -111,7 +111,10 @@ def then_stream_builder_fails(stream_builder: StreamHandlerBuilder) -> None:
         stream_builder.build()
 
 
-def test_stream_builder_negative_capacity() -> None:
-    builder = StreamHandlerBuilder.stdout()
+@pytest.mark.parametrize(
+    "ctor", [StreamHandlerBuilder.stdout, StreamHandlerBuilder.stderr]
+)
+def test_stream_builder_negative_capacity(ctor) -> None:
+    builder = ctor()
     with pytest.raises(OverflowError):
         builder.with_capacity(-1)

--- a/tests/test_handler_builders.py
+++ b/tests/test_handler_builders.py
@@ -131,6 +131,14 @@ def then_stream_builder_fails(stream_builder: StreamHandlerBuilder) -> None:
         stream_builder.build()
 
 
+@then(parsers.parse("setting stream flush timeout {timeout:d} fails"))
+def then_setting_stream_flush_timeout_fails(
+    stream_builder: StreamHandlerBuilder, timeout: int
+) -> None:
+    with pytest.raises(OverflowError):
+        stream_builder.with_flush_timeout_ms(timeout)
+
+
 @pytest.mark.parametrize(
     "ctor", [StreamHandlerBuilder.stdout, StreamHandlerBuilder.stderr]
 )

--- a/tests/test_handler_builders.py
+++ b/tests/test_handler_builders.py
@@ -55,16 +55,34 @@ def when_set_stream_flush_timeout(
     stream_builder.with_flush_timeout_ms(timeout)
 
 
-@when("I set flush interval 2")
-def when_set_flush_interval(file_builder: FileHandlerBuilder) -> None:
-    file_builder.with_flush_interval(2)
+@when(parsers.parse("I set flush interval {interval:d}"))
+def when_set_flush_interval(file_builder: FileHandlerBuilder, interval: int) -> None:
+    file_builder.with_flush_interval(interval)
+
+
+@when("I set overflow policy to timeout with 500ms")
+def when_set_overflow_policy_timeout(file_builder: FileHandlerBuilder) -> None:
+    file_builder.with_overflow_policy("timeout", timeout_ms=500)
 
 
 @then("the file handler builder matches snapshot")
 def then_file_builder_snapshot(file_builder: FileHandlerBuilder, snapshot) -> None:
     data = file_builder.as_dict()
     data["path"] = Path(data["path"]).name
-    assert data == snapshot
+    assert data == snapshot, "file builder dict must match snapshot"
+    handler = file_builder.build()
+    handler.close()
+
+
+@then("the file handler builder with timeout overflow matches snapshot")
+def then_file_builder_timeout_snapshot(
+    file_builder: FileHandlerBuilder, snapshot
+) -> None:
+    data = file_builder.as_dict()
+    data["path"] = Path(data["path"]).name
+    assert data["overflow_policy"] == "timeout", "must record timeout policy"
+    assert data["timeout_ms"] == 500, "must record configured timeout"
+    assert data == snapshot, "snapshot must include timeout fields"
     handler = file_builder.build()
     handler.close()
 
@@ -79,7 +97,9 @@ def then_file_builder_fails(file_builder: FileHandlerBuilder) -> None:
 def then_stream_builder_snapshot(
     stream_builder: StreamHandlerBuilder, snapshot
 ) -> None:
-    assert stream_builder.as_dict() == snapshot
+    assert stream_builder.as_dict() == snapshot, (
+        "stream builder dict must match snapshot"
+    )
     handler = stream_builder.build()
     handler.flush()
     handler.close()

--- a/tests/test_handler_builders.py
+++ b/tests/test_handler_builders.py
@@ -41,6 +41,13 @@ def when_set_stream_capacity(
     stream_builder.with_capacity(capacity)
 
 
+@when(parsers.parse("I set stream flush timeout {timeout:d}"))
+def when_set_stream_flush_timeout(
+    stream_builder: StreamHandlerBuilder, timeout: int
+) -> None:
+    stream_builder.with_flush_timeout_ms(timeout)
+
+
 @when("I set flush interval 2")
 def when_set_flush_interval(file_builder: FileHandlerBuilder) -> None:
     file_builder.with_flush_interval(2)
@@ -68,9 +75,16 @@ def then_stream_builder_snapshot(
     assert stream_builder.as_dict() == snapshot
     handler = stream_builder.build()
     handler.flush()
+    handler.close()
 
 
 @then("building the stream handler fails")
 def then_stream_builder_fails(stream_builder: StreamHandlerBuilder) -> None:
     with pytest.raises(ValueError):
         stream_builder.build()
+
+
+def test_stream_builder_negative_capacity() -> None:
+    builder = StreamHandlerBuilder.stdout()
+    with pytest.raises(OverflowError):
+        builder.with_capacity(-1)

--- a/tests/test_handler_builders.py
+++ b/tests/test_handler_builders.py
@@ -14,6 +14,7 @@ from pytest_bdd import given, scenarios, then, when, parsers
 from femtologging import (
     FileHandlerBuilder,
     StreamHandlerBuilder,
+    HandlerConfigError,
 )
 
 scenarios("features/handler_builders.feature")
@@ -70,7 +71,7 @@ def then_file_builder_snapshot(file_builder: FileHandlerBuilder, snapshot) -> No
 
 @then("building the file handler fails")
 def then_file_builder_fails(file_builder: FileHandlerBuilder) -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(HandlerConfigError):
         file_builder.build()
 
 
@@ -86,7 +87,7 @@ def then_stream_builder_snapshot(
 
 @then("building the stream handler fails")
 def then_stream_builder_fails(stream_builder: StreamHandlerBuilder) -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(HandlerConfigError):
         stream_builder.build()
 
 

--- a/tests/test_handler_builders.py
+++ b/tests/test_handler_builders.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pytest_bdd import given, scenarios, then, when, parsers
+
+from femtologging import (
+    FileHandlerBuilder,
+    StreamHandlerBuilder,
+)
+
+scenarios("features/handler_builders.feature")
+
+
+@given('a FileHandlerBuilder for path "test.log"', target_fixture="file_builder")
+def given_file_builder(tmp_path) -> FileHandlerBuilder:
+    path = tmp_path / "test.log"
+    return FileHandlerBuilder(str(path))
+
+
+@given("a StreamHandlerBuilder targeting stdout", target_fixture="stream_builder")
+def given_stream_stdout() -> StreamHandlerBuilder:
+    return StreamHandlerBuilder.stdout()
+
+
+@given("a StreamHandlerBuilder targeting stderr", target_fixture="stream_builder")
+def given_stream_stderr() -> StreamHandlerBuilder:
+    return StreamHandlerBuilder.stderr()
+
+
+@when(parsers.parse("I set file capacity {capacity:d}"))
+def when_set_file_capacity(file_builder: FileHandlerBuilder, capacity: int) -> None:
+    file_builder.with_capacity(capacity)
+
+
+@when(parsers.parse("I set stream capacity {capacity:d}"))
+def when_set_stream_capacity(
+    stream_builder: StreamHandlerBuilder, capacity: int
+) -> None:
+    stream_builder.with_capacity(capacity)
+
+
+@when("I set flush interval 2")
+def when_set_flush_interval(file_builder: FileHandlerBuilder) -> None:
+    file_builder.with_flush_interval(2)
+
+
+@then("the file handler builder matches snapshot")
+def then_file_builder_snapshot(file_builder: FileHandlerBuilder, snapshot) -> None:
+    data = file_builder.as_dict()
+    data["path"] = Path(data["path"]).name
+    assert data == snapshot
+    handler = file_builder.build()
+    handler.close()
+
+
+@then("building the file handler fails")
+def then_file_builder_fails(file_builder: FileHandlerBuilder) -> None:
+    with pytest.raises(ValueError):
+        file_builder.build()
+
+
+@then("the stream handler builder matches snapshot")
+def then_stream_builder_snapshot(
+    stream_builder: StreamHandlerBuilder, snapshot
+) -> None:
+    assert stream_builder.as_dict() == snapshot
+    handler = stream_builder.build()
+    handler.flush()
+
+
+@then("building the stream handler fails")
+def then_stream_builder_fails(stream_builder: StreamHandlerBuilder) -> None:
+    with pytest.raises(ValueError):
+        stream_builder.build()


### PR DESCRIPTION
## Summary
- add handler builder trait with file and stream implementations
- expose FileHandlerBuilder and StreamHandlerBuilder in Rust and Python
- test builder workflows from Rust and Python

## Testing
- `RUSTC_WRAPPER= make lint`
- `uv run pytest tests/test_handler_builders.py --snapshot-update`
- `RUSTC_WRAPPER= make test`


------
https://chatgpt.com/codex/tasks/task_e_68968741e5bc8322b0dadfebfab86e24

## Summary by Sourcery

Add a HandlerBuilderTrait abstraction in the Rust extension and provide concrete FileHandlerBuilder and StreamHandlerBuilder implementations with full PyO3 bindings and end-to-end tests in both Rust and Python. Update related documentation and project exports to support the new builder APIs.

New Features:
- Introduce HandlerBuilderTrait with FileHandlerBuilder and StreamHandlerBuilder in Rust
- Expose FileHandlerBuilder and StreamHandlerBuilder to Python via PyO3
- Implement build(), configuration, and validation logic for file and stream handler builders

Enhancements:
- Refactor handler module structure to include builders and consolidate exports
- Update Python package __init__ to export new builder classes

Documentation:
- Revise concurrency model documentation whitespace and formatting
- Document the initial implementation of FileHandlerBuilder and StreamHandlerBuilder in configuration design docs
- Update configuration roadmap to mark builder implementations as completed

Tests:
- Add Rust unit tests for file and stream builder validation and construction
- Add Python BDD tests for builder workflows using pytest and pytest-bdd