### PR TITLE
Add multithreaded file logging example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,8 +55,10 @@ cover/
 *.mo
 *.pot
 
+# Logs
+*.log
+
 # Django stuff:
-**/*.log
 local_settings.py
 db.sqlite3
 db.sqlite3-journal

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ cover/
 *.pot
 
 # Django stuff:
-*.log
+**/*.log
 local_settings.py
 db.sqlite3
 db.sqlite3-journal

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ release: ## Build release artifact
 
 clean: ## Remove build artifacts
 	$(CARGO) clean --manifest-path $(RUST_MANIFEST)
+	find . -name '*.log' -delete
 
 define ensure_tool
 $(if $(shell command -v $(1) >/dev/null 2>&1 && echo y),,\

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ release: ## Build release artifact
 
 clean: ## Remove build artifacts
 	$(CARGO) clean --manifest-path $(RUST_MANIFEST)
-	find . -name '*.log' -delete
+	find . -type f -name '*.log' -not -path './target/*' -delete
 
 define ensure_tool
 $(if $(shell command -v $(1) >/dev/null 2>&1 && echo y),,\

--- a/examples/multithreaded_file_logging.py
+++ b/examples/multithreaded_file_logging.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "femtologging @ {path = \"..\"}",
+# ]
+# ///
+"""Demonstrate femtologging's builder API with a file handler in many threads."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from random import randint
+from threading import Thread
+
+from femtologging import (
+    ConfigBuilder,
+    FileHandlerBuilder,
+    FormatterBuilder,
+    LoggerConfigBuilder,
+    get_logger,
+)
+
+
+def configure(logging_path: Path) -> None:
+    """Initialise femtologging with a file handler.
+
+    Using the builder pattern ensures the configuration is explicit and easy to
+    follow. The handler writes to ``logging_path`` and the root logger forwards
+    all records to it.
+    """
+
+    fmt = FormatterBuilder().with_format("{asctime} {threadName} {levelname} {message}")
+
+    handler = (
+        FileHandlerBuilder(str(logging_path))
+        .with_capacity(1024 * 1024)
+        .with_formatter("fmt")
+    )
+
+    config = (
+        ConfigBuilder()
+        .with_formatter("fmt", fmt)
+        .with_handler("file", handler)
+        .with_root_logger(
+            LoggerConfigBuilder().with_level("INFO").with_handlers(["file"])
+        )
+    )
+    config.build_and_init()
+
+
+def worker(thread_id: int) -> None:
+    """Generate and log a random range of integers."""
+    logger = get_logger("example")
+    start = randint(0, 1000)
+    stop = start + randint(10, 100)
+    for value in range(start, stop):
+        logger.info("thread %s produced %s", thread_id, value)
+
+
+def main() -> None:
+    """Configure logging and spawn worker threads."""
+    log_path = Path(__file__).with_suffix(".log")
+    configure(log_path)
+
+    threads = [Thread(target=worker, args=(i,), name=f"worker-{i}") for i in range(64)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multithreaded_file_logging.py
+++ b/examples/multithreaded_file_logging.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv run
+#!/usr/bin/env python3
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
@@ -25,22 +25,27 @@ from femtologging import (
 def configure(logging_path: Path) -> None:
     """Initialise femtologging with a file handler.
 
-    Using the builder pattern ensures the configuration is explicit and easy to
-    follow. The handler writes to ``logging_path`` and the root logger forwards
-    all records to it.
+    Parameters
+    ----------
+    logging_path : Path
+        Destination log file.
+
+    Notes
+    -----
+    Use the builder pattern to keep configuration explicit and easy to follow.
+    The handler writes to ``logging_path`` and the root logger forwards all
+    records to it.
     """
 
-    fmt = FormatterBuilder().with_format("{asctime} {threadName} {levelname} {message}")
-
-    handler = (
-        FileHandlerBuilder(str(logging_path))
-        .with_capacity(1024 * 1024)
-        .with_formatter("fmt")
+    simple_formatter = FormatterBuilder().with_format(
+        "{asctime} {threadName} {levelname} {name} {message}"
     )
+
+    handler = FileHandlerBuilder(str(logging_path)).with_formatter("simple_formatter")
 
     config = (
         ConfigBuilder()
-        .with_formatter("fmt", fmt)
+        .with_formatter("simple_formatter", simple_formatter)
         .with_handler("file", handler)
         .with_root_logger(
             LoggerConfigBuilder().with_level("INFO").with_handlers(["file"])
@@ -55,7 +60,7 @@ def worker(thread_id: int) -> None:
     start = randint(0, 1000)
     stop = start + randint(10, 100)
     for value in range(start, stop):
-        logger.info("thread %s produced %s", thread_id, value)
+        logger.info(f"thread {thread_id} produced {value}")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add executable example demonstrating file handler configuration with the builder API
- show 64 worker threads logging random integer ranges

## Testing
- `make fmt`
- `RUSTC_WRAPPER= make lint`
- `RUSTC_WRAPPER= make test`


------
https://chatgpt.com/codex/tasks/task_e_689e8f4382848322996207b5f58b3e49

## Summary by Sourcery

New Features:
- Add examples/multithreaded_file_logging.py showcasing file handler setup and multithreaded logging using the builder API.