### PR TITLE
Share handler instances across loggers

### DIFF
--- a/docs/configuration-design.md
+++ b/docs/configuration-design.md
@@ -159,9 +159,9 @@ pub trait HandlerBuilderTrait: Send + Sync {
 // `build_handler(&ConfigContext)` design has been dropped; shared state is
 // injected through builder fields instead of a dedicated context object.
 //
-// Built handlers are wrapped in `Arc` during realisation. The same `Arc` is
-// attached to multiple loggers, enabling safe cross-thread sharing of a single
-// handler instance.
+// Built handlers are wrapped in `Arc<dyn FemtoHandlerTrait>` during realisation.
+// The same `Arc` is attached to multiple loggers, enabling safe cross-thread
+// sharing of a single handler instance.
 
 // Example: In femtologging::handlers::FileHandlerBuilder
 pub struct FileHandlerBuilder {

--- a/docs/configuration-design.md
+++ b/docs/configuration-design.md
@@ -13,6 +13,8 @@ programmatic and type-safe setup of the logging system.
 
 ```rust
 // In femtologging::config::ConfigBuilder
+type DynHandlerBuilder = Box<dyn HandlerBuilderTrait + AsPyDict + Send + Sync>;
+
 pub struct ConfigBuilder {
     // Internal state to hold configuration parts
     version: u8,
@@ -20,7 +22,7 @@ pub struct ConfigBuilder {
     default_level: Option<Level>,
     formatters: BTreeMap<String, FormatterBuilder>,
     filters: BTreeMap<String, FilterBuilder>, // Future: FilterBuilder
-    handlers: BTreeMap<String, HandlerBuilder>,
+    handlers: BTreeMap<String, DynHandlerBuilder>,
     loggers: BTreeMap<String, LoggerConfigBuilder>,
     root_logger: Option<LoggerConfigBuilder>,
 }
@@ -49,7 +51,10 @@ impl ConfigBuilder {
     // } // Future
 
     /// Adds a handler configuration by its unique ID.
-    pub fn with_handler(mut self, id: impl Into<String>, builder: HandlerBuilder) -> Self {
+    pub fn with_handler<B>(mut self, id: impl Into<String>, builder: B) -> Self
+    where
+        B: HandlerBuilderTrait + AsPyDict + Send + Sync + 'static,
+    {
         /* ... */
     }
 

--- a/docs/configuration-design.md
+++ b/docs/configuration-design.md
@@ -13,7 +13,11 @@ programmatic and type-safe setup of the logging system.
 
 ```rust
 // In femtologging::config::ConfigBuilder
-type DynHandlerBuilder = Box<dyn HandlerBuilderTrait + AsPyDict + Send + Sync>;
+#[derive(Clone, Debug)]
+pub enum HandlerBuilder {
+    Stream(StreamHandlerBuilder),
+    File(FileHandlerBuilder),
+}
 
 pub struct ConfigBuilder {
     // Internal state to hold configuration parts
@@ -22,7 +26,7 @@ pub struct ConfigBuilder {
     default_level: Option<Level>,
     formatters: BTreeMap<String, FormatterBuilder>,
     filters: BTreeMap<String, FilterBuilder>, // Future: FilterBuilder
-    handlers: BTreeMap<String, DynHandlerBuilder>,
+    handlers: BTreeMap<String, HandlerBuilder>, // Concrete enum, not trait object
     loggers: BTreeMap<String, LoggerConfigBuilder>,
     root_logger: Option<LoggerConfigBuilder>,
 }
@@ -53,7 +57,7 @@ impl ConfigBuilder {
     /// Adds a handler configuration by its unique ID.
     pub fn with_handler<B>(mut self, id: impl Into<String>, builder: B) -> Self
     where
-        B: HandlerBuilderTrait + AsPyDict + Send + Sync + 'static,
+        B: Into<HandlerBuilder>,
     {
         /* ... */
     }

--- a/docs/configuration-design.md
+++ b/docs/configuration-design.md
@@ -27,7 +27,9 @@ pub struct ConfigBuilder {
     default_level: Option<Level>,
     formatters: BTreeMap<String, FormatterBuilder>,
     filters: BTreeMap<String, FilterBuilder>, // Future: FilterBuilder
-    handlers: BTreeMap<String, HandlerBuilder>, // Later insertions with the same ID overwrite earlier ones
+    handlers: BTreeMap<String, HandlerBuilder>,
+    // `HandlerBuilder` is a concrete enum; later insertions with the same ID
+    // overwrite earlier ones.
     loggers: BTreeMap<String, LoggerConfigBuilder>,
     root_logger: Option<LoggerConfigBuilder>,
 }

--- a/docs/configuration-roadmap.md
+++ b/docs/configuration-roadmap.md
@@ -19,10 +19,10 @@ expanded with specifics for the configuration design.
     via explicit fields; the previously proposed `ConfigContext` has been
     dropped.
 
-- [ ] **Enable multiple handler IDs to be attached to a single logger in the
+- [x] **Enable multiple handler IDs to be attached to a single logger in the
   builder API.**
 
-- [ ] **Store handlers in an `Arc` so that several loggers can share one
+- [x] **Store handlers in an `Arc` so that several loggers can share one
   instance safely.**
 
 - [x] **Introduce a `Manager` registry with dotted-name hierarchy support and a

--- a/rust_extension/src/config.rs
+++ b/rust_extension/src/config.rs
@@ -487,8 +487,8 @@ mod tests {
     use super::*;
     use pyo3::Python;
     use rstest::rstest;
-    // Serialise tests that mutate the global manager to avoid race conditions.
     use serial_test::serial;
+    use std::sync::Arc;
 
     #[rstest]
     fn build_rejects_invalid_version() {
@@ -525,9 +525,12 @@ mod tests {
             builder.build_and_init().expect("build should succeed");
             let first = manager::get_logger(py, "first").unwrap();
             let second = manager::get_logger(py, "second").unwrap();
-            let h1 = first.borrow(py).handler_ptrs_for_test();
-            let h2 = second.borrow(py).handler_ptrs_for_test();
-            assert_eq!(h1[0], h2[0], "handler should be shared");
+            let h1 = first.borrow(py).handlers_for_test();
+            let h2 = second.borrow(py).handlers_for_test();
+            assert!(
+                Arc::ptr_eq(&h1[0], &h2[0]),
+                "handler Arc pointers should be shared"
+            );
         });
     }
 

--- a/rust_extension/src/config.rs
+++ b/rust_extension/src/config.rs
@@ -457,6 +457,8 @@ mod tests {
     use super::*;
     use pyo3::Python;
     use rstest::rstest;
+    // Serialise tests that mutate the global manager to avoid race conditions.
+    use serial_test::serial;
 
     #[rstest]
     fn build_rejects_invalid_version() {
@@ -478,6 +480,7 @@ mod tests {
     }
 
     #[rstest]
+    #[serial]
     fn shared_handler_attached_once() {
         Python::with_gil(|py| {
             manager::reset_manager();
@@ -499,6 +502,7 @@ mod tests {
     }
 
     #[rstest]
+    #[serial]
     fn unknown_handler_id_rejected() {
         let root = LoggerConfigBuilder::new().with_level(FemtoLevel::Info);
         let logger_cfg = LoggerConfigBuilder::new().with_handlers(["missing"]);

--- a/rust_extension/src/handlers/common.rs
+++ b/rust_extension/src/handlers/common.rs
@@ -6,12 +6,14 @@ use std::num::NonZeroUsize;
 
 use pyo3::{prelude::*, types::PyDict, Bound};
 
+use super::FormatterId;
+
 #[derive(Clone, Debug, Default)]
 pub struct CommonBuilder {
     pub(crate) capacity: Option<NonZeroUsize>,
     pub(crate) capacity_set: bool,
     pub(crate) flush_timeout_ms: Option<u64>,
-    pub(crate) formatter_id: Option<String>,
+    pub(crate) formatter_id: Option<FormatterId>,
 }
 
 impl CommonBuilder {
@@ -55,7 +57,7 @@ impl CommonBuilder {
             d.set_item("flush_timeout_ms", ms)?;
         }
         if let Some(fid) = &self.formatter_id {
-            d.set_item("formatter_id", fid)?;
+            d.set_item("formatter_id", fid.as_str())?;
         }
         Ok(())
     }

--- a/rust_extension/src/handlers/common.rs
+++ b/rust_extension/src/handlers/common.rs
@@ -4,10 +4,14 @@
 
 use std::num::NonZeroUsize;
 
+use pyo3::{prelude::*, types::PyDict, Bound};
+
 #[derive(Clone, Debug, Default)]
 pub struct CommonBuilder {
     pub(crate) capacity: Option<NonZeroUsize>,
     pub(crate) capacity_set: bool,
+    pub(crate) flush_timeout_ms: Option<u64>,
+    pub(crate) formatter_id: Option<String>,
 }
 
 impl CommonBuilder {
@@ -40,5 +44,19 @@ impl CommonBuilder {
         } else {
             Ok(())
         }
+    }
+
+    /// Extend a Python dictionary with common builder fields.
+    pub(crate) fn extend_py_dict(&self, d: &Bound<'_, PyDict>) -> PyResult<()> {
+        if let Some(cap) = self.capacity {
+            d.set_item("capacity", cap.get())?;
+        }
+        if let Some(ms) = self.flush_timeout_ms {
+            d.set_item("flush_timeout_ms", ms)?;
+        }
+        if let Some(fid) = &self.formatter_id {
+            d.set_item("formatter_id", fid)?;
+        }
+        Ok(())
     }
 }

--- a/rust_extension/src/handlers/file_builder.rs
+++ b/rust_extension/src/handlers/file_builder.rs
@@ -112,7 +112,7 @@ impl AsPyDict for FileHandlerBuilder {
     fn as_pydict(&self, py: Python<'_>) -> PyResult<PyObject> {
         let d = pyo3::types::PyDict::new(py);
         self.fill_pydict(&d)?;
-        Ok(d.into())
+        Ok(d.unbind().into())
     }
 }
 
@@ -177,7 +177,7 @@ impl FileHandlerBuilder {
     fn as_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
         let d = pyo3::types::PyDict::new(py);
         self.fill_pydict(&d)?;
-        Ok(d.into())
+        Ok(d.unbind().into())
     }
 
     /// Build the handler, raising ``HandlerConfigError`` or ``HandlerIOError`` on

--- a/rust_extension/src/handlers/formatter_id.rs
+++ b/rust_extension/src/handlers/formatter_id.rs
@@ -1,0 +1,37 @@
+//! Identifier for registered formatters.
+//!
+//! Distinguishes between built-in formatter identifiers and arbitrary
+//! user-provided IDs to avoid scattering string comparisons.
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum FormatterId {
+    /// The built-in default formatter.
+    Default,
+    /// A user-specified formatter identifier.
+    Custom(String),
+}
+
+impl FormatterId {
+    /// Return the identifier as a string slice.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Default => "default",
+            Self::Custom(id) => id.as_str(),
+        }
+    }
+}
+
+impl From<String> for FormatterId {
+    fn from(id: String) -> Self {
+        match id.as_str() {
+            "default" => Self::Default,
+            _ => Self::Custom(id),
+        }
+    }
+}
+
+impl From<&str> for FormatterId {
+    fn from(id: &str) -> Self {
+        Self::from(id.to_owned())
+    }
+}

--- a/rust_extension/src/handlers/mod.rs
+++ b/rust_extension/src/handlers/mod.rs
@@ -15,11 +15,13 @@ use crate::handler::FemtoHandlerTrait;
 mod common;
 pub mod file;
 pub mod file_builder;
+mod formatter_id;
 pub mod stream_builder;
 #[cfg(test)]
 pub mod test_helpers;
 
 pub use file_builder::FileHandlerBuilder;
+pub use formatter_id::FormatterId;
 pub use stream_builder::StreamHandlerBuilder;
 
 // Define module-level Python exceptions for explicit handling on the Python side.

--- a/rust_extension/src/handlers/stream_builder.rs
+++ b/rust_extension/src/handlers/stream_builder.rs
@@ -18,6 +18,15 @@ enum StreamTarget {
     Stderr,
 }
 
+impl StreamTarget {
+    fn as_str(&self) -> &'static str {
+        match self {
+            StreamTarget::Stdout => "stdout",
+            StreamTarget::Stderr => "stderr",
+        }
+    }
+}
+
 /// Builder for constructing [`FemtoStreamHandler`] instances.
 #[pyclass]
 #[derive(Clone, Debug)]
@@ -81,15 +90,9 @@ impl AsPyDict for StreamHandlerBuilder {
     fn as_pydict(&self, py: Python<'_>) -> PyResult<PyObject> {
         use pyo3::types::PyDict;
         let d = PyDict::new(py);
-        d.set_item(
-            "target",
-            match self.target {
-                StreamTarget::Stdout => "stdout",
-                StreamTarget::Stderr => "stderr",
-            },
-        )?;
+        d.set_item("target", self.target.as_str())?;
         self.common.extend_py_dict(&d)?;
-        Ok(d.into())
+        Ok(d.unbind().into())
     }
 }
 

--- a/rust_extension/src/logger.rs
+++ b/rust_extension/src/logger.rs
@@ -171,6 +171,14 @@ impl FemtoLogger {
             }
         })
     }
+
+    fn handlers_for_test(&self) -> Vec<usize> {
+        self.handlers
+            .read()
+            .iter()
+            .map(|h| Arc::as_ptr(h) as *const () as usize)
+            .collect()
+    }
 }
 
 impl FemtoLogger {
@@ -190,8 +198,13 @@ impl FemtoLogger {
         }
     }
 
+    /// Return raw, stable pointers to the underlying handler `Arc`s.
+    ///
+    /// This is for tests to assert handler identity across loggers. The
+    /// returned pointers remain valid while the logger holds the `Arc`s and are
+    /// not exposed to Python.
     #[cfg(test)]
-    pub fn handlers_for_test(&self) -> Vec<*const ()> {
+    pub fn handler_ptrs_for_test(&self) -> Vec<*const ()> {
         self.handlers
             .read()
             .iter()

--- a/rust_extension/src/logger.rs
+++ b/rust_extension/src/logger.rs
@@ -172,7 +172,7 @@ impl FemtoLogger {
         })
     }
 
-    fn handlers_for_test(&self) -> Vec<usize> {
+    fn handler_ptrs_for_test(&self) -> Vec<usize> {
         self.handlers
             .read()
             .iter()
@@ -198,18 +198,9 @@ impl FemtoLogger {
         }
     }
 
-    /// Return raw, stable pointers to the underlying handler `Arc`s.
-    ///
-    /// This is for tests to assert handler identity across loggers. The
-    /// returned pointers remain valid while the logger holds the `Arc`s and are
-    /// not exposed to Python.
     #[cfg(test)]
-    pub fn handler_ptrs_for_test(&self) -> Vec<*const ()> {
-        self.handlers
-            .read()
-            .iter()
-            .map(|h| Arc::as_ptr(h) as *const ())
-            .collect()
+    pub fn handlers_for_test(&self) -> Vec<Arc<dyn FemtoHandlerTrait>> {
+        self.handlers.read().clone()
     }
 
     /// Clone the internal sender for use in tests.

--- a/rust_extension/src/logger.rs
+++ b/rust_extension/src/logger.rs
@@ -190,6 +190,15 @@ impl FemtoLogger {
         }
     }
 
+    #[cfg(test)]
+    pub fn handlers_for_test(&self) -> Vec<*const ()> {
+        self.handlers
+            .read()
+            .iter()
+            .map(|h| Arc::as_ptr(h) as *const ())
+            .collect()
+    }
+
     /// Clone the internal sender for use in tests.
     ///
     /// # Warning

--- a/rust_extension/src/macros.rs
+++ b/rust_extension/src/macros.rs
@@ -14,7 +14,7 @@ use pyo3::{
 use std::collections::BTreeMap;
 
 /// Convert a configuration builder into a Python dictionary.
-pub(crate) trait AsPyDict {
+pub trait AsPyDict {
     /// Return the builder's state as a Python dictionary.
     fn as_pydict(&self, py: Python<'_>) -> PyResult<PyObject>;
 }

--- a/tests/__snapshots__/test_config_builder.ambr
+++ b/tests/__snapshots__/test_config_builder.ambr
@@ -1,4 +1,30 @@
 # serializer version: 1
+# name: test_attach_handler_to_multiple_loggers
+  dict({
+    'disable_existing_loggers': False,
+    'handlers': dict({
+      'console': dict({
+        'target': 'stderr',
+      }),
+    }),
+    'loggers': dict({
+      'core': dict({
+        'handlers': list([
+          'console',
+        ]),
+      }),
+      'worker': dict({
+        'handlers': list([
+          'console',
+        ]),
+      }),
+    }),
+    'root': dict({
+      'level': 'INFO',
+    }),
+    'version': 1,
+  })
+# ---
 # name: test_build_simple_configuration
   dict({
     'disable_existing_loggers': False,

--- a/tests/features/config_builder.feature
+++ b/tests/features/config_builder.feature
@@ -18,9 +18,10 @@ Feature: ConfigBuilder
     And I add logger "worker" with handler "console"
     And I set root logger with level "INFO"
     Then the configuration matches snapshot
+    And loggers "core" and "worker" share handler "console"
 
   Scenario: unknown handler id
     Given a ConfigBuilder
     When I add logger "core" with handler "missing"
     And I set root logger with level "INFO"
-    Then building the configuration fails
+    Then building the configuration fails with error containing "unknown handler id: missing"

--- a/tests/features/config_builder.feature
+++ b/tests/features/config_builder.feature
@@ -10,3 +10,17 @@ Feature: ConfigBuilder
     Given a ConfigBuilder
     When I set version 2
     Then building the configuration fails
+
+  Scenario: attach handler to multiple loggers
+    Given a ConfigBuilder
+    When I add stream handler "console"
+    And I add logger "core" with handler "console"
+    And I add logger "worker" with handler "console"
+    And I set root logger with level "INFO"
+    Then the configuration matches snapshot
+
+  Scenario: unknown handler id
+    Given a ConfigBuilder
+    When I add logger "core" with handler "missing"
+    And I set root logger with level "INFO"
+    Then building the configuration fails

--- a/tests/features/config_builder.feature
+++ b/tests/features/config_builder.feature
@@ -13,7 +13,7 @@ Feature: ConfigBuilder
 
   Scenario: attach handler to multiple loggers
     Given a ConfigBuilder
-    When I add stream handler "console"
+    When I add stream handler "console" targeting "stderr"
     And I add logger "core" with handler "console"
     And I add logger "worker" with handler "console"
     And I set root logger with level "INFO"

--- a/tests/test_config_builder.py
+++ b/tests/test_config_builder.py
@@ -27,9 +27,13 @@ def add_logger(config_builder: ConfigBuilder) -> None:
     config_builder.with_logger("core", logger)
 
 
-@when(parsers.parse('I add stream handler "{hid}"'))
-def add_stream_handler(config_builder: ConfigBuilder, hid: str) -> None:
-    handler = StreamHandlerBuilder.stderr()
+@when(parsers.parse('I add stream handler "{hid}" targeting "{target}"'))
+def add_stream_handler(config_builder: ConfigBuilder, hid: str, target: str) -> None:
+    handler = (
+        StreamHandlerBuilder.stderr()
+        if target.lower() == "stderr"
+        else StreamHandlerBuilder.stdout()
+    )
     config_builder.with_handler(hid, handler)
 
 
@@ -86,8 +90,8 @@ def loggers_share_handler(first: str, second: str, hid: str) -> None:
     del hid  # parameter required by step signature
     first_logger = get_logger(first)
     second_logger = get_logger(second)
-    h1 = first_logger.handlers_for_test()
-    h2 = second_logger.handlers_for_test()
+    h1 = first_logger.handler_ptrs_for_test()
+    h2 = second_logger.handler_ptrs_for_test()
     assert h1[0] == h2[0], "handlers should be shared"
 
 

--- a/tests/test_config_builder.py
+++ b/tests/test_config_builder.py
@@ -89,6 +89,22 @@ def test_duplicate_formatter_overwrites() -> None:
     )
 
 
+def test_duplicate_handler_overwrites() -> None:
+    """Second handler with same ID should replace the first."""
+    builder = ConfigBuilder()
+    handler1 = StreamHandlerBuilder.stderr()
+    handler2 = StreamHandlerBuilder.stdout()
+    builder.with_handler("console", handler1)
+    builder.with_handler("console", handler2)
+    logger = LoggerConfigBuilder().with_handlers(["console"])
+    builder.with_logger("core", logger)
+    builder.with_root_logger(LoggerConfigBuilder().with_level("INFO"))
+    config = builder.as_dict()
+    assert config["handlers"]["console"]["target"] == "stdout", (
+        "Later handler should overwrite earlier one",
+    )
+
+
 def test_duplicate_logger_overwrites() -> None:
     """Second logger with same ID should replace the first."""
     builder = ConfigBuilder()


### PR DESCRIPTION
## Summary
- allow ConfigBuilder to register handlers and attach them to multiple loggers
- build handlers once and share them via `Arc` across loggers
- document and test the new handler-sharing configuration API

## Testing
- `RUSTC_WRAPPER= make lint`
- `RUSTC_WRAPPER= make test`
- `make markdownlint`
- `make nixie` *(fails: Error running command bun x @mermaid-js/mermaid-cli)*

------
https://chatgpt.com/codex/tasks/task_e_689e40c0d3b48322a7c2b7bccbed4c43

## Summary by Sourcery

Enable handler registration and sharing across loggers by building each handler once into an Arc and attaching it by identifier to multiple loggers.

New Features:
- Allow ConfigBuilder to register handler builders and attach them to multiple loggers by identifier
- Build handlers once into Arc<dyn FemtoHandlerTrait> and share the same instance across loggers
- Expose handler-sharing API to Python with a unified `with_handler` method and dict representation

Enhancements:
- Unify `as_dict` implementations for FileHandlerBuilder and StreamHandlerBuilder via a new AsPyDict trait
- Add error handling for unknown handler identifiers and handler build failures

Documentation:
- Update configuration design and roadmap documentation to describe handler-sharing via Arc

Tests:
- Add Rust and Python tests verifying that handlers are shared across loggers and that unknown handler IDs are rejected