### PR TITLE
Add docstring and assert message to root logger test

### DIFF
--- a/tests/test_config_builder.py
+++ b/tests/test_config_builder.py
@@ -115,6 +115,7 @@ def test_no_root_logger_behavior() -> None:
         ("ERROR", "INFO", "INFO"),
         ("DEBUG", "WARN", "WARN"),
     ],
+    ids=["INFO→ERROR", "ERROR→INFO", "DEBUG→WARN"],
 )
 def test_root_logger_last_assignment_wins(
     first: str, second: str, expected: str
@@ -124,6 +125,4 @@ def test_root_logger_last_assignment_wins(
     builder.with_root_logger(LoggerConfigBuilder().with_level(first))
     builder.with_root_logger(LoggerConfigBuilder().with_level(second))
     config = builder.as_dict()
-    assert config["root"]["level"] == expected, (
-        "Last root logger assignment should take effect"
-    )
+    assert config["root"]["level"] == expected, "Last root logger assignment wins"

--- a/tests/test_config_builder.py
+++ b/tests/test_config_builder.py
@@ -108,14 +108,23 @@ def test_no_root_logger_behavior() -> None:
         builder.build_and_init()
 
 
-def test_multiple_root_logger_assignments() -> None:
-    """Test that multiple root logger assignments result in the last assignment taking effect."""
+@pytest.mark.parametrize(
+    ("first", "second", "expected"),
+    [
+        ("INFO", "ERROR", "ERROR"),
+        ("ERROR", "INFO", "INFO"),
+        ("DEBUG", "WARN", "WARN"),
+    ],
+)
+def test_root_logger_last_assignment_wins(
+    first: str, second: str, expected: str
+) -> None:
+    """Verify last-write-wins semantics when assigning the root logger multiple times."""
     builder = ConfigBuilder()
-    root1 = LoggerConfigBuilder().with_level("INFO")
-    root2 = LoggerConfigBuilder().with_level("ERROR")
-    builder.with_root_logger(root1)
-    builder.with_root_logger(root2)
+    builder.with_root_logger(LoggerConfigBuilder().with_level(first))
+    builder.with_root_logger(LoggerConfigBuilder().with_level(second))
     config = builder.as_dict()
-    assert config["root"]["level"] == "ERROR", (
+    assert config["root"]["level"] == expected, (
         "Last root logger assignment should take effect"
     )
+    return

--- a/tests/test_config_builder.py
+++ b/tests/test_config_builder.py
@@ -127,4 +127,3 @@ def test_root_logger_last_assignment_wins(
     assert config["root"]["level"] == expected, (
         "Last root logger assignment should take effect"
     )
-    return

--- a/tests/test_config_builder.py
+++ b/tests/test_config_builder.py
@@ -125,4 +125,4 @@ def test_root_logger_last_assignment_wins(
     builder.with_root_logger(LoggerConfigBuilder().with_level(first))
     builder.with_root_logger(LoggerConfigBuilder().with_level(second))
     config = builder.as_dict()
-    assert config["root"]["level"] == expected, "Last root logger assignment wins"
+    assert config["root"]["level"] == expected, f"Last root logger assignment wins: {first}→{second}"


### PR DESCRIPTION
## Summary
- clarify root logger assignment test with a docstring and explicit assert message

## Testing
- `make fmt` (fails: docs/concurrency-models-in-high-performance-logging.md:206 MD039/no-space-in-links)
- `RUSTC_WRAPPER="" make lint`
- `RUSTC_WRAPPER="" make test`


------
https://chatgpt.com/codex/tasks/task_e_6896861cbe6c8322bd8c6d82c8be4b09

## Summary by Sourcery

Add a new test to verify that the last root logger assignment takes effect and improve its clarity with a docstring and explicit assertion message.

New Features:
- Add test_multiple_root_logger_assignments to ensure the final root logger setting overrides previous ones.

Tests:
- Include a descriptive docstring and explicit assert message in the new root logger assignment test.