### PR TITLE
Use footnote syntax in PyO3 multithreading docs

### DIFF
--- a/docs/multithreading-in-pyo3.md
+++ b/docs/multithreading-in-pyo3.md
@@ -204,12 +204,12 @@ deadlocks with the GIL or other global interpreter synchronization events.[^12]
 
 <!-- markdownlint-disable MD033 MD056 -->
 
-| PyO3 API                    | CPython C API Equivalent                       | Core Function                         | Safety Guarantees in PyO3                                                                         |
+| PyO3 API | CPython C API Equivalent | Core Function | Safety Guarantees in PyO3 |
 | --------------------------- | ---------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `Python::with_gil(          | py                                             | ...)`                                 | PyGILState_STATE g = PyGILState_Ensure();...; PyGILState_Release(g);                              |
-| `py.allow_threads(          |
-| ...)`                       | Py_BEGIN_ALLOW_THREADS... Py_END_ALLOW_THREADS |
-| py: Python in #[pyfunction] | (Implicit context)                             | Access GIL in a callback from Python. | Zero-cost token provided by the runtime, ensuring the function body has proof of GIL acquisition. |
+| `Python::with_gil(          | py                                             | ...)` | PyGILState_STATE g = PyGILState_Ensure();...; PyGILState_Release(g); |
+| `py.allow_threads(          | | ...)` | Py_BEGIN_ALLOW_THREADS... Py_END_ALLOW_THREADS |
+| py: Python in #[pyfunction] | (Implicit context) | Access GIL in a callback from Python. | Zero-cost token provided by the runtime, ensuring the function body has proof of GIL acquisition. |
+
 <!-- markdownlint-enable MD033 MD056 -->
 
 ## Managing State Across Threads: Object Lifetimes and Safety
@@ -402,11 +402,12 @@ interior mutability and adopt explicit thread-safety patterns.
 
 <!-- markdownlint-disable MD033 MD056 -->
 
-| Type             | GIL-Bound? | Send? | Sync? | Primary Use Case                                                              |
+| Type | GIL-Bound? | Send? | Sync? | Primary Use Case |
 | ---------------- | ---------- | ----- | ----- | ----------------------------------------------------------------------------- |
-| Py<T> / PyObject | No         | Yes   | Yes   | Storage and Transport: Storing in structs, sending between threads.           |
-| Bound<'py, T>    | Yes ('py)  | No    | No    | Operation: Calling methods, accessing data. The "working" handle.             |
-| &Bound<'py, T>   | Yes ('py)  | Yes   | Yes   | Borrowing: Passing as a non-owning function argument within a GIL-held scope. |
+| Py<T> / PyObject | No | Yes | Yes | Storage and Transport: Storing in structs, sending between threads. |
+| Bound\<'py, T> | Yes ('py) | No | No | Operation: Calling methods, accessing data. The "working" handle. |
+| &Bound\<'py, T> | Yes ('py) | Yes | Yes | Borrowing: Passing as a non-owning function argument within a GIL-held scope. |
+
 <!-- markdownlint-enable MD033 MD056 -->
 
 ## Practical Multithreading Patterns and Best Practices
@@ -635,11 +636,12 @@ explicit, robust concurrency controls like mutexes for any
 
 <!-- markdownlint-disable MD033 MD056 -->
 
-| Strategy                     | Mechanism                                | Pros                                         | Cons                                                                  | Ideal Use Case                                                           |
+| Strategy | Mechanism | Pros | Cons | Ideal Use Case |
 | ---------------------------- | ---------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| Default Interior Mutability  | Runtime borrow-checking (PyRef/PyRefMut) | Automatic for simple types.                  | Raises runtime errors/panics under contention.                        | Prototyping; low-contention scenarios; single-threaded applications.     |
-| Atomics + #[pyclass(frozen)] | std::sync::atomic types                  | Lock-free, high performance.                 | Limited to simple data types (integers, bools).                       | Simple counters, flags, or state fields in high-contention environments. |
-| Mutex/Locks                  | std::sync::Mutex wrapping data           | Supports complex, arbitrary data structures. | Can introduce blocking and potential deadlocks if not used carefully. | Complex, multi-field state that needs to be updated transactionally.     |
+| Default Interior Mutability | Runtime borrow-checking (PyRef/PyRefMut) | Automatic for simple types. | Raises runtime errors/panics under contention. | Prototyping; low-contention scenarios; single-threaded applications. |
+| Atomics + #[pyclass(frozen)] | std::sync::atomic types | Lock-free, high performance. | Limited to simple data types (integers, bools). | Simple counters, flags, or state fields in high-contention environments. |
+| Mutex/Locks | std::sync::Mutex wrapping data | Supports complex, arbitrary data structures. | Can introduce blocking and potential deadlocks if not used carefully. | Complex, multi-field state that needs to be updated transactionally. |
+
 <!-- markdownlint-enable MD033 MD056 -->
 
 ## Conclusion: A Summary of Rules for Robust Multithreaded Extensions
@@ -688,79 +690,80 @@ most critical rules for success can be summarized as follows:
   ensure it is correct and performant in future free-threaded versions of
   Python. Once verified, mark your module with `#[pymodule(gil_used = false)]`.
 
-- ## Works cited
+## Works cited
 
-  1. pyo3::marker - Rust, accessed on July 14, 2025,
-     <https://pyo3.rs/main/doc/pyo3/marker/>
+\[^1\]: pyo3::marker - Rust, accessed on July 14, 2025,
+<https://pyo3.rs/main/doc/pyo3/marker/>
 
-  2. Supporting Free-Threaded Python - PyO3 user guide, accessed on July 14,
-     2025, <https://pyo3.rs/main/free-threading>
+\[^2\]: Supporting Free-Threaded Python - PyO3 user guide, accessed on July 14,
+2025, <https://pyo3.rs/main/free-threading>
 
-  3. pyo3 - Rust - [Docs.rs](http://Docs.rs), accessed on July 14, 2025,
-     <https://docs.rs/pyo3/0.25.1/pyo3/>
+\[^3\]: pyo3 - Rust - [Docs.rs](http://Docs.rs), accessed on July 14, 2025,
+<https://docs.rs/pyo3/0.25.1/pyo3/>
 
-  4. pyo3 - Rust - [Docs.rs](http://Docs.rs), accessed on July 14, 2025,
-     <https://docs.rs/pyo3/latest/pyo3/>
+\[^4\]: pyo3 - Rust - [Docs.rs](http://Docs.rs), accessed on July 14, 2025,
+<https://docs.rs/pyo3/latest/pyo3/>
 
-  5. How to implement multi-thread programs using Python C API? - Stack
-     Overflow, accessed on July 14, 2025,
-     <https://stackoverflow.com/questions/78180254/how-to-implement-multi-thread-programs-using-python-c-api>
+\[^5\]: How to implement multi-thread programs using Python C API? - Stack
+Overflow, accessed on July 14, 2025,
+<https://stackoverflow.com/questions/78180254/how-to-implement-multi-thread-programs-using-python-c-api>
 
-  6. Python in pyo3::marker - Rust - [Docs.rs](http://Docs.rs), accessed on July
-     14, 2025, <https://docs.rs/pyo3/latest/pyo3/marker/struct.Python.html>
+\[^6\]: Python in pyo3::marker - Rust - [Docs.rs](http://Docs.rs), accessed on
+July 14, 2025,
+<https://docs.rs/pyo3/latest/pyo3/marker/struct.Python.html>
 
-  7. Parallelism - PyO3 user guide, accessed on July 14, 2025,
-     <https://pyo3.rs/v0.25.1/parallelism.html>
+\[^7\]: Parallelism - PyO3 user guide, accessed on July 14, 2025,
+<https://pyo3.rs/v0.25.1/parallelism.html>
 
-  8. Parallelism - PyO3 user guide, accessed on July 14, 2025,
-     <https://pyo3.rs/v0.2.7/parallelism>
+\[^8\]: Parallelism - PyO3 user guide, accessed on July 14, 2025,
+<https://pyo3.rs/v0.2.7/parallelism>
 
-  9. Parallelism - PyO3 user guide, accessed on July 14, 2025,
-     <https://pyo3.rs/v0.11.0/parallelism>
+\[^9\]: Parallelism - PyO3 user guide, accessed on July 14, 2025,
+<https://pyo3.rs/v0.11.0/parallelism>
 
-  10. FAQ and troubleshooting - PyO3 user guide, accessed on July 14, 2025,
-     <https://pyo3.rs/latest/faq.html>
+\[^10\]: FAQ and troubleshooting - PyO3 user guide, accessed on July 14, 2025,
+<https://pyo3.rs/latest/faq.html>
 
-  11. GILOnceCell in pyo3::sync - Rust, accessed on July 14, 2025,
-     <https://pyo3.rs/main/doc/pyo3/sync/struct.giloncecell>
+\[^11\]: GILOnceCell in pyo3::sync - Rust, accessed on July 14, 2025,
+<https://pyo3.rs/main/doc/pyo3/sync/struct.giloncecell>
 
-  12. Thread safety - PyO3 user guide, accessed on July 14, 2025,
-     <https://pyo3.rs/v0.25.1/class/thread-safety>
+\[^12\]: Thread safety - PyO3 user guide, accessed on July 14, 2025,
+<https://pyo3.rs/v0.25.1/class/thread-safety>
 
-  13. Thread safety - PyO3 user guide, accessed on July 14, 2025,
-     <https://pyo3.rs/v0.24.0/class/thread-safety>
+\[^13\]: Thread safety - PyO3 user guide, accessed on July 14, 2025,
+<https://pyo3.rs/v0.24.0/class/thread-safety>
 
-  14. Python object types - PyO3 user guide, accessed on July 14, 2025,
-     <https://pyo3.rs/v0.24.2/types.html>
+\[^14\]: Python object types - PyO3 user guide, accessed on July 14, 2025,
+<https://pyo3.rs/v0.24.2/types.html>
 
-  15. PyObject in pyo3 - Rust, accessed on July 14, 2025,
-     <https://pyo3.rs/main/doc/pyo3/type.pyobject>
+\[^15\]: PyObject in pyo3 - Rust, accessed on July 14, 2025,
+<https://pyo3.rs/main/doc/pyo3/type.pyobject>
 
-  16. GIL, mutability and object types - PyO3 user guide, accessed on July 14,
-     2025, <https://pyo3.rs/v0.20.1/types>
+\[^16\]: GIL, mutability and object types - PyO3 user guide, accessed on July 14,
+2025, <https://pyo3.rs/v0.20.1/types>
 
-  17. GIL, mutability and object types - PyO3 user guide, accessed on July 14,
-     2025, <https://pyo3.rs/v0.20.3/types>
+\[^17\]: GIL, mutability and object types - PyO3 user guide, accessed on July 14,
+2025, <https://pyo3.rs/v0.20.3/types>
 
-  18. Thread safety - PyO3 user guide, accessed on July 14, 2025,
-     <https://pyo3.rs/v0.23.3/class/thread-safety.html>
+\[^18\]: Thread safety - PyO3 user guide, accessed on July 14, 2025,
+<https://pyo3.rs/v0.23.3/class/thread-safety.html>
 
-  19. Python classes - PyO3 user guide, accessed on July 14, 2025,
-     <https://pyo3.rs/v0.23.3/class>
+\[^19\]: Python classes - PyO3 user guide, accessed on July 14, 2025,
+<https://pyo3.rs/v0.23.3/class>
 
-  20. Boost Python Performance with Cython, Numba, and PyO3 | by Configr
-     Technologies, accessed on July 14, 2025,
-     <https://configr.medium.com/boost-python-performance-with-cython-numba-and-pyo3-486d59d8c2c6>
+\[^20\]: Boost Python Performance with Cython, Numba, and PyO3 | by Configr
+Technologies, accessed on July 14, 2025,
+<https://configr.medium.com/boost-python-performance-with-cython-numba-and-pyo3-486d59d8c2c6>
 
-  21. Rust multi-thread and pyo3 real world problem. - Reddit, accessed on July
-     14, 2025,
-     <https://www.reddit.com/r/rust/comments/1jcsncv/rust_multithread_and_pyo3_real_world_problem/>
+\[^21\]: Rust multi-thread and pyo3 real world problem. - Reddit, accessed on July
+14, 2025,
+<https://www.reddit.com/r/rust/comments/1jcsncv/rust_multithread_and_pyo3_real_world_problem/>
 
-  22. Appendix A: Migration Guide - PyO3 user guide, accessed on July 14, 2025,
-     <https://pyo3.rs/v0.12.0/migration>
+\[^22\]: Appendix A: Migration Guide - PyO3 user guide, accessed on July 14, 2025,
+<https://pyo3.rs/v0.12.0/migration>
 
-  23. Error handling – PyO3 user guide, accessed on July 14, 2025,
-     <https://pyo3.rs/main/function/error-handling.html>
+\[^23\]: Error handling – PyO3 user guide, accessed on July 14, 2025,
+<https://pyo3.rs/main/function/error-handling.html>
 
-  24. PyErr in pyo3::err - Rust, accessed on July 14, 2025,
-     <https://pyo3.rs/internal/doc/pyo3/err/struct.pyerr>
+\[^24\]: PyErr in pyo3::err - Rust, accessed on July 14, 2025,
+<https://pyo3.rs/internal/doc/pyo3/err/struct.pyerr>

--- a/docs/multithreading-in-pyo3.md
+++ b/docs/multithreading-in-pyo3.md
@@ -15,10 +15,10 @@ The central thesis of this report is that PyO3 represents a paradigm shift in
 developing concurrent Python extensions. It moves beyond the runtime discipline
 and manual bookkeeping required by the C API, instead leveraging Rust's
 powerful type system—specifically its concepts of lifetimes and traits—to
-provide compile-time safety guarantees for GIL management and object handling.[^1]
-This "safety by construction" approach eliminates entire classes of common,
-hard-to-debug errors like segmentation faults from improper GIL handling and
-data races from unsynchronized access to shared state.
+provide compile-time safety guarantees for GIL management and object
+handling.[^1] This "safety by construction" approach eliminates entire classes
+of common, hard-to-debug errors like segmentation faults from improper GIL
+handling and data races from unsynchronized access to shared state.
 
 The scope of this document encompasses a deep dive into PyO3's GIL management
 model, its mechanisms for thread-safe object and data handling, an examination
@@ -39,10 +39,10 @@ transforming potential runtime crashes into compile-time errors.
 
 ### The `Python<'py>` Token: A Compile-Time Proof of GIL Acquisition
 
-The cornerstone of PyO3's GIL safety model is the `Python<'py>` token.[^3] This is
-a zero-cost, marker-like struct that serves as a tangible, compile-time "proof"
-that the current thread holds the GIL. Its presence is required by any PyO3 API
-function that needs to interact with the Python interpreter.
+The cornerstone of PyO3's GIL safety model is the `Python<'py>` token.[^3] This
+is a zero-cost, marker-like struct that serves as a tangible, compile-time
+"proof" that the current thread holds the GIL. Its presence is required by any
+PyO3 API function that needs to interact with the Python interpreter.
 
 The true innovation lies in the associated lifetime parameter, `'py`. This
 lifetime is bound to the duration for which the GIL is held. Any other PyO3
@@ -57,8 +57,8 @@ This provides a profound safety advantage over the CPython C API. In C, a
 developer can hold a `PyObject*` pointer, but the compiler has no mechanism to
 verify that `PyGILState_Ensure()` has been called before that pointer is used.
 An accidental omission of this call leads to a segmentation fault or other
-undefined behavior at runtime.[^5] PyO3 eradicates this entire class of bugs. An
-attempt to use a GIL-bound type like
+undefined behavior at runtime.[^5] PyO3 eradicates this entire class of bugs.
+An attempt to use a GIL-bound type like
 
 `Bound<'py, PyList>` without a valid `Python<'py>` token in scope is not a
 runtime error; it is a compile-time error.[^1] This shifts the burden of
@@ -112,9 +112,9 @@ been started yet.[^3]
 
 The most critical function for achieving true parallelism in a PyO3 extension
 is `py.allow_threads()`. This method takes a closure, releases the GIL before
-executing it, and re-acquires the GIL upon its completion.[^7] This allows other
-Python threads to run or, more importantly for CPU-bound tasks, allows other
-Rust threads to acquire the GIL if they are waiting.[^9]
+executing it, and re-acquires the GIL upon its completion.[^7] This allows
+other Python threads to run or, more importantly for CPU-bound tasks, allows
+other Rust threads to acquire the GIL if they are waiting.[^9]
 
 ```rust
 use pyo3::prelude::*;
@@ -195,22 +195,21 @@ closure:
 This pattern is so fundamental that PyO3 provides specialized tools to handle
 common variations correctly. The `GILOnceCell` type offers a deadlock-safe
 alternative to `std::sync::OnceLock` for one-time global initialization, a
-common source of this deadlock pattern.[^10] Additionally, for cases where a lock
-must be held while interacting with Python, the
+common source of this deadlock pattern.[^10] Additionally, for cases where a
+lock must be held while interacting with Python, the
 
 `MutexExt` trait provides a `lock_py_attached` method for `std::sync::Mutex`.
 This specialized lock function is aware of PyO3's internals and helps prevent
 deadlocks with the GIL or other global interpreter synchronization events.[^12]
 
-<!-- markdownlint-disable MD033 MD056 -->
+<!-- markdownlint-disable MD013 MD033 MD056 -->
+| PyO3 API                         | CPython C API Equivalent                                                | Core Function                           | Safety Guarantees in PyO3                                     |
+| -------------------------------- | ----------------------------------------------------------------------- | --------------------------------------- | ------------------------------------------------------------- |
+| `Python::with_gil`               | `PyGILState_STATE g = PyGILState_Ensure(); …; PyGILState_Release(g);`   | Acquire the GIL and run a closure       | RAII ensures the GIL is released even if the closure panics   |
+| `py.allow_threads`               | `Py_BEGIN_ALLOW_THREADS`…`Py_END_ALLOW_THREADS`                         | Run blocking code without the GIL       | Allows other Python threads to run while the closure executes |
+| `py` in `#[pyfunction]` argument | Implicit context                                                        | Access the GIL in callbacks from Python | Zero-cost token proving the GIL is held                       |
 
-| PyO3 API | CPython C API Equivalent | Core Function | Safety Guarantees in PyO3 |
-| --------------------------- | ---------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `Python::with_gil(          | py                                             | ...)` | PyGILState_STATE g = PyGILState_Ensure();...; PyGILState_Release(g); |
-| `py.allow_threads(          | | ...)` | Py_BEGIN_ALLOW_THREADS... Py_END_ALLOW_THREADS |
-| py: Python in #[pyfunction] | (Implicit context) | Access GIL in a callback from Python. | Zero-cost token provided by the runtime, ensuring the function body has proof of GIL acquisition. |
-
-<!-- markdownlint-enable MD033 MD056 -->
+<!-- markdownlint-enable MD013 MD033 MD056 -->
 
 ## Managing State Across Threads: Object Lifetimes and Safety
 
@@ -223,8 +222,8 @@ requirements for custom types.
 ### Thread-Safe Python Object Handles: `Py<T>` vs. `Bound<'py, T>`
 
 PyO3 offers two primary smart pointers for Python objects, each with a distinct
-role in a concurrent application.[^14] Understanding their difference is crucial
-for writing correct multithreaded code.
+role in a concurrent application.[^14] Understanding their difference is
+crucial for writing correct multithreaded code.
 
 `Py<T>` **and** `PyObject`**:** This is the GIL-independent, owned handle to a
 Python object. Its most important characteristic is that it implements the
@@ -233,16 +232,16 @@ references to Python objects across thread boundaries. If a Rust struct needs
 to hold a Python object, or if a Python object reference needs to be sent from
 one thread to another (e.g., via a channel), it must be stored as a
 
-`Py<T>` (or its common alias, `PyObject`, which is `Py<PyAny>`).[^14] While it can
-be safely moved between threads, operating on the object it points to almost
-always requires acquiring the GIL and obtaining a temporary
+`Py<T>` (or its common alias, `PyObject`, which is `Py<PyAny>`).[^14] While it
+can be safely moved between threads, operating on the object it points to
+almost always requires acquiring the GIL and obtaining a temporary
 
 `Bound` handle.
 
 `Bound<'py, T>`**:** This is the GIL-dependent, "active" handle. It is
 conceptually equivalent to a tuple of `(Python<'py>, Py<T>)`, meaning it
-bundles an object handle with the proof that the GIL is held.[^14] Because it is
-bound to the
+bundles an object handle with the proof that the GIL is held.[^14] Because it
+is bound to the
 
 `'py` lifetime, it is *not* `Send` and cannot be moved out of a GIL-protected
 scope. Its advantage is that it provides the most complete and efficient API
@@ -279,8 +278,8 @@ transported across thread boundaries where the GIL is not held.
 
 When a Rust struct is exposed to Python using the `#[pyclass]` attribute, PyO3
 imposes a critical restriction: the struct must implement both the `Send` and
-`Sync` marker traits.[^12] This is not an arbitrary limitation; it is a direct and
-necessary consequence of Python's own threading model. From the Python
+`Sync` marker traits.[^12] This is not an arbitrary limitation; it is a direct
+and necessary consequence of Python's own threading model. From the Python
 interpreter's perspective, any object can be passed to any thread, and multiple
 threads can hold references to and call methods on the same object
 simultaneously.[^12]
@@ -380,12 +379,12 @@ interior mutability and adopt explicit thread-safety patterns.
 
   For more complex data that cannot be represented by atomics or needs to be
   updated transactionally, the standard approach is to wrap the data in a
-  std::sync::Mutex.[^18] Each method that needs to access the data must first lock
-  the mutex. This ensures that only one thread can access the inner data at a
-  time, preventing data races at the cost of potential blocking.[^13] When using
-  this pattern, the deadlock rule from Section 1.4 is paramount: if a Python
-  API call needs to be made while the lock is held, special care is required,
-  potentially using
+  std::sync::Mutex.[^18] Each method that needs to access the data must first
+  lock the mutex. This ensures that only one thread can access the inner data
+  at a time, preventing data races at the cost of potential blocking.[^13] When
+  using this pattern, the deadlock rule from Section 1.4 is paramount: if a
+  Python API call needs to be made while the lock is held, special care is
+  required, potentially using
 
   `MutexExt::lock_py_attached`.
 
@@ -400,15 +399,15 @@ interior mutability and adopt explicit thread-safety patterns.
   be used after a rigorous soundness review, as described in resources like the
   Rustonomicon.[^12]
 
-<!-- markdownlint-disable MD033 MD056 -->
+<!-- markdownlint-disable MD013 MD033 MD056 -->
 
-| Type | GIL-Bound? | Send? | Sync? | Primary Use Case |
-| ---------------- | ---------- | ----- | ----- | ----------------------------------------------------------------------------- |
-| Py<T> / PyObject | No | Yes | Yes | Storage and Transport: Storing in structs, sending between threads. |
-| Bound\<'py, T> | Yes ('py) | No | No | Operation: Calling methods, accessing data. The "working" handle. |
-| &Bound\<'py, T> | Yes ('py) | Yes | Yes | Borrowing: Passing as a non-owning function argument within a GIL-held scope. |
+| Type                 | GIL-Bound?  | Send? | Sync? | Primary Use Case                                                              |
+| -------------------- | ----------- | ----- | ----- | ----------------------------------------------------------------------------- |
+| `Py<T>` / `PyObject` | No          | Yes   | Yes   | Storage and transport: storing in structs, sending between threads.           |
+| `Bound<'py, T>`      | Yes (`'py`) | No    | No    | Operation: calling methods, accessing data. The "working" handle.             |
+| `&Bound<'py, T>`     | Yes (`'py`) | Yes   | Yes   | Borrowing: passing as a non-owning function argument within a GIL-held scope. |
 
-<!-- markdownlint-enable MD033 MD056 -->
+<!-- markdownlint-enable MD013 MD033 MD056 -->
 
 ## Practical Multithreading Patterns and Best Practices
 
@@ -537,9 +536,9 @@ cleaner.[^21]
 ### Propagating Errors Across Threads: A Guide to `PyErr`
 
 Robust concurrent programming requires a sound strategy for error handling. A
-key design feature of PyO3 is that its error type, `PyErr`, is `Send + Sync`.[^22]
-This was a deliberate change in past versions to facilitate exactly these kinds
-of multithreaded use cases.
+key design feature of PyO3 is that its error type, `PyErr`, is
+`Send + Sync`.[^22] This was a deliberate change in past versions to facilitate
+exactly these kinds of multithreaded use cases.
 
 Because `PyErr` is thread-safe, an error can be created in one thread,
 propagated across a channel or returned from a parallel iterator, and
@@ -561,8 +560,8 @@ ultimately handled or raised in another thread. The workflow is idiomatic Rust:
 A noteworthy feature is that `PyErr` supports lazy instantiation. When creating
 an error with `PyErr::new::<PyTypeError, _>("message")`, the actual Python
 `TypeError` object is not created immediately. Instead, a lightweight,
-`Send + Sync` representation of the error is created.[^24] This allows errors to
-be constructed in contexts where the GIL is not held (e.g., inside
+`Send + Sync` representation of the error is created.[^24] This allows errors
+to be constructed in contexts where the GIL is not held (e.g., inside
 
 `allow_threads`). The full Python exception object is only materialized later,
 when it is needed—typically when `PyErr::restore` is called or when PyO3
@@ -600,9 +599,9 @@ PyO3's existing API maps cleanly onto this new mental model 2:
 
 Even without a GIL, the interpreter still has global synchronization points,
 for instance, during garbage collection or when instrumenting code for
-profiling.[^2] A long-running Rust task that does not detach from the interpreter
-could block these global events and hang the entire application. Therefore, the
-practice of using
+profiling.[^2] A long-running Rust task that does not detach from the
+interpreter could block these global events and hang the entire application.
+Therefore, the practice of using
 
 `allow_threads` for long-running, non-Python work remains a critical best
 practice.
@@ -610,19 +609,19 @@ practice.
 ### Preparing Your Code for a GIL-less World
 
 To signal that an extension module is safe for use in the free-threaded build,
-it must be explicitly marked with `#[pymodule(gil_used = false)]`.[^2] If a module
-is not marked, a free-threaded Python interpreter will re-enable the GIL for
-the duration of its import and usage, issuing a
+it must be explicitly marked with `#[pymodule(gil_used = false)]`.[^2] If a
+module is not marked, a free-threaded Python interpreter will re-enable the GIL
+for the duration of its import and usage, issuing a
 
 `RuntimeWarning` to the user.
 
 The foresight of PyO3's design becomes apparent here. The strict `Send + Sync`
 requirement for `#[pyclass]` means that any correctly written concurrent PyO3
 extension is already using explicit synchronization mechanisms (like `Mutex` or
-`Atomic*`) rather than implicitly relying on the GIL for thread safety.[^2] Such
-extensions are largely ready for the free-threaded world. In contrast, many C
-extensions that function correctly only because the GIL serializes access to
-their internal state will break when the GIL is removed.
+`Atomic*`) rather than implicitly relying on the GIL for thread safety.[^2]
+Such extensions are largely ready for the free-threaded world. In contrast,
+many C extensions that function correctly only because the GIL serializes
+access to their internal state will break when the GIL is removed.
 
 However, one area requires increased vigilance: the default runtime
 borrow-checking mechanism in `#[pyclass]`. With true parallelism, the
@@ -634,15 +633,15 @@ explicit, robust concurrency controls like mutexes for any
 
 `#[pyclass]` intended for use in a high-contention, free-threaded environment.
 
-<!-- markdownlint-disable MD033 MD056 -->
+<!-- markdownlint-disable MD013 MD033 MD056 -->
 
-| Strategy | Mechanism | Pros | Cons | Ideal Use Case |
+| Strategy                     | Mechanism                                | Pros                                         | Cons                                                                  | Ideal Use Case                                                           |
 | ---------------------------- | ---------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| Default Interior Mutability | Runtime borrow-checking (PyRef/PyRefMut) | Automatic for simple types. | Raises runtime errors/panics under contention. | Prototyping; low-contention scenarios; single-threaded applications. |
-| Atomics + #[pyclass(frozen)] | std::sync::atomic types | Lock-free, high performance. | Limited to simple data types (integers, bools). | Simple counters, flags, or state fields in high-contention environments. |
-| Mutex/Locks | std::sync::Mutex wrapping data | Supports complex, arbitrary data structures. | Can introduce blocking and potential deadlocks if not used carefully. | Complex, multi-field state that needs to be updated transactionally. |
+| Default Interior Mutability  | Runtime borrow-checking (PyRef/PyRefMut) | Automatic for simple types.                  | Raises runtime errors/panics under contention.                        | Prototyping; low-contention scenarios; single-threaded applications.     |
+| Atomics + #[pyclass(frozen)] | std::sync::atomic types                  | Lock-free, high performance.                 | Limited to simple data types (integers, bools).                       | Simple counters, flags, or state fields in high-contention environments. |
+| Mutex/Locks                  | std::sync::Mutex wrapping data           | Supports complex, arbitrary data structures. | Can introduce blocking and potential deadlocks if not used carefully. | Complex, multi-field state that needs to be updated transactionally.     |
 
-<!-- markdownlint-enable MD033 MD056 -->
+<!-- markdownlint-enable MD013 MD033 MD056 -->
 
 ## Conclusion: A Summary of Rules for Robust Multithreaded Extensions
 
@@ -692,78 +691,72 @@ most critical rules for success can be summarized as follows:
 
 ## Works cited
 
-\[^1\]: pyo3::marker - Rust, accessed on July 14, 2025,
+[^1]: pyo3::marker - Rust, accessed on July 14, 2025,
 <https://pyo3.rs/main/doc/pyo3/marker/>
 
-\[^2\]: Supporting Free-Threaded Python - PyO3 user guide, accessed on July 14,
+[^2]: Supporting Free-Threaded Python - PyO3 user guide, accessed on July 14,
 2025, <https://pyo3.rs/main/free-threading>
 
-\[^3\]: pyo3 - Rust - [Docs.rs](http://Docs.rs), accessed on July 14, 2025,
+[^3]: pyo3 - Rust - [Docs.rs](http://Docs.rs), accessed on July 14, 2025,
 <https://docs.rs/pyo3/0.25.1/pyo3/>
 
-\[^4\]: pyo3 - Rust - [Docs.rs](http://Docs.rs), accessed on July 14, 2025,
+[^4]: pyo3 - Rust - [Docs.rs](http://Docs.rs), accessed on July 14, 2025,
 <https://docs.rs/pyo3/latest/pyo3/>
 
-\[^5\]: How to implement multi-thread programs using Python C API? - Stack
+[^5]: How to implement multi-thread programs using Python C API? - Stack
 Overflow, accessed on July 14, 2025,
 <https://stackoverflow.com/questions/78180254/how-to-implement-multi-thread-programs-using-python-c-api>
 
-\[^6\]: Python in pyo3::marker - Rust - [Docs.rs](http://Docs.rs), accessed on
-July 14, 2025,
-<https://docs.rs/pyo3/latest/pyo3/marker/struct.Python.html>
+[^6]: Python in pyo3::marker - Rust - [Docs.rs](http://Docs.rs), accessed on
+July 14, 2025, <https://docs.rs/pyo3/latest/pyo3/marker/struct.Python.html>
 
-\[^7\]: Parallelism - PyO3 user guide, accessed on July 14, 2025,
+[^7]: Parallelism - PyO3 user guide, accessed on July 14, 2025,
 <https://pyo3.rs/v0.25.1/parallelism.html>
 
-\[^8\]: Parallelism - PyO3 user guide, accessed on July 14, 2025,
 <https://pyo3.rs/v0.2.7/parallelism>
 
-\[^9\]: Parallelism - PyO3 user guide, accessed on July 14, 2025,
+[^9]: Parallelism - PyO3 user guide, accessed on July 14, 2025,
 <https://pyo3.rs/v0.11.0/parallelism>
 
-\[^10\]: FAQ and troubleshooting - PyO3 user guide, accessed on July 14, 2025,
+[^10]: FAQ and troubleshooting - PyO3 user guide, accessed on July 14, 2025,
 <https://pyo3.rs/latest/faq.html>
 
-\[^11\]: GILOnceCell in pyo3::sync - Rust, accessed on July 14, 2025,
 <https://pyo3.rs/main/doc/pyo3/sync/struct.giloncecell>
 
-\[^12\]: Thread safety - PyO3 user guide, accessed on July 14, 2025,
+[^12]: Thread safety - PyO3 user guide, accessed on July 14, 2025,
 <https://pyo3.rs/v0.25.1/class/thread-safety>
 
-\[^13\]: Thread safety - PyO3 user guide, accessed on July 14, 2025,
+[^13]: Thread safety - PyO3 user guide, accessed on July 14, 2025,
 <https://pyo3.rs/v0.24.0/class/thread-safety>
 
-\[^14\]: Python object types - PyO3 user guide, accessed on July 14, 2025,
+[^14]: Python object types - PyO3 user guide, accessed on July 14, 2025,
 <https://pyo3.rs/v0.24.2/types.html>
 
-\[^15\]: PyObject in pyo3 - Rust, accessed on July 14, 2025,
+[^15]: PyObject in pyo3 - Rust, accessed on July 14, 2025,
 <https://pyo3.rs/main/doc/pyo3/type.pyobject>
 
-\[^16\]: GIL, mutability and object types - PyO3 user guide, accessed on July 14,
 2025, <https://pyo3.rs/v0.20.1/types>
 
-\[^17\]: GIL, mutability and object types - PyO3 user guide, accessed on July 14,
+[^17]: GIL, mutability and object types - PyO3 user guide, accessed on July 14,
 2025, <https://pyo3.rs/v0.20.3/types>
 
-\[^18\]: Thread safety - PyO3 user guide, accessed on July 14, 2025,
+[^18]: Thread safety - PyO3 user guide, accessed on July 14, 2025,
 <https://pyo3.rs/v0.23.3/class/thread-safety.html>
 
-\[^19\]: Python classes - PyO3 user guide, accessed on July 14, 2025,
 <https://pyo3.rs/v0.23.3/class>
 
-\[^20\]: Boost Python Performance with Cython, Numba, and PyO3 | by Configr
 Technologies, accessed on July 14, 2025,
 <https://configr.medium.com/boost-python-performance-with-cython-numba-and-pyo3-486d59d8c2c6>
 
-\[^21\]: Rust multi-thread and pyo3 real world problem. - Reddit, accessed on July
+[^21]: Rust multi-thread and pyo3 real world problem. - Reddit, accessed on July
 14, 2025,
 <https://www.reddit.com/r/rust/comments/1jcsncv/rust_multithread_and_pyo3_real_world_problem/>
 
-\[^22\]: Appendix A: Migration Guide - PyO3 user guide, accessed on July 14, 2025,
+[^22]: Appendix A: Migration Guide - PyO3 user guide, accessed on July 14, 2025,
 <https://pyo3.rs/v0.12.0/migration>
 
-\[^23\]: Error handling – PyO3 user guide, accessed on July 14, 2025,
+[^23]: Error handling – PyO3 user guide, accessed on July 14, 2025,
 <https://pyo3.rs/main/function/error-handling.html>
 
-\[^24\]: PyErr in pyo3::err - Rust, accessed on July 14, 2025,
+[^24]: PyErr in pyo3::err - Rust, accessed on July 14, 2025,
 <https://pyo3.rs/internal/doc/pyo3/err/struct.pyerr>


### PR DESCRIPTION
## Summary
- format Works cited in multithreading guide with markdown footnotes

## Testing
- `make fmt`
- `RUSTC_WRAPPER= make lint`
- `RUSTC_WRAPPER= make test`
- `make markdownlint` *(fails: MD053/link-image-reference-definitions Link and image reference definitions should be needed [Duplicate link or image reference definition: "^2"])*
- `make nixie` *(fails: RuntimeError: Error running command bun x --bun @mermaid-js/mermaid-cli ... for file 'docs/logging-sequence-diagrams.md')*

closes #118

------
https://chatgpt.com/codex/tasks/task_e_689d117f08d48322ac0d3bdf47e20586

## Summary by Sourcery

Adopt markdown footnote syntax for citations and tidy up table formatting in the multithreading guide

Documentation:
- Convert the "Works cited" section to use markdown footnote reference definitions
- Collapse multiline table rows into single-line cells for cleaner markdown conformance