### PR TITLE
Centralise overflow policy parsing

### DIFF
--- a/rust_extension/src/handlers/file/policy.rs
+++ b/rust_extension/src/handlers/file/policy.rs
@@ -10,95 +10,78 @@ use pyo3::prelude::*;
 
 use super::config::OverflowPolicy;
 
-#[derive(Debug)]
-struct PyOverflowPolicyConfig {
-    policy: String,
+const VALID_POLICIES: &str = "drop, block, timeout:N";
+
+fn parse_overflow_policy(
+    policy: &str,
     timeout_ms: Option<u64>,
-}
+    expects_external_timeout: bool,
+) -> PyResult<OverflowPolicy> {
+    let trimmed = policy.trim();
+    let normalized = trimmed.to_ascii_lowercase();
 
-impl PyOverflowPolicyConfig {
-    fn new(policy: String, timeout_ms: Option<u64>) -> Self {
-        Self { policy, timeout_ms }
-    }
-
-    fn normalise(policy: &str) -> String {
-        policy.trim().to_ascii_lowercase()
-    }
-
-    fn invalid_message(policy: &str) -> String {
-        let valid = ["drop", "block", "timeout:N"].join(", ");
-        format!("invalid overflow policy '{policy}'. Valid options are: {valid}")
-    }
-
-    fn from_policy_string(policy: &str) -> PyResult<Self> {
-        let normalized = Self::normalise(policy);
-        match normalized.as_str() {
-            "drop" | "block" => Ok(Self::new(normalized, None)),
-            "timeout" => Err(PyValueError::new_err(
-                "timeout requires a positive integer N, use 'timeout:N'",
-            )),
-            _ => {
-                if let Some(rest) = normalized.strip_prefix("timeout:") {
-                    let ms: i64 = rest.trim().parse().map_err(|_| {
-                        PyValueError::new_err(
-                            "timeout must be a positive integer (N in 'timeout:N')",
-                        )
-                    })?;
-                    if ms <= 0 {
-                        return Err(PyValueError::new_err("timeout must be greater than zero"));
-                    }
-                    Ok(Self::new("timeout".to_string(), Some(ms as u64)))
-                } else {
-                    Err(PyValueError::new_err(Self::invalid_message(&normalized)))
-                }
-            }
+    if let Some(rest) = normalized.strip_prefix("timeout:") {
+        let ms: i64 = rest.trim().parse().map_err(|_| {
+            PyValueError::new_err("timeout must be a positive integer (N in 'timeout:N')")
+        })?;
+        if ms <= 0 {
+            return Err(PyValueError::new_err("timeout must be greater than zero"));
         }
+        return Ok(OverflowPolicy::Timeout(Duration::from_millis(ms as u64)));
     }
 
-    #[cfg(feature = "python")]
-    fn from_policy_and_timeout(policy: &str, timeout_ms: Option<u64>) -> PyResult<Self> {
-        let normalized = Self::normalise(policy);
-        match normalized.as_str() {
-            "drop" | "block" => Ok(Self::new(normalized, None)),
-            "timeout" => {
-                let ms = timeout_ms.ok_or_else(|| {
-                    PyValueError::new_err("timeout_ms required for timeout policy")
-                })?;
-                if ms == 0 {
-                    return Err(PyValueError::new_err(
-                        "timeout_ms must be greater than zero",
-                    ));
-                }
-                Ok(Self::new(normalized, Some(ms)))
+    match normalized.as_str() {
+        "drop" => Ok(OverflowPolicy::Drop),
+        "block" => Ok(OverflowPolicy::Block),
+        "timeout" => {
+            if !expects_external_timeout {
+                return Err(PyValueError::new_err(
+                    "timeout requires a positive integer N, use 'timeout:N'",
+                ));
             }
-            _ => Err(PyValueError::new_err(Self::invalid_message(&normalized))),
+
+            let ms = timeout_ms
+                .ok_or_else(|| PyValueError::new_err("timeout_ms required for timeout policy"))?;
+
+            if ms == 0 {
+                return Err(PyValueError::new_err(
+                    "timeout_ms must be greater than zero",
+                ));
+            }
+
+            Ok(OverflowPolicy::Timeout(Duration::from_millis(ms)))
         }
+        _ => Err(PyValueError::new_err(format!(
+            "invalid overflow policy '{normalized}'. Valid options are: {VALID_POLICIES}"
+        ))),
     }
 }
 
-impl TryFrom<&PyOverflowPolicyConfig> for OverflowPolicy {
-    type Error = PyErr;
-
-    fn try_from(config: &PyOverflowPolicyConfig) -> PyResult<Self> {
-        match config.policy.as_str() {
-            "drop" => Ok(OverflowPolicy::Drop),
-            "block" => Ok(OverflowPolicy::Block),
-            "timeout" => {
-                let ms = config.timeout_ms.ok_or_else(|| {
-                    PyValueError::new_err("timeout_ms required for timeout policy")
-                })?;
-                Ok(OverflowPolicy::Timeout(Duration::from_millis(ms)))
-            }
-            other => Err(PyValueError::new_err(
-                PyOverflowPolicyConfig::invalid_message(other),
-            )),
-        }
-    }
-}
-
+/// Parses a policy string into an [`OverflowPolicy`].
+///
+/// # Accepted input formats
+/// - "drop": Drop new items when the buffer is full.
+/// - "block": Block until space is available.
+/// - "timeout:N": Wait up to N milliseconds before dropping (N is a positive integer).
+///
+/// # Errors
+/// Returns a [`PyValueError`] if the input string is not a valid policy.
+///
+/// # Examples
+/// ```ignore
+/// # use femtologging_rs::handlers::file::policy;
+/// # use femtologging_rs::handlers::file::OverflowPolicy;
+/// assert!(matches!(
+///     policy::parse_policy_string("drop").unwrap(),
+///     OverflowPolicy::Drop
+/// ));
+/// assert!(matches!(
+///     policy::parse_policy_string("timeout:1000").unwrap(),
+///     OverflowPolicy::Timeout(_)
+/// ));
+/// ```
 pub(crate) fn parse_policy_string(policy: &str) -> PyResult<OverflowPolicy> {
-    let config = PyOverflowPolicyConfig::from_policy_string(policy)?;
-    OverflowPolicy::try_from(&config)
+    parse_overflow_policy(policy, None, false)
 }
 
 #[cfg(feature = "python")]
@@ -106,21 +89,12 @@ pub(crate) fn parse_policy_with_timeout(
     policy: &str,
     timeout_ms: Option<u64>,
 ) -> PyResult<OverflowPolicy> {
-    let config = PyOverflowPolicyConfig::from_policy_and_timeout(policy, timeout_ms)?;
-    OverflowPolicy::try_from(&config)
+    parse_overflow_policy(policy, timeout_ms, true)
 }
 
-#[cfg(all(test, feature = "python"))]
+#[cfg(test)]
 mod tests {
     use super::*;
-    use pyo3::Python;
-
-    fn assert_value_error_message(err: PyErr, expected: &str) {
-        Python::with_gil(|py| {
-            assert!(err.is_instance_of::<PyValueError>(py));
-            assert_eq!(err.value(py).to_string(), expected);
-        });
-    }
 
     #[test]
     fn parse_policy_string_accepts_drop_whitespace() {
@@ -142,65 +116,96 @@ mod tests {
 
     #[test]
     fn parse_policy_string_rejects_missing_timeout_value() {
-        assert_value_error_message(
-            parse_policy_string("timeout").unwrap_err(),
-            "timeout requires a positive integer N, use 'timeout:N'",
-        );
-    }
-
-    #[test]
-    fn parse_policy_string_rejects_non_numeric_timeout_value() {
-        assert_value_error_message(
-            parse_policy_string("timeout:abc").unwrap_err(),
-            "timeout must be a positive integer (N in 'timeout:N')",
-        );
-    }
-
-    #[test]
-    fn parse_policy_string_rejects_zero_timeout_value() {
-        assert_value_error_message(
-            parse_policy_string("timeout:0").unwrap_err(),
-            "timeout must be greater than zero",
-        );
+        assert!(parse_policy_string("timeout").is_err());
     }
 
     #[test]
     fn parse_policy_string_rejects_unknown_policy() {
-        assert_value_error_message(
-            parse_policy_string("unknown").unwrap_err(),
-            "invalid overflow policy 'unknown'. Valid options are: drop, block, timeout:N",
-        );
+        assert!(parse_policy_string("unknown").is_err());
     }
 
-    #[test]
-    fn parse_policy_with_timeout_supports_drop() {
-        assert_eq!(
-            parse_policy_with_timeout("drop", None).unwrap(),
-            OverflowPolicy::Drop
-        );
-    }
+    #[cfg(feature = "python")]
+    mod python {
+        use super::*;
+        use pyo3::Python;
 
-    #[test]
-    fn parse_policy_with_timeout_requires_timeout_value() {
-        assert_value_error_message(
-            parse_policy_with_timeout("timeout", None).unwrap_err(),
-            "timeout_ms required for timeout policy",
-        );
-    }
+        fn assert_value_error_message(err: PyErr, expected: &str) {
+            Python::with_gil(|py| {
+                assert!(err.is_instance_of::<PyValueError>(py));
+                assert_eq!(err.value(py).to_string(), expected);
+            });
+        }
 
-    #[test]
-    fn parse_policy_with_timeout_rejects_zero_timeout_value() {
-        assert_value_error_message(
-            parse_policy_with_timeout("timeout", Some(0)).unwrap_err(),
-            "timeout_ms must be greater than zero",
-        );
-    }
+        #[test]
+        fn parse_policy_string_rejects_non_numeric_timeout_value() {
+            assert_value_error_message(
+                parse_policy_string("timeout:abc").unwrap_err(),
+                "timeout must be a positive integer (N in 'timeout:N')",
+            );
+        }
 
-    #[test]
-    fn parse_policy_with_timeout_accepts_timeout_value() {
-        assert_eq!(
-            parse_policy_with_timeout("timeout", Some(500)).unwrap(),
-            OverflowPolicy::Timeout(Duration::from_millis(500))
-        );
+        #[test]
+        fn parse_policy_string_rejects_zero_timeout_value() {
+            assert_value_error_message(
+                parse_policy_string("timeout:0").unwrap_err(),
+                "timeout must be greater than zero",
+            );
+        }
+
+        #[test]
+        fn parse_policy_string_reports_missing_timeout_hint() {
+            assert_value_error_message(
+                parse_policy_string("timeout").unwrap_err(),
+                "timeout requires a positive integer N, use 'timeout:N'",
+            );
+        }
+
+        #[test]
+        fn parse_policy_string_rejects_unknown_policy_message() {
+            assert_value_error_message(
+                parse_policy_string("unknown").unwrap_err(),
+                "invalid overflow policy 'unknown'. Valid options are: drop, block, timeout:N",
+            );
+        }
+
+        #[test]
+        fn parse_policy_with_timeout_supports_drop() {
+            assert_eq!(
+                parse_policy_with_timeout("drop", None).unwrap(),
+                OverflowPolicy::Drop
+            );
+        }
+
+        #[test]
+        fn parse_policy_with_timeout_requires_timeout_value() {
+            assert_value_error_message(
+                parse_policy_with_timeout("timeout", None).unwrap_err(),
+                "timeout_ms required for timeout policy",
+            );
+        }
+
+        #[test]
+        fn parse_policy_with_timeout_rejects_zero_timeout_value() {
+            assert_value_error_message(
+                parse_policy_with_timeout("timeout", Some(0)).unwrap_err(),
+                "timeout_ms must be greater than zero",
+            );
+        }
+
+        #[test]
+        fn parse_policy_with_timeout_accepts_timeout_value() {
+            assert_eq!(
+                parse_policy_with_timeout("timeout", Some(500)).unwrap(),
+                OverflowPolicy::Timeout(Duration::from_millis(500))
+            );
+        }
+
+        #[test]
+        fn parse_policy_with_timeout_handles_inline_value() {
+            assert_eq!(
+                parse_policy_with_timeout("timeout:125", None).unwrap(),
+                OverflowPolicy::Timeout(Duration::from_millis(125))
+            );
+        }
     }
 }

--- a/rust_extension/src/handlers/file/policy.rs
+++ b/rust_extension/src/handlers/file/policy.rs
@@ -1,0 +1,206 @@
+//! Overflow policy parsing helpers for the file handler.
+//!
+//! Provides shared parsing logic for Python-facing APIs so behaviour
+//! remains consistent between constructors and builder methods.
+
+use std::time::Duration;
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use super::config::OverflowPolicy;
+
+#[derive(Debug)]
+struct PyOverflowPolicyConfig {
+    policy: String,
+    timeout_ms: Option<u64>,
+}
+
+impl PyOverflowPolicyConfig {
+    fn new(policy: String, timeout_ms: Option<u64>) -> Self {
+        Self { policy, timeout_ms }
+    }
+
+    fn normalise(policy: &str) -> String {
+        policy.trim().to_ascii_lowercase()
+    }
+
+    fn invalid_message(policy: &str) -> String {
+        let valid = ["drop", "block", "timeout:N"].join(", ");
+        format!("invalid overflow policy '{policy}'. Valid options are: {valid}")
+    }
+
+    fn from_policy_string(policy: &str) -> PyResult<Self> {
+        let normalized = Self::normalise(policy);
+        match normalized.as_str() {
+            "drop" | "block" => Ok(Self::new(normalized, None)),
+            "timeout" => Err(PyValueError::new_err(
+                "timeout requires a positive integer N, use 'timeout:N'",
+            )),
+            _ => {
+                if let Some(rest) = normalized.strip_prefix("timeout:") {
+                    let ms: i64 = rest.trim().parse().map_err(|_| {
+                        PyValueError::new_err(
+                            "timeout must be a positive integer (N in 'timeout:N')",
+                        )
+                    })?;
+                    if ms <= 0 {
+                        return Err(PyValueError::new_err("timeout must be greater than zero"));
+                    }
+                    Ok(Self::new("timeout".to_string(), Some(ms as u64)))
+                } else {
+                    Err(PyValueError::new_err(Self::invalid_message(&normalized)))
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "python")]
+    fn from_policy_and_timeout(policy: &str, timeout_ms: Option<u64>) -> PyResult<Self> {
+        let normalized = Self::normalise(policy);
+        match normalized.as_str() {
+            "drop" | "block" => Ok(Self::new(normalized, None)),
+            "timeout" => {
+                let ms = timeout_ms.ok_or_else(|| {
+                    PyValueError::new_err("timeout_ms required for timeout policy")
+                })?;
+                if ms == 0 {
+                    return Err(PyValueError::new_err(
+                        "timeout_ms must be greater than zero",
+                    ));
+                }
+                Ok(Self::new(normalized, Some(ms)))
+            }
+            _ => Err(PyValueError::new_err(Self::invalid_message(&normalized))),
+        }
+    }
+}
+
+impl TryFrom<&PyOverflowPolicyConfig> for OverflowPolicy {
+    type Error = PyErr;
+
+    fn try_from(config: &PyOverflowPolicyConfig) -> PyResult<Self> {
+        match config.policy.as_str() {
+            "drop" => Ok(OverflowPolicy::Drop),
+            "block" => Ok(OverflowPolicy::Block),
+            "timeout" => {
+                let ms = config.timeout_ms.ok_or_else(|| {
+                    PyValueError::new_err("timeout_ms required for timeout policy")
+                })?;
+                Ok(OverflowPolicy::Timeout(Duration::from_millis(ms)))
+            }
+            other => Err(PyValueError::new_err(
+                PyOverflowPolicyConfig::invalid_message(other),
+            )),
+        }
+    }
+}
+
+pub(crate) fn parse_policy_string(policy: &str) -> PyResult<OverflowPolicy> {
+    let config = PyOverflowPolicyConfig::from_policy_string(policy)?;
+    OverflowPolicy::try_from(&config)
+}
+
+#[cfg(feature = "python")]
+pub(crate) fn parse_policy_with_timeout(
+    policy: &str,
+    timeout_ms: Option<u64>,
+) -> PyResult<OverflowPolicy> {
+    let config = PyOverflowPolicyConfig::from_policy_and_timeout(policy, timeout_ms)?;
+    OverflowPolicy::try_from(&config)
+}
+
+#[cfg(all(test, feature = "python"))]
+mod tests {
+    use super::*;
+    use pyo3::Python;
+
+    fn assert_value_error_message(err: PyErr, expected: &str) {
+        Python::with_gil(|py| {
+            assert!(err.is_instance_of::<PyValueError>(py));
+            assert_eq!(err.value(py).to_string(), expected);
+        });
+    }
+
+    #[test]
+    fn parse_policy_string_accepts_drop_whitespace() {
+        assert_eq!(parse_policy_string(" drop ").unwrap(), OverflowPolicy::Drop);
+    }
+
+    #[test]
+    fn parse_policy_string_accepts_block_case_insensitive() {
+        assert_eq!(parse_policy_string("BLOCK").unwrap(), OverflowPolicy::Block);
+    }
+
+    #[test]
+    fn parse_policy_string_parses_timeout_values() {
+        assert_eq!(
+            parse_policy_string("timeout:250").unwrap(),
+            OverflowPolicy::Timeout(Duration::from_millis(250))
+        );
+    }
+
+    #[test]
+    fn parse_policy_string_rejects_missing_timeout_value() {
+        assert_value_error_message(
+            parse_policy_string("timeout").unwrap_err(),
+            "timeout requires a positive integer N, use 'timeout:N'",
+        );
+    }
+
+    #[test]
+    fn parse_policy_string_rejects_non_numeric_timeout_value() {
+        assert_value_error_message(
+            parse_policy_string("timeout:abc").unwrap_err(),
+            "timeout must be a positive integer (N in 'timeout:N')",
+        );
+    }
+
+    #[test]
+    fn parse_policy_string_rejects_zero_timeout_value() {
+        assert_value_error_message(
+            parse_policy_string("timeout:0").unwrap_err(),
+            "timeout must be greater than zero",
+        );
+    }
+
+    #[test]
+    fn parse_policy_string_rejects_unknown_policy() {
+        assert_value_error_message(
+            parse_policy_string("unknown").unwrap_err(),
+            "invalid overflow policy 'unknown'. Valid options are: drop, block, timeout:N",
+        );
+    }
+
+    #[test]
+    fn parse_policy_with_timeout_supports_drop() {
+        assert_eq!(
+            parse_policy_with_timeout("drop", None).unwrap(),
+            OverflowPolicy::Drop
+        );
+    }
+
+    #[test]
+    fn parse_policy_with_timeout_requires_timeout_value() {
+        assert_value_error_message(
+            parse_policy_with_timeout("timeout", None).unwrap_err(),
+            "timeout_ms required for timeout policy",
+        );
+    }
+
+    #[test]
+    fn parse_policy_with_timeout_rejects_zero_timeout_value() {
+        assert_value_error_message(
+            parse_policy_with_timeout("timeout", Some(0)).unwrap_err(),
+            "timeout_ms must be greater than zero",
+        );
+    }
+
+    #[test]
+    fn parse_policy_with_timeout_accepts_timeout_value() {
+        assert_eq!(
+            parse_policy_with_timeout("timeout", Some(500)).unwrap(),
+            OverflowPolicy::Timeout(Duration::from_millis(500))
+        );
+    }
+}

--- a/rust_extension/src/handlers/file_builder.rs
+++ b/rust_extension/src/handlers/file_builder.rs
@@ -11,6 +11,8 @@ use std::num::NonZeroUsize;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 
+#[cfg(feature = "python")]
+use super::file;
 use super::{common::CommonBuilder, file::*, FormatterId, HandlerBuildError, HandlerBuilderTrait};
 use crate::formatter::DefaultFormatter;
 #[cfg(feature = "python")]
@@ -159,23 +161,7 @@ impl FileHandlerBuilder {
         policy: &str,
         timeout_ms: Option<u64>,
     ) -> PyResult<PyRefMut<'py, Self>> {
-        slf.overflow_policy = if policy.eq_ignore_ascii_case("drop") {
-            OverflowPolicy::Drop
-        } else if policy.eq_ignore_ascii_case("block") {
-            OverflowPolicy::Block
-        } else if policy.eq_ignore_ascii_case("timeout") {
-            let ms = timeout_ms.ok_or_else(|| {
-                PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                    "timeout_ms required for timeout policy",
-                )
-            })?;
-            CommonBuilder::ensure_non_zero("timeout_ms", Some(ms)).map_err(PyErr::from)?;
-            OverflowPolicy::Timeout(std::time::Duration::from_millis(ms))
-        } else {
-            return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "invalid overflow policy: {policy}",
-            )));
-        };
+        slf.overflow_policy = file::policy::parse_policy_with_timeout(policy, timeout_ms)?;
         Ok(slf)
     }
 

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -268,7 +268,10 @@ def test_timeout_policy_validation(tmp_path: Path) -> None:
     path = tmp_path / "bad_timeout.log"
     with pytest.raises(ValueError, match="timeout must be greater than zero"):
         FemtoFileHandler(str(path), policy="timeout:0")
-    with pytest.raises(ValueError, match="timeout must be greater than zero"):
+    with pytest.raises(
+        ValueError,
+        match=r"timeout must be a positive integer \(N in 'timeout:N'\)",
+    ):
         FemtoFileHandler(str(path), policy="timeout:-1")
 
 

--- a/tests/test_handler_builders.py
+++ b/tests/test_handler_builders.py
@@ -163,7 +163,7 @@ def test_file_builder_timeout_rejects_zero_timeout(tmp_path: Path) -> None:
     """Zero timeout values are rejected for timeout overflow policy."""
 
     builder = FileHandlerBuilder(str(tmp_path / "builder_timeout_zero.log"))
-    with pytest.raises(ValueError, match="timeout_ms must be greater than zero"):
+    with pytest.raises(ValueError, match="timeout must be greater than zero"):
         builder.with_overflow_policy("timeout", timeout_ms=0)
 
 

--- a/tests/test_handler_builders.py
+++ b/tests/test_handler_builders.py
@@ -149,3 +149,28 @@ def test_stream_builder_negative_capacity(ctor) -> None:
     builder = ctor()
     with pytest.raises(OverflowError):
         builder.with_capacity(-1)
+
+
+def test_file_builder_timeout_requires_explicit_timeout(tmp_path: Path) -> None:
+    """Timeout policy without a timeout raises ``ValueError``."""
+
+    builder = FileHandlerBuilder(str(tmp_path / "builder_timeout_missing.log"))
+    with pytest.raises(ValueError, match="timeout_ms required for timeout policy"):
+        builder.with_overflow_policy("timeout", timeout_ms=None)
+
+
+def test_file_builder_timeout_rejects_zero_timeout(tmp_path: Path) -> None:
+    """Zero timeout values are rejected for timeout overflow policy."""
+
+    builder = FileHandlerBuilder(str(tmp_path / "builder_timeout_zero.log"))
+    with pytest.raises(ValueError, match="timeout_ms must be greater than zero"):
+        builder.with_overflow_policy("timeout", timeout_ms=0)
+
+
+def test_file_builder_accepts_inline_timeout(tmp_path: Path) -> None:
+    """Inline timeout syntax is accepted for builder configuration."""
+
+    builder = FileHandlerBuilder(str(tmp_path / "builder_timeout_inline.log"))
+    builder = builder.with_overflow_policy("timeout:125", timeout_ms=None)
+    handler = builder.build()
+    handler.close()


### PR DESCRIPTION
## Summary
- add a shared overflow policy parser for Python entry points and reuse it from the handler constructor and builder
- cover the parser with unit tests and gate Python-specific helpers behind the `python` feature
- closes #154

## Testing
- make fmt
- RUSTC_WRAPPER= SCCACHE_DISABLE=1 make lint
- RUSTC_WRAPPER= SCCACHE_DISABLE=1 make test

------
https://chatgpt.com/codex/tasks/task_e_68ca17d72abc8322aba947e5368403f0

## Summary by Sourcery

Extract overflow policy parsing logic into a shared module and reuse it in both the file handler constructor and builder, while gating Python-specific helpers behind the `python` feature and adding comprehensive unit tests.

Enhancements:
- Centralise overflow policy parsing into a new `file::policy` module
- Replace inline parsing logic in handler constructor and builder with calls to the shared parser
- Gate Python-specific parsing helper behind the `python` feature

Tests:
- Add unit tests for `parse_policy_string` covering valid policies, error cases, and normalization
- Add Python-specific tests for `parse_policy_with_timeout` under the `python` feature