### PR TITLE
Use into_py_any for PyDict conversions

### DIFF
--- a/docs/dependency-analysis.md
+++ b/docs/dependency-analysis.md
@@ -19,7 +19,7 @@ implementation:
 
 - **PyO3** provides bindings so the Rust library can be imported from Python. It
   replaces the C++ extension used by picologging. The project now targets
-  `pyo3` version `>=0.25.1,<0.26.0` to ensure compatibility with Python 3.14.
+  `pyo3` version `^0.25.1` to ensure compatibility with Python 3.14.
 - **crossbeam-channel** (v0.5.15) is recommended as the baseline synchronous
   multi-producer, single-consumer queue for handler threads. Alternatives like
   `flume` or `tokio::sync::mpsc` may be benchmarked later. Version 0.5.15

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -1,9 +1,9 @@
 # Rust Extension
 
 This project includes a small Rust extension built with
-[PyO3](https://pyo3.rs/) (currently `>=0.25.1,<0.26.0`). Initially, it exposed
-only a trivial `hello()` function and the `FemtoLogger` class. It has since
-grown to provide the core handler implementations as well:
+[PyO3](https://pyo3.rs/) (currently `^0.25.1`). Initially, it exposed only a
+trivial `hello()` function and the `FemtoLogger` class. It has since grown to
+provide the core handler implementations as well:
 
 - `FemtoStreamHandler` writes log records to `stdout` or `stderr` on a
   background thread.
@@ -30,11 +30,16 @@ declares the extension module as `femtologging._femtologging_rs`, so running
 MSVC build tools installed, or may need to run maturin with
 `--compatibility windows` to build.
 
-PyO3 0.25 introduced `Bound` return types for constructors like
-`PyDict::new(py)`. When these dictionaries must be returned to Python, convert
-them using `into_py_any(py)` rather than the pre‑0.25 pattern of
-`unbind().into()`. This ensures the object remains bound to the GIL during the
-conversion.
+PyO3 0.25 introduced `Bound` return types for constructors such as
+`PyDict::new(py)`. When dictionaries must be returned to Python, use
+`pyo3::IntoPyObjectExt::into_py_any(d, py)` rather than the pre‑0.25 pattern of
+`unbind().into()`. This keeps the object bound to the Global Interpreter Lock
+(GIL) during conversion.
+
+```rust
+let d = pyo3::types::PyDict::new(py);
+let obj = pyo3::IntoPyObjectExt::into_py_any(d, py)?;
+```
 
 `FemtoLogRecord` now groups its contextual fields into a `RecordMetadata`
 struct. Each record stores a timestamp, source file and line, module path and

--- a/docs/rust-extension.md
+++ b/docs/rust-extension.md
@@ -30,6 +30,12 @@ declares the extension module as `femtologging._femtologging_rs`, so running
 MSVC build tools installed, or may need to run maturin with
 `--compatibility windows` to build.
 
+PyO3 0.25 introduced `Bound` return types for constructors like
+`PyDict::new(py)`. When these dictionaries must be returned to Python, convert
+them using `into_py_any(py)` rather than the pre‑0.25 pattern of
+`unbind().into()`. This ensures the object remains bound to the GIL during the
+conversion.
+
 `FemtoLogRecord` now groups its contextual fields into a `RecordMetadata`
 struct. Each record stores a timestamp, source file and line, module path and
 thread ID. The thread name is included when available, along with any

--- a/rust_extension/Cargo.toml
+++ b/rust_extension/Cargo.toml
@@ -9,7 +9,7 @@ name = "_femtologging_rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3 = { version = ">=0.25.1,<0.26.0", default-features = false, features = ["macros", "auto-initialize"] }
+pyo3 = { version = "0.25.1", default-features = false, features = ["macros", "auto-initialize"] }
 crossbeam-channel = "0.5.15"
 log = "0.4"
 once_cell = "1"

--- a/rust_extension/src/handlers/file_builder.rs
+++ b/rust_extension/src/handlers/file_builder.rs
@@ -112,7 +112,7 @@ impl AsPyDict for FileHandlerBuilder {
     fn as_pydict(&self, py: Python<'_>) -> PyResult<PyObject> {
         let d = pyo3::types::PyDict::new(py);
         self.fill_pydict(&d)?;
-        Ok(d.unbind().into())
+        pyo3::IntoPyObjectExt::into_py_any(d, py)
     }
 }
 
@@ -177,7 +177,7 @@ impl FileHandlerBuilder {
     fn as_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
         let d = pyo3::types::PyDict::new(py);
         self.fill_pydict(&d)?;
-        Ok(d.unbind().into())
+        pyo3::IntoPyObjectExt::into_py_any(d, py)
     }
 
     /// Build the handler, raising ``HandlerConfigError`` or ``HandlerIOError`` on

--- a/rust_extension/src/handlers/file_builder.rs
+++ b/rust_extension/src/handlers/file_builder.rs
@@ -11,7 +11,10 @@ use std::num::NonZeroUsize;
 use pyo3::prelude::*;
 
 use super::{common::CommonBuilder, file::*, FormatterId, HandlerBuildError, HandlerBuilderTrait};
-use crate::{formatter::DefaultFormatter, macros::AsPyDict};
+use crate::{
+    formatter::DefaultFormatter,
+    macros::{dict_into_py, AsPyDict},
+};
 
 /// Builder for constructing [`FemtoFileHandler`] instances.
 #[pyclass]
@@ -112,7 +115,7 @@ impl AsPyDict for FileHandlerBuilder {
     fn as_pydict(&self, py: Python<'_>) -> PyResult<PyObject> {
         let d = pyo3::types::PyDict::new(py);
         self.fill_pydict(&d)?;
-        pyo3::IntoPyObjectExt::into_py_any(d, py)
+        dict_into_py(d, py)
     }
 }
 
@@ -175,9 +178,7 @@ impl FileHandlerBuilder {
 
     /// Return a dictionary describing the builder configuration.
     fn as_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
-        let d = pyo3::types::PyDict::new(py);
-        self.fill_pydict(&d)?;
-        pyo3::IntoPyObjectExt::into_py_any(d, py)
+        self.as_pydict(py)
     }
 
     /// Build the handler, raising ``HandlerConfigError`` or ``HandlerIOError`` on

--- a/rust_extension/src/handlers/stream_builder.rs
+++ b/rust_extension/src/handlers/stream_builder.rs
@@ -92,7 +92,7 @@ impl AsPyDict for StreamHandlerBuilder {
         let d = PyDict::new(py);
         d.set_item("target", self.target.as_str())?;
         self.common.extend_py_dict(&d)?;
-        Ok(d.unbind().into())
+        pyo3::IntoPyObjectExt::into_py_any(d, py)
     }
 }
 

--- a/rust_extension/src/handlers/stream_builder.rs
+++ b/rust_extension/src/handlers/stream_builder.rs
@@ -10,7 +10,11 @@ use std::{num::NonZeroUsize, time::Duration};
 use pyo3::prelude::*;
 
 use super::{common::CommonBuilder, FormatterId, HandlerBuildError, HandlerBuilderTrait};
-use crate::{formatter::DefaultFormatter, macros::AsPyDict, stream_handler::FemtoStreamHandler};
+use crate::{
+    formatter::DefaultFormatter,
+    macros::{dict_into_py, AsPyDict},
+    stream_handler::FemtoStreamHandler,
+};
 
 #[derive(Clone, Copy, Debug)]
 enum StreamTarget {
@@ -92,7 +96,7 @@ impl AsPyDict for StreamHandlerBuilder {
         let d = PyDict::new(py);
         d.set_item("target", self.target.as_str())?;
         self.common.extend_py_dict(&d)?;
-        pyo3::IntoPyObjectExt::into_py_any(d, py)
+        dict_into_py(d, py)
     }
 }
 

--- a/rust_extension/src/macros.rs
+++ b/rust_extension/src/macros.rs
@@ -111,7 +111,7 @@ macro_rules! impl_as_pydict {
             fn as_pydict(&self, py: Python<'_>) -> PyResult<PyObject> {
                 let d = pyo3::types::PyDict::new(py);
                 $(crate::macros::$setter(py, &d, $key, &self.$field)?;)*
-                Ok(d.unbind().into())
+                pyo3::IntoPyObjectExt::into_py_any(d, py)
             }
         }
     };

--- a/rust_extension/src/macros.rs
+++ b/rust_extension/src/macros.rs
@@ -6,6 +6,7 @@
 //! uniform serialization behaviour across all builder types.
 
 use pyo3::conversion::IntoPyObject;
+use pyo3::IntoPyObjectExt;
 use pyo3::{
     prelude::*,
     types::{PyDict, PyList},
@@ -17,6 +18,25 @@ use std::collections::BTreeMap;
 pub trait AsPyDict {
     /// Return the builder's state as a Python dictionary.
     fn as_pydict(&self, py: Python<'_>) -> PyResult<PyObject>;
+}
+
+/// Convert a [`PyDict`] bound to the current GIL into a [`PyObject`].
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use crate::macros::dict_into_py;
+/// use pyo3::prelude::*;
+///
+/// fn demo(py: Python<'_>) -> PyResult<()> {
+///     let d = pyo3::types::PyDict::new(py);
+///     let obj = dict_into_py(d, py)?;
+///     let _ = obj;
+///     Ok(())
+/// }
+/// ```
+pub(crate) fn dict_into_py(dict: Bound<'_, PyDict>, py: Python<'_>) -> PyResult<PyObject> {
+    dict.into_py_any(py)
 }
 
 pub(crate) fn set_opt<'py, T>(
@@ -111,7 +131,7 @@ macro_rules! impl_as_pydict {
             fn as_pydict(&self, py: Python<'_>) -> PyResult<PyObject> {
                 let d = pyo3::types::PyDict::new(py);
                 $(crate::macros::$setter(py, &d, $key, &self.$field)?;)*
-                pyo3::IntoPyObjectExt::into_py_any(d, py)
+                crate::macros::dict_into_py(d, py)
             }
         }
     };


### PR DESCRIPTION
## Summary
- use `IntoPyObjectExt::into_py_any` to convert `PyDict` instances in `AsPyDict`
- document `into_py_any` requirement for bound dictionaries

## Testing
- `make fmt`
- `make lint`
- `make markdownlint`
- `make test`

closes #149

------
https://chatgpt.com/codex/tasks/task_e_68a427532b2c83229f2fb459c177ffcb

## Summary by Sourcery

Replace all instances of unbind-and-into conversion for PyDict with IntoPyObjectExt::into_py_any to properly handle PyO3 0.25 Bound return types and update documentation accordingly.

Enhancements:
- Adopt IntoPyObjectExt::into_py_any for converting PyDict instances in AsPyDict implementations
- Ensure PyDicts remain bound to the GIL by switching from unbind().into() to into_py_any

Documentation:
- Document the need to use into_py_any for returning bound PyDicts in Rust extensions