### PR TITLE
Document builder test suite completion

### DIFF
--- a/docs/configuration-design.md
+++ b/docs/configuration-design.md
@@ -550,4 +550,4 @@ to the appropriate loggers.
 A basic test suite validates these builders. Rust unit tests use `rstest` to
 cover success and failure cases, while Python behavioural tests leverage
 `pytest-bdd` with `syrupy` snapshots to assert dictionary output and
-initialisation errors.
+initialization errors.

--- a/docs/configuration-design.md
+++ b/docs/configuration-design.md
@@ -546,3 +546,8 @@ The initial implementation introduces `ConfigBuilder`, `LoggerConfigBuilder`,
 fluent, chainable methods exposed to Python via `PyO3`. `build_and_init`
 constructs each configured handler once, wraps it in an `Arc`, and attaches it
 to the appropriate loggers.
+
+A basic test suite validates these builders. Rust unit tests use `rstest` to
+cover success and failure cases, while Python behavioural tests leverage
+`pytest-bdd` with `syrupy` snapshots to assert dictionary output and
+initialisation errors.

--- a/docs/configuration-roadmap.md
+++ b/docs/configuration-roadmap.md
@@ -41,7 +41,7 @@ expanded with specifics for the configuration design.
 
 - [ ] Ensure all components satisfy `Send`/`Sync` requirements.
 
-- [ ] Establish a basic test suite covering unit and integration tests for the
+- [x] Establish a basic test suite covering unit and integration tests for the
   builder configuration system in both Rust and Python.
 
 ## Phase 2 – Expanded Handlers & Core Features (Configuration-related tasks)

--- a/docs/configuration-roadmap.md
+++ b/docs/configuration-roadmap.md
@@ -42,7 +42,8 @@ expanded with specifics for the configuration design.
 - [ ] Ensure all components satisfy `Send`/`Sync` requirements.
 
 - [x] Establish a basic test suite covering unit and integration tests for the
-  builder configuration system in both Rust and Python.
+  builder configuration system in both Rust and Python, including syrupy
+  snapshot assertions.
 
 ## Phase 2 – Expanded Handlers & Core Features (Configuration-related tasks)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,7 +45,7 @@ from that design.
 - [x] Provide a programmatic configuration API using the builder pattern.
 - [ ] Add compile‑time log level filtering via Cargo features.
 - [ ] Ensure all components satisfy `Send`/`Sync` requirements.
-- [ ] Establish a basic test suite covering unit and integration tests.
+- [x] Establish a basic test suite covering unit and integration tests.
 
 ## Phase 2 – Expanded Handlers & Core Features
 

--- a/tests/test_config_builder.py
+++ b/tests/test_config_builder.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest_bdd import given, when, then, scenarios, parsers
+from syrupy import SnapshotAssertion
 
 from femtologging import (
     ConfigBuilder,
@@ -62,7 +63,9 @@ def set_root(config_builder: ConfigBuilder, level: str) -> None:
 
 
 @then("the configuration matches snapshot")
-def configuration_matches_snapshot(config_builder: ConfigBuilder, snapshot) -> None:
+def configuration_matches_snapshot(
+    config_builder: ConfigBuilder, snapshot: SnapshotAssertion
+) -> None:
     assert config_builder.as_dict() == snapshot
     config_builder.build_and_init()
 

--- a/tests/test_handler_builders.py
+++ b/tests/test_handler_builders.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 from pytest_bdd import given, scenarios, then, when, parsers
+from syrupy import SnapshotAssertion
 
 from femtologging import (
     FileHandlerBuilder,
@@ -86,7 +87,9 @@ def when_set_stream_formatter(
 
 
 @then("the file handler builder matches snapshot")
-def then_file_builder_snapshot(file_builder: FileHandlerBuilder, snapshot) -> None:
+def then_file_builder_snapshot(
+    file_builder: FileHandlerBuilder, snapshot: SnapshotAssertion
+) -> None:
     data = file_builder.as_dict()
     data["path"] = Path(data["path"]).name
     assert data == snapshot, "file builder dict must match snapshot"
@@ -96,7 +99,7 @@ def then_file_builder_snapshot(file_builder: FileHandlerBuilder, snapshot) -> No
 
 @then("the file handler builder with timeout overflow matches snapshot")
 def then_file_builder_timeout_snapshot(
-    file_builder: FileHandlerBuilder, snapshot
+    file_builder: FileHandlerBuilder, snapshot: SnapshotAssertion
 ) -> None:
     data = file_builder.as_dict()
     data["path"] = Path(data["path"]).name
@@ -115,7 +118,7 @@ def then_file_builder_fails(file_builder: FileHandlerBuilder) -> None:
 
 @then("the stream handler builder matches snapshot")
 def then_stream_builder_snapshot(
-    stream_builder: StreamHandlerBuilder, snapshot
+    stream_builder: StreamHandlerBuilder, snapshot: SnapshotAssertion
 ) -> None:
     assert stream_builder.as_dict() == snapshot, (
         "stream builder dict must match snapshot"


### PR DESCRIPTION
## Summary
- mark configuration roadmap as complete for initial test suite
- note cross-language tests in configuration design notes

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: Error running command bun x --bun @mermaid-js/mermaid-cli ... FileNotFound: failed copying files from cache to destination for package mermaid)*

------
https://chatgpt.com/codex/tasks/task_e_689fca93590c8322b96a843007291104

## Summary by Sourcery

Document the completion of the initial configuration builder test suite and add cross-language testing details to design and roadmap documentation.

Documentation:
- Mark the basic builder configuration test suite as complete in configuration-roadmap.md and roadmap.md
- Add details on Rust (rstest) and Python (pytest-bdd with syrupy) test implementations in configuration-design.md