### PR TITLE
Ensure handler cleanup and refine policy validation

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -115,7 +115,7 @@ Legacy constructors like ``with_capacity_flush_blocking`` and
 consumer thread receives `FemtoLogRecord` values, moves the writer and
 formatter into the worker thread, and writes directly without locking. This
 mirrors the design in
-[`concurrency-models-in-high-performance- logging.md`][cmhp-log]. The default
+[`concurrency-models-in-high-performance-logging.md`][cmhp-log]. The default
 bounded queue size is 1024 records, but `FemtoStreamHandler::with_capacity`
 lets callers configure a custom capacity when needed. Flushing is driven by a
 timeout measured in milliseconds.
@@ -178,7 +178,7 @@ shuts down.
 
 The worker thread begins processing records as soon as the handler is created.
 Production code therefore leaves the optional `start_barrier` field unset. Unit
-tests may use this barrier to synchronise multiple workers and avoid race
+tests may use this barrier to synchronize multiple workers and avoid race
 conditions. Should a future feature require coordinated startup (for example,
 rotating several files at once), the `WorkerConfig` creation logic will need to
 expose this.

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -178,7 +178,7 @@ shuts down.
 
 The worker thread begins processing records as soon as the handler is created.
 Production code therefore leaves the optional `start_barrier` field unset. Unit
-tests may use this barrier to synchronize multiple workers and avoid race
+tests may use this barrier to synchronize multiple workers, avoiding race
 conditions. Should a future feature require coordinated startup (for example,
 rotating several files at once), the `WorkerConfig` creation logic will need to
 expose this.

--- a/rust_extension/src/handlers/file/config.rs
+++ b/rust_extension/src/handlers/file/config.rs
@@ -167,6 +167,10 @@ impl PyHandlerConfig {
             Err(pyo3::exceptions::PyValueError::new_err(
                 "timeout_ms can only be set when policy is 'timeout'",
             ))
+        } else if self.policy == "timeout" && value.is_none() {
+            Err(pyo3::exceptions::PyValueError::new_err(
+                "timeout_ms required when policy is 'timeout'",
+            ))
         } else if matches!(value, Some(ms) if ms == 0) {
             Err(pyo3::exceptions::PyValueError::new_err(
                 "timeout_ms must be greater than zero",
@@ -188,6 +192,24 @@ impl PyHandlerConfig {
     fn set_flush_interval(&mut self, value: usize) -> PyResult<()> {
         Self::validate_positive(value, "flush_interval")?;
         self.flush_interval = value;
+        Ok(())
+    }
+
+    /// Atomically switch to the TIMEOUT policy with a required, non-zero
+    /// timeout.
+    ///
+    /// # Examples
+    ///
+    /// ```python
+    /// cfg = PyHandlerConfig(1, 1, "drop", timeout_ms=None)
+    /// cfg.set_policy_timeout(250)
+    /// assert cfg.policy == "timeout"
+    /// assert cfg.timeout_ms == 250
+    /// ```
+    pub fn set_policy_timeout(&mut self, timeout_ms: u64) -> PyResult<()> {
+        Self::validate_policy("timeout", Some(timeout_ms))?;
+        self.policy = "timeout".to_string();
+        self.timeout_ms = Some(timeout_ms);
         Ok(())
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from contextlib import closing, contextmanager
+import gc
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Callable, ContextManager, Generator
 
@@ -29,9 +30,13 @@ def file_handler_factory() -> FileHandlerFactory:
             OverflowPolicy.DROP.value,
             timeout_ms=None,
         )
-        with closing(
-            FemtoFileHandler.with_capacity_flush_policy(str(path), cfg)
-        ) as handler:
+        handler = FemtoFileHandler.with_capacity_flush_policy(str(path), cfg)
+        try:
             yield handler
+        finally:
+            if hasattr(handler, "close"):
+                handler.close()
+            del handler
+            gc.collect()
 
     return factory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,8 +34,7 @@ def file_handler_factory() -> FileHandlerFactory:
         try:
             yield handler
         finally:
-            if hasattr(handler, "close"):
-                handler.close()
+            handler.close()
             del handler
             gc.collect()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,9 @@ def file_handler_factory() -> FileHandlerFactory:
         try:
             yield handler
         finally:
+            # Ensure the worker thread shuts down deterministically.
+            # Close explicitly, then force finalization in case any ref-cycles
+            # or delayed drops remain that could otherwise leak threads in CI.
             handler.close()
             del handler
             gc.collect()

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -257,7 +257,9 @@ def test_overflow_policy_builder_invalid(tmp_path: Path) -> None:
 def test_overflow_policy_builder_timeout_missing_ms(tmp_path: Path) -> None:
     """Timeout policy without ``timeout_ms`` is rejected."""
     path = tmp_path / "missing_ms.log"
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="timeout_ms required when policy is 'timeout'"
+    ):
         FemtoFileHandler.with_capacity_flush_policy(
             str(path),
             PyHandlerConfig(

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -332,6 +332,10 @@ def test_py_handler_config_set_timeout_missing_for_timeout_policy() -> None:
         ValueError, match="timeout_ms required when policy is 'timeout'"
     ):
         cfg.timeout_ms = None
+    assert cfg.timeout_ms == 1
+    assert cfg.capacity == 1
+    assert cfg.flush_interval == 1
+    assert cfg.policy == OverflowPolicy.TIMEOUT.value
 
 
 def test_py_handler_config_set_policy_timeout(tmp_path: Path) -> None:

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -338,6 +338,8 @@ def test_py_handler_config_set_policy_timeout(tmp_path: Path) -> None:
     """Switching to ``timeout`` policy sets ``timeout_ms`` atomically."""
     cfg = PyHandlerConfig(1, 1, OverflowPolicy.DROP.value, timeout_ms=None)
     cfg.set_policy_timeout(50)
+    assert cfg.policy == OverflowPolicy.TIMEOUT.value
+    assert cfg.timeout_ms == 50
     path = tmp_path / "policy_timeout.log"
     with closing(
         FemtoFileHandler.with_capacity_flush_policy(str(path), cfg)


### PR DESCRIPTION
## Summary
- close test file handlers before GC to avoid leaked threads
- document worker barrier sync and correct link spacing
- validate overflow policies via a shared constant and reject zero timeouts
- assert missing timeout message for timeout policy configuration

## Testing
- `make fmt`
- `RUSTC_WRAPPER= make lint`
- `RUSTC_WRAPPER= make test`
- `make markdownlint`
- `make nixie` *(fails: FileNotFound errors while copying mermaid-related packages)*

------
https://chatgpt.com/codex/tasks/task_e_689e033689608322aa972ad93efdae1b

## Summary by Sourcery

Ensure proper cleanup of file handler resources in tests, refine overflow policy validation by using a shared constant and rejecting zero timeouts, update related tests, and correct documentation formatting.

Bug Fixes:
- Close FemtoFileHandler instances in tests to prevent leaked threads
- Reject zero-millisecond timeout values in overflow policy validation

Enhancements:
- Centralize valid overflow policies in a shared constant for validation

Documentation:
- Fix markdown link formatting and correct spelling in documentation

Tests:
- Update test fixtures to explicitly close handlers and adjust assertions for refined error messages