### PR TITLE
Refactor logger ancestor collection

### DIFF
--- a/rust_extension/src/config/build.rs
+++ b/rust_extension/src/config/build.rs
@@ -20,9 +20,10 @@ use super::types::{ConfigBuilder, LoggerConfigBuilder};
 ///
 /// # Examples
 /// ```ignore
-/// use std::collections::BTreeMap;
+///
 /// use crate::config::build::logger_names_with_ancestors;
 /// use crate::config::LoggerConfigBuilder;
+/// use std::collections::BTreeMap;
 /// let mut loggers = BTreeMap::new();
 /// loggers.insert("a.b.c".to_string(), LoggerConfigBuilder::new());
 /// let names = logger_names_with_ancestors(&loggers);


### PR DESCRIPTION
## Summary
- extract `logger_names_with_ancestors` to compute logger ancestor names for `disable_existing_loggers`
- use helper in builder and add focused unit test

## Testing
- `make fmt`
- `RUSTC_WRAPPER= make lint`
- `RUSTC_WRAPPER= make test`


------
https://chatgpt.com/codex/tasks/task_e_68c065e6a05c8322a1171f0be2d5938c

## Summary by Sourcery

Extract logger ancestor collection into a shared helper and integrate it in ConfigBuilder; add documentation and focused unit tests

New Features:
- Add logger_names_with_ancestors helper to compute logger names and their ancestors for disable_existing_loggers

Enhancements:
- Use logger_names_with_ancestors in ConfigBuilder.build_and_init to replace manual ancestor collection

Documentation:
- Document logger_names_with_ancestors with a doc comment and example usage

Tests:
- Add parameterized unit tests for logger_names_with_ancestors