### PR TITLE
Respect file handler flush intervals

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -171,7 +171,9 @@ maximize durability. To batch writes, pass a custom configuration via
 `flush_interval` in `HandlerConfig` or `PyHandlerConfig` defers flushing until
 the specified number of records have been written. The value must be greater
 than zero, so periodic flushing always occurs. Higher values reduce syscall
-overhead in high-volume scenarios.
+overhead in high-volume scenarios. Internally the handler buffers writes with
+`BufWriter`, so records only reach the file once a flush occurs or the handler
+shuts down.
 
 The worker thread begins processing records as soon as the handler is created.
 Production code therefore leaves the optional `start_barrier` field unset. Unit


### PR DESCRIPTION
## Summary
- buffer file handler writes so flush_interval controls when records hit disk
- document buffered writes in handler docs

## Testing
- `RUSTC_WRAPPER="" make lint`
- `make markdownlint`
- `RUSTC_WRAPPER="" make test`

------
https://chatgpt.com/codex/tasks/task_e_689cfb8e2c008322bb1f66b54184d692

## Summary by Sourcery

Wrap file handler writes in a buffered writer so that flush_interval controls when records are flushed to disk, and update documentation to describe this buffering behavior.

Bug Fixes:
- Wrap the file in BufWriter to defer writes until flush_interval or shutdown, preventing immediate OS-level writes.

Documentation:
- Document that the file handler uses internal buffering via BufWriter so records only reach disk on flush or shutdown.