### PR TITLE
Add project authors to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "femtologging package"
 readme = "README.md"
 requires-python = ">=3.12"
 license = { text = "ISC" }
+authors = [{ name = "Payton McIntosh", email = "pmcintosh@df12.net" }]
 dependencies = []
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
- add authors entry to pyproject metadata

## Testing
- `make fmt` (fails: .rules/python-pyproject.md missing link references)
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a6e89417388322aebc13ad87d5aad7