### PR TITLE
Add docstring and assertion for root logger test

### DIFF
--- a/docs/concurrency-models-in-high-performance-logging.md
+++ b/docs/concurrency-models-in-high-performance-logging.md
@@ -40,7 +40,7 @@ locking.
 
 A crucial detail of this implementation is the sequence of operations within
 the `handle` method: filtering occurs *before* the lock is acquired. This is an
-important optimisation, as it prevents the cost of filtering out a message from
+important optimization, as it prevents the cost of filtering out a message from
 contributing to lock contention. However, the work of formatting the message
 via the `Formatter` occurs *inside* the locked region, as it is part of the
 `emit` call chain.
@@ -63,7 +63,7 @@ Lock (GIL)**.
   during application start-up in a single-threaded context. By avoiding an
   explicit global lock, `picologging` eliminates a potential point of
   contention for the far more frequent operation of emitting log messages,
-  thereby prioritising runtime performance[^1].
+  thereby prioritizing runtime performance[^1].
 
 ## 2. A Rust Implementation: The Power of Compile-Time Safety
 
@@ -203,5 +203,5 @@ expensive.[^1][^2]
       [logging-cpython-picologging-comparison.md](logging-cpython-picologging-comparison.md)
 
 [^2]: Source:
-  [`microsoft/picologging/picologging-dc110b52c9f2e209f97a6fe80d286afb73a8437e/src/picologging/handlers.py`](microsoft/picologging/picologging-dc110b52c9f2e209f97a6fe80d286afb73a8437e/src/picologging/handlers.py)
-
+      <!-- markdownlint-disable-next-line MD013 -->
+      [`handlers.py`](https://github.com/microsoft/picologging/blob/dc110b52c9f2e209f97a6fe80d286afb73a8437e/src/picologging/handlers.py)

--- a/docs/concurrency-models-in-high-performance-logging.md
+++ b/docs/concurrency-models-in-high-performance-logging.md
@@ -203,7 +203,5 @@ expensive.[^1][^2]
       [logging-cpython-picologging-comparison.md](logging-cpython-picologging-comparison.md)
 
 [^2]: Source:
-      [handlers.py][handlers-source]
+  [`microsoft/picologging/picologging-dc110b52c9f2e209f97a6fe80d286afb73a8437e/src/picologging/handlers.py`](microsoft/picologging/picologging-dc110b52c9f2e209f97a6fe80d286afb73a8437e/src/picologging/handlers.py)
 
-[handlers-source]:
-https://github.com/microsoft/picologging/blob/dc110b52c9f2e209f97a6fe80d286afb73a8437e/src/picologging/handlers.py

--- a/tests/test_config_builder.py
+++ b/tests/test_config_builder.py
@@ -109,7 +109,7 @@ def test_no_root_logger_behavior() -> None:
 
 
 def test_multiple_root_logger_assignments() -> None:
-    """Test that multiple root logger assignments result in last assignment taking effect."""
+    """Test that multiple root logger assignments result in the last assignment taking effect."""
     builder = ConfigBuilder()
     root1 = LoggerConfigBuilder().with_level("INFO")
     root2 = LoggerConfigBuilder().with_level("ERROR")

--- a/tests/test_config_builder.py
+++ b/tests/test_config_builder.py
@@ -109,11 +109,13 @@ def test_no_root_logger_behavior() -> None:
 
 
 def test_multiple_root_logger_assignments() -> None:
-    """Test that later root logger assignments replace earlier ones."""
+    """Test that multiple root logger assignments result in last assignment taking effect."""
     builder = ConfigBuilder()
     root1 = LoggerConfigBuilder().with_level("INFO")
     root2 = LoggerConfigBuilder().with_level("ERROR")
     builder.with_root_logger(root1)
     builder.with_root_logger(root2)
     config = builder.as_dict()
-    assert config["root"]["level"] == "ERROR", "Last root logger should win"
+    assert config["root"]["level"] == "ERROR", (
+        "Last root logger assignment should take effect"
+    )


### PR DESCRIPTION
## Summary
- ensure `test_multiple_root_logger_assignments` documents expected behaviour and asserts with a helpful message
- fix markdown link in concurrency models doc for linting

## Testing
- `make fmt`
- `RUSTC_WRAPPER= make lint`
- `RUSTC_WRAPPER= make test`


------
https://chatgpt.com/codex/tasks/task_e_6896863973048322967f4cf5d18b678e

## Summary by Sourcery

Add assertion and docstring to root logger assignment test and fix markdown link formatting in concurrency models documentation

Documentation:
- Fix line wrapping and markdown link indentation in concurrency models documentation for linting

Tests:
- Add test_multiple_root_logger_assignments with docstring and helpful assertion message to verify last root logger assignment takes effect