### PR TITLE
Detail RotatingFileHandler tasks

### DIFF
--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -85,7 +85,7 @@ of the manual.
   tools.
 - Put function attributes after the doc comment.
 
-````rust
+```rust
 /// Returns the sum of `a` and `b`.
 ///
 /// # Parameters
@@ -104,7 +104,7 @@ of the manual.
 pub fn add(a: i32, b: i32) -> i32 {
     a + b
 }
-````
+```
 
 ## Diagrams and images
 

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -217,8 +217,12 @@ These defaults are consistent across the Rust builder and Python API.
 - The worker thread evaluates rotation without blocking producers by computing
   `current_file_len + next_record_bytes > max_bytes` using the formatted record
   length to avoid flush-induced drift.
-- Rotation renames existing files with incremental numeric suffixes and opens a
-  fresh file; once `backup_count` is exceeded the oldest file is removed.
+- Rotation closes the active file handle before cascading existing backups from
+  the highest index to the lowest (for example, ``<base>.3`` → ``<base>.4``, …,
+  ``<base>`` → ``<base>.1``), then opens a fresh base file. Files beyond
+  `backup_count` are deleted after the cascade.
+- Filename indices start at `1` and increase sequentially up to
+  `backup_count`; rollover prunes any files numbered above that cap.
 - `max_bytes` and `backup_count` are surfaced through the Rust builder and
   Python API to keep configuration familiar. When `backup_count == 0`, rollover
   truncates the base file and does not create any backup files (matching

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -205,6 +205,18 @@ All handlers spawn their consumer threads on creation and expose a
 created, ensuring log messages are dispatched without blocking. Dropping the
 sender signals the consumer to finish once the queue is drained.
 
+#### RotatingFileHandler
+
+`FemtoRotatingFileHandler` mirrors Python's `RotatingFileHandler` and rotates
+when the log file exceeds a configured `max_bytes`.
+
+- The worker thread checks the active file size before each write and performs
+  rotation without blocking producers.
+- Rotation renames existing files with incremental numeric suffixes and opens a
+  fresh file; once `backup_count` is exceeded the oldest file is removed.
+- `max_bytes` and `backup_count` are surfaced through the Rust builder and
+  Python API to keep configuration familiar.
+
 ## Thread Safety Considerations
 
 - `FemtoLogRecord` and any user data it carries must implement `Send` so records

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -211,8 +211,9 @@ sender signals the consumer to finish once the queue is drained.
 when the log file exceeds a configured `max_bytes`.
 
 By default `max_bytes` and `backup_count` are `0`. A `max_bytes` of `0`
-disables rotation entirely, and a `backup_count` of `0` retains no history.
-These defaults are consistent across the Rust builder and Python API.
+disables rotation entirely. A `backup_count` of `0` retains no history, so a
+rollover truncates the base file and stops. These defaults are consistent
+across the Rust builder and Python API.
 
 - The worker thread evaluates rotation without blocking producers using the
   formatted record length. Let `tracked_bytes` be the number of bytes the
@@ -228,9 +229,9 @@ These defaults are consistent across the Rust builder and Python API.
   files.
 - Rotation closes the active file handle, then renames existing files from
   highest to lowest index (``<path>.<n>`` → ``<path>.<n+1>``, …, ``<path>`` →
-  ``<path>.1``), and finally opens a fresh base file. Once `backup_count` is
-  exceeded, remove the oldest file. Closing the handle first is required on
-  Windows.
+  ``<path>.1``), and finally opens a fresh base file. The cascade deletes any
+  file whose new index would exceed `backup_count`, so only the configured
+  number of backups remain. Closing the handle first is required on Windows.
 - Filename indices start at `1` and increase sequentially up to
   `backup_count`; rollover prunes any files numbered above that cap.
 - `max_bytes` and `backup_count` are surfaced through the Rust builder and

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -229,9 +229,7 @@ These defaults are consistent across the Rust builder and Python API.
 - Filename indices start at `1` and increase sequentially up to
   `backup_count`; rollover prunes any files numbered above that cap.
 - `max_bytes` and `backup_count` are surfaced through the Rust builder and
-  Python API to keep configuration familiar. When `backup_count == 0`, rollover
-  truncates the base file and does not create any backup files (matching
-  CPython).
+  Python API to keep configuration familiar.
 
 ## Thread Safety Considerations
 

--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -217,6 +217,11 @@ These defaults are consistent across the Rust builder and Python API.
 - The worker thread evaluates rotation without blocking producers by computing
   `current_file_len + next_record_bytes > max_bytes` using the formatted record
   length to avoid flush-induced drift.
+- If `next_record_bytes` alone exceeds `max_bytes`, the worker triggers an
+  immediate rollover whenever rotation is enabled. After the cascade it
+  truncates the base file and writes the oversized record to the freshly
+  truncated base file in full, mirroring CPython so no record is split across
+  files.
 - Rotation closes the active file handle before cascading existing backups from
   the highest index to the lowest (for example, ``<base>.3`` → ``<base>.4``, …,
   ``<base>`` → ``<base>.1``), then opens a fresh base file. Files beyond

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -55,6 +55,16 @@ from that design.
 - [x] Implement `femtologging.dictConfig()` translating to the builder API.
 - [ ] Implement `FemtoRotatingFileHandler` and `FemtoTimedRotatingFileHandler`
   with their respective rotation logic.
+  - `FemtoRotatingFileHandler`:
+    - [ ] Expose `max_bytes` and `backup_count` options in Rust builders and
+      Python wrappers.
+    - [ ] Check file size in the worker thread and trigger rotation without
+      blocking producers.
+    - [ ] Implement rotation algorithm that cascades file renames from highest
+      to lowest index before opening a new file.
+    - [ ] Provide a file name strategy producing `<path>.<n>` sequences and
+      pruning entries beyond `backup_count`.
+    - [ ] Add builder and Python tests verifying size-based rollover.
 - [ ] Add `FemtoSocketHandler` with serialization (e.g. MessagePack or CBOR) and
   reconnection handling.
 - [x] Define the `FemtoFilter` trait and implement common filter

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -62,16 +62,16 @@ from that design.
       blocking producers.
     - [ ] Implement rotation algorithm that cascades file renames from highest
       to lowest index before opening a new file.
-    - [ ] Provide a filename strategy producing `<path>.<n>` sequences and
-      pruning entries beyond `backup_count`.
+    - [ ] Provide a filename strategy producing `<path>.<n>` sequences starting
+      at `1` and capping at `backup_count`, pruning anything beyond that cap.
     - [ ] Add builder and Python tests verifying size-based rollover.
       - [ ] Cover boundaries: exactly `max_bytes`, one byte over, and an
-        individual
-        record larger than `max_bytes`.
+        individual record larger than `max_bytes`.
       - [ ] Verify `backup_count == 0` truncates base file with no backups.
+      - [ ] Verify lowering `backup_count` prunes excess backups on the next
+        rollover.
       - [ ] Verify cascade renames run highest→lowest and never overwrite
-        existing
-        files.
+        existing files.
       - [ ] Close-and-rename behaviour passes on Windows (no renaming of open
         files).
       - [ ] Assert rotation happens on the worker thread and producers remain

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -62,9 +62,20 @@ from that design.
       blocking producers.
     - [ ] Implement rotation algorithm that cascades file renames from highest
       to lowest index before opening a new file.
-    - [ ] Provide a file name strategy producing `<path>.<n>` sequences and
+    - [ ] Provide a filename strategy producing `<path>.<n>` sequences and
       pruning entries beyond `backup_count`.
     - [ ] Add builder and Python tests verifying size-based rollover.
+      - [ ] Cover boundaries: exactly `max_bytes`, one byte over, and an
+        individual
+        record larger than `max_bytes`.
+      - [ ] Verify `backup_count == 0` truncates base file with no backups.
+      - [ ] Verify cascade renames run highest→lowest and never overwrite
+        existing
+        files.
+      - [ ] Close-and-rename behaviour passes on Windows (no renaming of open
+        files).
+      - [ ] Assert rotation happens on the worker thread and producers remain
+        non-blocking under load.
 - [ ] Add `FemtoSocketHandler` with serialization (e.g. MessagePack or CBOR) and
   reconnection handling.
 - [x] Define the `FemtoFilter` trait and implement common filter

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -60,6 +60,9 @@ from that design.
       Python wrappers.
     - [ ] Check file size in the worker thread and trigger rotation without
       blocking producers.
+      - [ ] Define the predicate as UTF-8 byte measurement:
+        `current_file_len + buffered_bytes + next_record_bytes > max_bytes` (do
+        not flush solely to measure).
     - [ ] Implement rotation algorithm that cascades file renames from highest
       to lowest index before opening a new file.
     - [ ] Provide a filename strategy producing `<path>.<n>` sequences starting
@@ -67,6 +70,8 @@ from that design.
     - [ ] Add builder and Python tests verifying size-based rollover.
       - [ ] Cover boundaries: exactly `max_bytes`, one byte over, and an
         individual record larger than `max_bytes`.
+      - [ ] Verify records containing multi-byte UTF-8 characters trigger
+        rotation based on byte length, not character count.
       - [ ] Verify `backup_count == 0` truncates base file with no backups.
       - [ ] Verify lowering `backup_count` prunes excess backups on the next
         rollover.


### PR DESCRIPTION
## Summary
- move RotatingFileHandler section after FileHandler internals in design doc
- expand roadmap subtasks with rotation algorithm and filename strategy

## Testing
- `make fmt`
- `make markdownlint`
- `make nixie`
- `RUSTC_WRAPPER= make lint`
- `RUSTC_WRAPPER= make test`


------
https://chatgpt.com/codex/tasks/task_e_68c60ca9f430832288c2b61f1b695132

## Summary by Sourcery

Reorganize and enrich the documentation for the RotatingFileHandler and its development roadmap

Documentation:
- Move the RotatingFileHandler section to follow FileHandler internals in the design document
- Detail size-based rotation behavior, file renaming strategy, backup pruning, and configuration options in the design doc
- Expand the roadmap with explicit subtasks for exposing parameters in builders, checking file size, rotation algorithm, filename sequencing, pruning logic, and corresponding tests