### PR TITLE
Scope MD053 markdownlint suppression to footnotes

### DIFF
--- a/.rules/python-pyproject.md
+++ b/.rules/python-pyproject.md
@@ -1,5 +1,3 @@
-<!-- markdownlint-disable MD053 -->
-
 # 1. Overview of `uv` and `pyproject.toml`
 
 Astral's `uv` is a Rust-based project and package manager that uses
@@ -292,7 +290,7 @@ Following these conventions ensures that your project is fully PEP-compliant,
 easy to maintain, and integrates seamlessly with Astral `uv`. For detailed
 configuration options, refer to the uv documentation.[^2]
 
+<!-- markdownlint-disable MD053 -->
 [^1]: <https://semver.org/>
 [^2]: <https://docs.astral.sh/uv/concepts/projects/config/>
-
 <!-- markdownlint-enable MD053 -->


### PR DESCRIPTION
## Summary
- limit MD053 markdownlint rule suppression to footnote block

## Testing
- `make fmt`
- `make markdownlint`
- `make nixie`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 make lint`
- `RUSTC_WRAPPER= SCCACHE_DISABLE=1 make test`


------
https://chatgpt.com/codex/tasks/task_e_68aca4dce50c83228a04aba28c748509

## Summary by Sourcery

Documentation:
- Restrict MD053 markdownlint disable to the footnote section in .rules/python-pyproject.md