### PR TITLE
Implement rotating handler size predicate

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -63,9 +63,9 @@ from that design.
       - [x] Define the predicate as UTF-8 byte measurement:
         `current_file_len + buffered_bytes + next_record_bytes > max_bytes` (do
         not flush solely to measure).
-    - [ ] Implement rotation algorithm that cascades file renames from highest
+    - [x] Implement rotation algorithm that cascades file renames from highest
       to lowest index before opening a new file.
-    - [ ] Provide a filename strategy producing `<path>.<n>` sequences starting
+    - [x] Provide a filename strategy producing `<path>.<n>` sequences starting
       at `1` and capping at `backup_count`, pruning anything beyond that cap.
     - [x] Add builder and Python tests verifying size-based rollover.
       - [x] Cover boundaries: exactly `max_bytes`, one byte over, and an
@@ -73,9 +73,9 @@ from that design.
       - [x] Verify records containing multi-byte UTF-8 characters trigger
         rotation based on byte length, not character count.
       - [x] Verify `backup_count == 0` truncates base file with no backups.
-      - [ ] Verify lowering `backup_count` prunes excess backups on the next
+      - [x] Verify lowering `backup_count` prunes excess backups on the next
         rollover.
-      - [ ] Verify cascade renames run highest→lowest and never overwrite
+      - [x] Verify cascade renames run highest→lowest and never overwrite
         existing files.
       - [ ] Close-and-rename behaviour passes on Windows (no renaming of open
         files).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -58,21 +58,21 @@ from that design.
   - `FemtoRotatingFileHandler`:
     - [x] Expose `max_bytes` and `backup_count` options in Rust builders and
       Python wrappers.
-    - [ ] Check file size in the worker thread and trigger rotation without
+    - [x] Check file size in the worker thread and trigger rotation without
       blocking producers.
-      - [ ] Define the predicate as UTF-8 byte measurement:
+      - [x] Define the predicate as UTF-8 byte measurement:
         `current_file_len + buffered_bytes + next_record_bytes > max_bytes` (do
         not flush solely to measure).
     - [ ] Implement rotation algorithm that cascades file renames from highest
       to lowest index before opening a new file.
     - [ ] Provide a filename strategy producing `<path>.<n>` sequences starting
       at `1` and capping at `backup_count`, pruning anything beyond that cap.
-    - [ ] Add builder and Python tests verifying size-based rollover.
-      - [ ] Cover boundaries: exactly `max_bytes`, one byte over, and an
+    - [x] Add builder and Python tests verifying size-based rollover.
+      - [x] Cover boundaries: exactly `max_bytes`, one byte over, and an
         individual record larger than `max_bytes`.
-      - [ ] Verify records containing multi-byte UTF-8 characters trigger
+      - [x] Verify records containing multi-byte UTF-8 characters trigger
         rotation based on byte length, not character count.
-      - [ ] Verify `backup_count == 0` truncates base file with no backups.
+      - [x] Verify `backup_count == 0` truncates base file with no backups.
       - [ ] Verify lowering `backup_count` prunes excess backups on the next
         rollover.
       - [ ] Verify cascade renames run highest→lowest and never overwrite

--- a/docs/rust-multithreaded-logging-framework-for-python-design.md
+++ b/docs/rust-multithreaded-logging-framework-for-python-design.md
@@ -719,16 +719,17 @@ potential future enhancement.
 #### 6.3.1. Rotating file handler configuration decisions
 
 - The rotating handler remains a thin wrapper around the file handler builder.
-  Rotation thresholds are stored on `FemtoRotatingFileHandler`, while the
-  worker thread owns the logic that evaluates when a rollover must occur.
-- The worker evaluates the predicate
-  `current_file_len + buffered_bytes + next_record_bytes > max_bytes` before
-  each write. `next_record_bytes` counts the UTF-8 payload plus the newline
-  that `writeln!` appends so the check mirrors the eventual I/O.
+  Rotation thresholds live on `FemtoRotatingFileHandler`, while the worker
+  thread owns the logic that evaluates when a rollover must occur.
+- The worker evaluates the predicate `current_file_len + buffered_bytes +
+  next_record_bytes >
+  max_bytes` before each write. `next_record_bytes` counts the UTF-8 payload plus the newline that `
+  writeln!` appends so the check mirrors the eventual I/O.
 - Measuring never flushes buffered data. When the predicate fires, the worker
-  flushes once, truncates the base file, and then writes the new record. Future
-  work will extend the rotation strategy to cascade renames when backups are
-  enabled.
+  flushes once, cascades existing backups (dropping the oldest if necessary),
+  copies the current log to `.1`, truncates the base file, and then writes the
+  new record. This keeps rotation non-blocking for producers whilst ensuring
+  backup files remain consistent.
 - `max_bytes == 0` and `backup_count == 0` disable rotation. Builder validation
   in Rust and the Python `HandlerOptions` mirror this rule, ensuring both
   values are set together and exposing the builder API as the canonical

--- a/rust_extension/src/handlers/file/tests.rs
+++ b/rust_extension/src/handlers/file/tests.rs
@@ -84,8 +84,12 @@ fn build_from_worker_wires_handler_components() {
         overflow_policy: OverflowPolicy::Block,
     };
     let policy = handler_cfg.overflow_policy;
-    let mut handler =
-        FemtoFileHandler::build_from_worker(writer, DefaultFormatter, handler_cfg, None, None);
+    let mut handler = FemtoFileHandler::build_from_worker(
+        writer,
+        DefaultFormatter,
+        handler_cfg,
+        BuilderOptions::default(),
+    );
 
     assert!(handler.tx.is_some());
     assert!(handler.handle.is_some());
@@ -237,8 +241,12 @@ fn femto_file_handler_flush_and_close_idempotency() {
         flush_interval: 0,
         overflow_policy: OverflowPolicy::Block,
     };
-    let mut handler =
-        FemtoFileHandler::build_from_worker(writer, DefaultFormatter, handler_cfg, None, None);
+    let mut handler = FemtoFileHandler::build_from_worker(
+        writer,
+        DefaultFormatter,
+        handler_cfg,
+        BuilderOptions::default(),
+    );
 
     assert!(handler.flush());
     assert_eq!(flushed.load(Ordering::Relaxed), 1);

--- a/rust_extension/src/handlers/file/tests.rs
+++ b/rust_extension/src/handlers/file/tests.rs
@@ -78,14 +78,14 @@ fn worker_config_from_handlerconfig_copies_values() {
 fn build_from_worker_wires_handler_components() {
     let buffer = SharedBuf::default();
     let writer = buffer.clone();
-    let worker_cfg = WorkerConfig {
+    let handler_cfg = HandlerConfig {
         capacity: 1,
         flush_interval: 1,
-        start_barrier: None,
+        overflow_policy: OverflowPolicy::Block,
     };
-    let policy = OverflowPolicy::Block;
+    let policy = handler_cfg.overflow_policy;
     let mut handler =
-        FemtoFileHandler::build_from_worker(writer, DefaultFormatter, worker_cfg, policy);
+        FemtoFileHandler::build_from_worker(writer, DefaultFormatter, handler_cfg, None, None);
 
     assert!(handler.tx.is_some());
     assert!(handler.handle.is_some());
@@ -232,17 +232,13 @@ fn femto_file_handler_flush_and_close_idempotency() {
     };
 
     // Disable periodic flushing to ensure deterministic counter checks.
-    let worker_cfg = WorkerConfig {
+    let handler_cfg = HandlerConfig {
         capacity: 10,
         flush_interval: 0,
-        start_barrier: None,
+        overflow_policy: OverflowPolicy::Block,
     };
-    let mut handler = FemtoFileHandler::build_from_worker(
-        writer,
-        DefaultFormatter,
-        worker_cfg,
-        OverflowPolicy::Block,
-    );
+    let mut handler =
+        FemtoFileHandler::build_from_worker(writer, DefaultFormatter, handler_cfg, None, None);
 
     assert!(handler.flush());
     assert_eq!(flushed.load(Ordering::Relaxed), 1);

--- a/rust_extension/src/handlers/rotating.rs
+++ b/rust_extension/src/handlers/rotating.rs
@@ -18,7 +18,9 @@ use pyo3::prelude::*;
 use crate::{
     formatter::FemtoFormatter,
     handler::FemtoHandlerTrait,
-    handlers::file::{FemtoFileHandler, HandlerConfig, RotationStrategy, TestConfig},
+    handlers::file::{
+        BuilderOptions, FemtoFileHandler, HandlerConfig, RotationStrategy, TestConfig,
+    },
     log_record::FemtoLogRecord,
 };
 
@@ -280,8 +282,11 @@ impl FemtoRotatingFileHandler {
                     rotation_config.backup_count,
                 )))
             };
-        let handler =
-            FemtoFileHandler::build_from_worker(writer, formatter, config, rotation, None);
+        let options = BuilderOptions {
+            rotation,
+            start_barrier: None,
+        };
+        let handler = FemtoFileHandler::build_from_worker(writer, formatter, config, options);
         Ok(Self::new_with_rotation_limits(
             handler,
             rotation_config.max_bytes,

--- a/rust_extension/src/handlers/rotating/mod.rs
+++ b/rust_extension/src/handlers/rotating/mod.rs
@@ -5,9 +5,9 @@
 
 use std::{
     any::Any,
-    fs::{self, File, OpenOptions},
-    io::{self, BufWriter, Seek, SeekFrom, Write},
-    path::{Path, PathBuf},
+    fs::{File, OpenOptions},
+    io::{self, BufWriter},
+    path::Path,
 };
 
 use delegate::delegate;
@@ -18,11 +18,12 @@ use pyo3::prelude::*;
 use crate::{
     formatter::FemtoFormatter,
     handler::FemtoHandlerTrait,
-    handlers::file::{
-        BuilderOptions, FemtoFileHandler, HandlerConfig, RotationStrategy, TestConfig,
-    },
+    handlers::file::{BuilderOptions, FemtoFileHandler, HandlerConfig, TestConfig},
     log_record::FemtoLogRecord,
 };
+
+mod strategy;
+pub(crate) use strategy::FileRotationStrategy;
 
 #[cfg(feature = "python")]
 use crate::{
@@ -73,132 +74,6 @@ impl RotationConfig {
 impl Default for RotationConfig {
     fn default() -> Self {
         Self::disabled()
-    }
-}
-
-struct FileRotationStrategy {
-    path: PathBuf,
-    max_bytes: u64,
-    backup_count: usize,
-}
-
-impl FileRotationStrategy {
-    fn new(path: PathBuf, max_bytes: u64, backup_count: usize) -> Self {
-        Self {
-            path,
-            max_bytes,
-            backup_count,
-        }
-    }
-
-    fn next_record_bytes(message: &str) -> u64 {
-        message.len() as u64 + 1
-    }
-
-    fn should_rotate(&self, writer: &BufWriter<File>, next_record_bytes: u64) -> io::Result<bool> {
-        if self.max_bytes == 0 {
-            return Ok(false);
-        }
-        let current_file_len = writer.get_ref().metadata()?.len();
-        let buffered_bytes = writer.buffer().len() as u64;
-        Ok(current_file_len + buffered_bytes + next_record_bytes > self.max_bytes)
-    }
-
-    fn rotate(&mut self, writer: &mut BufWriter<File>) -> io::Result<()> {
-        writer.flush()?;
-        if self.backup_count == 0 {
-            let file = writer.get_mut();
-            file.set_len(0)?;
-            file.seek(SeekFrom::Start(0))?;
-            return Ok(());
-        }
-        self.rotate_backups()?;
-        if self.path.exists() {
-            fs::copy(&self.path, self.backup_path(1))?;
-        }
-        let file = writer.get_mut();
-        file.set_len(0)?;
-        file.seek(SeekFrom::Start(0))?;
-        Ok(())
-    }
-
-    fn remove_file_if_exists(path: &Path) -> io::Result<()> {
-        match fs::remove_file(path) {
-            Ok(()) => Ok(()),
-            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
-            Err(err) => Err(err),
-        }
-    }
-
-    fn rename_file_if_exists(src: &Path, dst: &Path) -> io::Result<()> {
-        match fs::rename(src, dst) {
-            Ok(()) => Ok(()),
-            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
-            Err(err) => Err(err),
-        }
-    }
-
-    fn remove_excess_backups(&self) -> io::Result<()> {
-        let mut extra = self.backup_count + 1;
-        loop {
-            let candidate = self.backup_path(extra);
-            match fs::remove_file(&candidate) {
-                Ok(()) => {
-                    extra += 1;
-                }
-                Err(err) if err.kind() == io::ErrorKind::NotFound => {
-                    break;
-                }
-                Err(err) => {
-                    return Err(err);
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn cascade_backups(&self) -> io::Result<()> {
-        for idx in (1..self.backup_count).rev() {
-            let src = self.backup_path(idx);
-            if src.exists() {
-                let dst = self.backup_path(idx + 1);
-                Self::rename_file_if_exists(&src, &dst)?;
-            }
-        }
-        Ok(())
-    }
-
-    fn rotate_backups(&self) -> io::Result<()> {
-        if self.backup_count == 0 {
-            return Ok(());
-        }
-        self.remove_excess_backups()?;
-        let oldest = self.backup_path(self.backup_count);
-        Self::remove_file_if_exists(&oldest)?;
-        self.cascade_backups()?;
-        Ok(())
-    }
-
-    fn backup_path(&self, index: usize) -> PathBuf {
-        let mut backup = self.path.clone();
-        let mut name = self
-            .path
-            .file_name()
-            .map(|file_name| file_name.to_os_string())
-            .unwrap_or_else(|| self.path.as_os_str().to_os_string());
-        name.push(format!(".{index}"));
-        backup.set_file_name(name);
-        backup
-    }
-}
-
-impl RotationStrategy<BufWriter<File>> for FileRotationStrategy {
-    fn before_write(&mut self, writer: &mut BufWriter<File>, formatted: &str) -> io::Result<()> {
-        let next_bytes = Self::next_record_bytes(formatted);
-        if self.should_rotate(writer, next_bytes)? {
-            self.rotate(writer)?;
-        }
-        Ok(())
     }
 }
 

--- a/rust_extension/src/handlers/rotating/strategy.rs
+++ b/rust_extension/src/handlers/rotating/strategy.rs
@@ -1,0 +1,139 @@
+//! Size-based rotation strategy for rotating file handlers.
+
+use std::{
+    fs::{self, File},
+    io::{self, BufWriter, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+};
+
+use crate::handlers::file::RotationStrategy;
+
+pub(crate) struct FileRotationStrategy {
+    path: PathBuf,
+    max_bytes: u64,
+    backup_count: usize,
+}
+
+impl FileRotationStrategy {
+    pub(crate) fn new(path: PathBuf, max_bytes: u64, backup_count: usize) -> Self {
+        Self {
+            path,
+            max_bytes,
+            backup_count,
+        }
+    }
+
+    pub(crate) fn next_record_bytes(message: &str) -> u64 {
+        message.len() as u64 + 1
+    }
+
+    pub(crate) fn should_rotate(
+        &self,
+        writer: &BufWriter<File>,
+        next_record_bytes: u64,
+    ) -> io::Result<bool> {
+        if self.max_bytes == 0 {
+            return Ok(false);
+        }
+        let current_file_len = writer.get_ref().metadata()?.len();
+        let buffered_bytes = writer.buffer().len() as u64;
+        Ok(current_file_len + buffered_bytes + next_record_bytes > self.max_bytes)
+    }
+
+    pub(crate) fn rotate(&mut self, writer: &mut BufWriter<File>) -> io::Result<()> {
+        writer.flush()?;
+        if self.backup_count == 0 {
+            let file = writer.get_mut();
+            file.set_len(0)?;
+            file.seek(SeekFrom::Start(0))?;
+            return Ok(());
+        }
+        self.rotate_backups()?;
+        if self.path.exists() {
+            fs::copy(&self.path, self.backup_path(1))?;
+        }
+        let file = writer.get_mut();
+        file.set_len(0)?;
+        file.seek(SeekFrom::Start(0))?;
+        Ok(())
+    }
+
+    pub(crate) fn remove_file_if_exists(path: &Path) -> io::Result<()> {
+        match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
+
+    pub(crate) fn rename_file_if_exists(src: &Path, dst: &Path) -> io::Result<()> {
+        match fs::rename(src, dst) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
+
+    pub(crate) fn remove_excess_backups(&self) -> io::Result<()> {
+        let mut extra = self.backup_count + 1;
+        loop {
+            let candidate = self.backup_path(extra);
+            match fs::remove_file(&candidate) {
+                Ok(()) => {
+                    extra += 1;
+                }
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                    break;
+                }
+                Err(err) => {
+                    return Err(err);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn cascade_backups(&self) -> io::Result<()> {
+        for idx in (1..self.backup_count).rev() {
+            let src = self.backup_path(idx);
+            if src.exists() {
+                let dst = self.backup_path(idx + 1);
+                Self::rename_file_if_exists(&src, &dst)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn rotate_backups(&self) -> io::Result<()> {
+        if self.backup_count == 0 {
+            return Ok(());
+        }
+        self.remove_excess_backups()?;
+        let oldest = self.backup_path(self.backup_count);
+        Self::remove_file_if_exists(&oldest)?;
+        self.cascade_backups()?;
+        Ok(())
+    }
+
+    pub(crate) fn backup_path(&self, index: usize) -> PathBuf {
+        let mut backup = self.path.clone();
+        let mut name = self
+            .path
+            .file_name()
+            .map(|file_name| file_name.to_os_string())
+            .unwrap_or_else(|| self.path.as_os_str().to_os_string());
+        name.push(format!(".{index}"));
+        backup.set_file_name(name);
+        backup
+    }
+}
+
+impl RotationStrategy<BufWriter<File>> for FileRotationStrategy {
+    fn before_write(&mut self, writer: &mut BufWriter<File>, formatted: &str) -> io::Result<()> {
+        let next_bytes = Self::next_record_bytes(formatted);
+        if self.should_rotate(writer, next_bytes)? {
+            self.rotate(writer)?;
+        }
+        Ok(())
+    }
+}

--- a/rust_extension/src/handlers/rotating/tests.rs
+++ b/rust_extension/src/handlers/rotating/tests.rs
@@ -1,0 +1,168 @@
+//! Unit tests for the rotating file handler.
+
+use super::*;
+use crate::formatter::DefaultFormatter;
+use crate::handlers::file::TestConfig;
+use crate::log_record::FemtoLogRecord;
+use rstest::rstest;
+use std::fs::{self, OpenOptions};
+use std::io::{self, BufWriter, ErrorKind, Read, Seek, SeekFrom, Write};
+use tempfile::tempdir;
+
+#[rstest]
+#[case::rotates_when_existing_file_and_next_record_exceed_budget(
+    "012345678901234567890123456789",
+    "",
+    "next",
+    34,
+    true,
+    1
+)]
+#[case::stays_below_threshold("012345678901234567890123456789", "", "next", 35, false, 1)]
+#[case::counts_buffered_bytes("seed\n", "pending", "next", 15, true, 1)]
+#[case::buffered_fits_exactly("seed\n", "pending", "next", 17, false, 1)]
+#[case::multibyte_overflows("", "", "😀", 4, true, 1)]
+#[case::multibyte_boundary("", "", "😀", 5, false, 1)]
+#[case::single_record_exceeds_limit("", "", "toolong", 5, true, 1)]
+#[case::rotation_disabled("", "", "message", 0, false, 0)]
+fn rotation_predicate_respects_byte_lengths(
+    #[case] initial: &str,
+    #[case] buffered: &str,
+    #[case] message: &str,
+    #[case] max_bytes: u64,
+    #[case] should_rotate: bool,
+    #[case] backup_count: usize,
+) -> io::Result<()> {
+    let dir = tempdir()?;
+    let path = dir.path().join("rotating.log");
+    let mut file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&path)?;
+    file.write_all(initial.as_bytes())?;
+    file.flush()?;
+    drop(file);
+
+    let file = OpenOptions::new().read(true).write(true).open(&path)?;
+    let mut writer = BufWriter::new(file);
+    writer.write_all(buffered.as_bytes())?;
+
+    let mut strategy = FileRotationStrategy::new(path.clone(), max_bytes, backup_count);
+    let next_bytes = FileRotationStrategy::next_record_bytes(message);
+    assert_eq!(
+        strategy.should_rotate(&writer, next_bytes)?,
+        should_rotate,
+        "rotation decision mismatch for message {message:?}"
+    );
+
+    if should_rotate {
+        strategy.rotate(&mut writer)?;
+        writer.flush()?;
+        let mut reopened = OpenOptions::new().read(true).open(&path)?;
+        let mut contents = String::new();
+        reopened.read_to_string(&mut contents)?;
+        assert!(contents.is_empty(), "rotated file should be truncated");
+    }
+
+    Ok(())
+}
+
+#[rstest]
+fn rotate_promotes_existing_backups() -> io::Result<()> {
+    let dir = tempdir()?;
+    let path = dir.path().join("rotating.log");
+    fs::write(path.with_extension("log.1"), "old backup")?;
+    fs::write(&path, "seed")?;
+
+    let file = OpenOptions::new().read(true).write(true).open(&path)?;
+    let mut writer = BufWriter::new(file);
+    let mut strategy = FileRotationStrategy::new(path.clone(), 1, 2);
+    strategy.rotate(&mut writer)?;
+    writer.flush()?;
+
+    let promoted = fs::read_to_string(path.with_extension("log.2"))?;
+    assert_eq!(promoted, "old backup");
+    let newest = fs::read_to_string(path.with_extension("log.1"))?;
+    assert_eq!(newest, "seed");
+
+    Ok(())
+}
+
+#[rstest]
+fn rotate_prunes_excess_backups_when_limit_lowered() -> io::Result<()> {
+    let dir = tempdir()?;
+    let path = dir.path().join("rotating.log");
+    fs::write(path.with_extension("log.1"), "keep")?;
+    fs::write(path.with_extension("log.2"), "prune one")?;
+    fs::write(path.with_extension("log.3"), "prune two")?;
+    fs::write(&path, "seed")?;
+
+    let file = OpenOptions::new().read(true).write(true).open(&path)?;
+    let mut writer = BufWriter::new(file);
+    let mut strategy = FileRotationStrategy::new(path.clone(), 1, 1);
+    strategy.rotate(&mut writer)?;
+    writer.flush()?;
+
+    assert!(!path.with_extension("log.2").exists());
+    assert!(!path.with_extension("log.3").exists());
+    let newest = fs::read_to_string(path.with_extension("log.1"))?;
+    assert_eq!(newest, "seed");
+
+    Ok(())
+}
+
+#[rstest]
+fn rotating_handler_performs_size_based_rotation() -> io::Result<()> {
+    let dir = tempdir()?;
+    let path = dir.path().join("rotating.log");
+    let handler = FemtoRotatingFileHandler::with_capacity_flush_policy(
+        &path,
+        DefaultFormatter,
+        HandlerConfig::default(),
+        RotationConfig::new(20, 2),
+    )?;
+    handler.handle(FemtoLogRecord::new("core", "INFO", "first"));
+    handler.handle(FemtoLogRecord::new("core", "INFO", "second"));
+    drop(handler);
+
+    let primary = fs::read_to_string(&path)?;
+    assert!(primary.contains("second"));
+    let backup = path.with_extension("log.1");
+    assert!(backup.exists(), "expected first backup file");
+    let backup_contents = fs::read_to_string(backup)?;
+    assert!(backup_contents.contains("first"));
+
+    Ok(())
+}
+
+#[rstest]
+fn rotating_handler_respects_test_builder_defaults() {
+    struct NoopWriter;
+    impl Write for NoopWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Seek for NoopWriter {
+        fn seek(&mut self, _pos: SeekFrom) -> io::Result<u64> {
+            Err(io::Error::new(
+                ErrorKind::Unsupported,
+                "seek unsupported for NoopWriter",
+            ))
+        }
+    }
+
+    let mut cfg = TestConfig::new(NoopWriter, DefaultFormatter);
+    cfg.capacity = 2;
+    cfg.flush_interval = 1;
+
+    let handler = FemtoFileHandler::with_writer_for_test(cfg);
+    handler.handle(FemtoLogRecord::new("core", "INFO", "message"));
+    drop(handler);
+}

--- a/rust_extension/tests/test_utils/shared_buffer.rs
+++ b/rust_extension/tests/test_utils/shared_buffer.rs
@@ -4,7 +4,7 @@
 //! log output in both standard and loom-based scenarios.
 
 pub mod std {
-    use std::io::{self, Write};
+    use std::io::{self, ErrorKind, Seek, SeekFrom, Write};
 
     pub type Arc<T> = std::sync::Arc<T>;
     pub type Mutex<T> = std::sync::Mutex<T>;
@@ -59,6 +59,15 @@ pub mod std {
         }
     }
 
+    impl Seek for SharedBuf {
+        fn seek(&mut self, _pos: SeekFrom) -> io::Result<u64> {
+            Err(io::Error::new(
+                ErrorKind::Unsupported,
+                "seek unsupported for SharedBuf",
+            ))
+        }
+    }
+
     #[allow(dead_code)]
     pub fn read_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
         String::from_utf8(buffer.lock().expect("Buffer mutex poisoned").clone())
@@ -68,7 +77,7 @@ pub mod std {
 
 #[allow(dead_code)]
 pub mod loom {
-    use std::io::{self, Write};
+    use std::io::{self, ErrorKind, Seek, SeekFrom, Write};
 
     pub type Arc<T> = loom::sync::Arc<T>;
     pub type Mutex<T> = loom::sync::Mutex<T>;
@@ -114,6 +123,15 @@ pub mod loom {
                 .lock()
                 .expect("SharedBuf mutex poisoned")
                 .flush()
+        }
+    }
+
+    impl Seek for SharedBuf {
+        fn seek(&mut self, _pos: SeekFrom) -> io::Result<u64> {
+            Err(io::Error::new(
+                ErrorKind::Unsupported,
+                "seek unsupported for SharedBuf",
+            ))
         }
     }
 

--- a/tests/__snapshots__/test_rotating_rotation.ambr
+++ b/tests/__snapshots__/test_rotating_rotation.ambr
@@ -1,0 +1,26 @@
+# serializer version: 1
+# name: test_leaves_logs_intact_when_rotation_is_disabled
+  dict({
+    'rotating.log': '''
+      rotate [INFO] first message
+      rotate [INFO] second message
+  
+    ''',
+  })
+# ---
+# name: test_respects_multibyte_characters_when_evaluating_record_sizes
+  dict({
+    'rotating.log': '''
+      rotate [INFO] emoji 😁
+  
+    ''',
+  })
+# ---
+# name: test_rotates_when_the_next_record_exceeds_the_byte_budget
+  dict({
+    'rotating.log': '''
+      rotate [INFO] second message
+  
+    ''',
+  })
+# ---

--- a/tests/__snapshots__/test_rotating_rotation.ambr
+++ b/tests/__snapshots__/test_rotating_rotation.ambr
@@ -4,23 +4,24 @@
     'rotating.log': '''
       rotate [INFO] first message
       rotate [INFO] second message
-  
     ''',
   })
 # ---
 # name: test_respects_multibyte_characters_when_evaluating_record_sizes
   dict({
-    'rotating.log': '''
-      rotate [INFO] emoji 😁
-  
-    ''',
+    'rotating.log': 'rotate [INFO] emoji 😁',
+    'rotating.log.1': 'rotate [INFO] emoji 😀',
+  })
+# ---
+# name: test_rotates_when_a_single_record_exceeds_the_byte_budget
+  dict({
+    'rotating.log': 'rotate [INFO] overlong message',
+    'rotating.log.1': '',
   })
 # ---
 # name: test_rotates_when_the_next_record_exceeds_the_byte_budget
   dict({
-    'rotating.log': '''
-      rotate [INFO] second message
-  
-    ''',
+    'rotating.log': 'rotate [INFO] second message',
+    'rotating.log.1': 'rotate [INFO] first message',
   })
 # ---

--- a/tests/features/rotating_handler_rotation.feature
+++ b/tests/features/rotating_handler_rotation.feature
@@ -1,0 +1,22 @@
+Feature: Rotating file handler size-based rotation
+
+  Scenario: rotates when the next record exceeds the byte budget
+    Given a rotating handler with max bytes 30 and backup count 1
+    When I log record "first message" at level "INFO" for logger "rotate"
+    And I log record "second message" at level "INFO" for logger "rotate"
+    And I close the rotating handler
+    Then the rotating log files match snapshot
+
+  Scenario: respects multibyte characters when evaluating record sizes
+    Given a rotating handler with max bytes 34 and backup count 1
+    When I log record "emoji 😀" at level "INFO" for logger "rotate"
+    And I log record "emoji 😁" at level "INFO" for logger "rotate"
+    And I close the rotating handler
+    Then the rotating log files match snapshot
+
+  Scenario: leaves logs intact when rotation is disabled
+    Given a rotating handler with max bytes 0 and backup count 0
+    When I log record "first message" at level "INFO" for logger "rotate"
+    And I log record "second message" at level "INFO" for logger "rotate"
+    And I close the rotating handler
+    Then the rotating log files match snapshot

--- a/tests/features/rotating_handler_rotation.feature
+++ b/tests/features/rotating_handler_rotation.feature
@@ -7,6 +7,12 @@ Feature: Rotating file handler size-based rotation
     And I close the rotating handler
     Then the rotating log files match snapshot
 
+  Scenario: rotates when a single record exceeds the byte budget
+    Given a rotating handler with max bytes 10 and backup count 1
+    When I log record "overlong message" at level "INFO" for logger "rotate"
+    And I close the rotating handler
+    Then the rotating log files match snapshot
+
   Scenario: respects multibyte characters when evaluating record sizes
     Given a rotating handler with max bytes 34 and backup count 1
     When I log record "emoji 😀" at level "INFO" for logger "rotate"

--- a/tests/test_rotating_rotation.py
+++ b/tests/test_rotating_rotation.py
@@ -1,0 +1,80 @@
+"""Behavioural tests covering rotating file handler size-based rotation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import pathlib
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+from syrupy.assertion import SnapshotAssertion
+
+from femtologging import FemtoRotatingFileHandler, HandlerOptions
+
+
+scenarios("features/rotating_handler_rotation.feature")
+
+
+@dataclass
+class RotatingContext:
+    handler: FemtoRotatingFileHandler
+    path: pathlib.Path
+    closed: bool = False
+
+
+@given(
+    parsers.parse(
+        "a rotating handler with max bytes {max_bytes:d} and backup count {backup_count:d}"
+    ),
+    target_fixture="rotating_ctx",
+)
+def given_rotating_handler(
+    tmp_path: pathlib.Path,
+    max_bytes: int,
+    backup_count: int,
+    request: pytest.FixtureRequest,
+) -> RotatingContext:
+    path = tmp_path / "rotating.log"
+    handler = FemtoRotatingFileHandler(
+        str(path),
+        options=HandlerOptions(rotation=(max_bytes, backup_count)),
+    )
+    ctx = RotatingContext(handler=handler, path=path)
+
+    def _finaliser() -> None:
+        if not ctx.closed:
+            ctx.handler.close()
+            ctx.closed = True
+
+    request.addfinalizer(_finaliser)
+    return ctx
+
+
+@when(
+    parsers.parse('I log record "{message}" at level "{level}" for logger "{logger}"')
+)
+def when_log_record(
+    rotating_ctx: RotatingContext, message: str, level: str, logger: str
+) -> None:
+    rotating_ctx.handler.handle(logger, level, message)
+
+
+@when("I close the rotating handler")
+def when_close_handler(rotating_ctx: RotatingContext) -> None:
+    rotating_ctx.handler.close()
+    rotating_ctx.closed = True
+
+
+@then("the rotating log files match snapshot")
+def then_log_files_snapshot(
+    rotating_ctx: RotatingContext, snapshot: SnapshotAssertion
+) -> None:
+    if not rotating_ctx.closed:
+        rotating_ctx.handler.close()
+        rotating_ctx.closed = True
+
+    base = rotating_ctx.path
+    contents = {}
+    for candidate in sorted(base.parent.glob(f"{base.name}*")):
+        contents[candidate.name] = candidate.read_text()
+    assert contents == snapshot

--- a/tests/test_rotating_rotation.py
+++ b/tests/test_rotating_rotation.py
@@ -74,7 +74,8 @@ def then_log_files_snapshot(
         rotating_ctx.closed = True
 
     base = rotating_ctx.path
-    contents = {}
-    for candidate in sorted(base.parent.glob(f"{base.name}*")):
-        contents[candidate.name] = candidate.read_text()
-    assert contents == snapshot
+    contents = {
+        candidate.name: candidate.read_text().rstrip("\n")
+        for candidate in sorted(base.parent.glob(f"{base.name}*"))
+    }
+    snapshot.assert_match(contents)


### PR DESCRIPTION
## Summary
- integrate a size-aware rotation strategy into the rotating handler and file worker
- add Rust unit coverage plus pytest-bdd scenarios with snapshots for rotation behaviour
- document the rotation predicate design and mark roadmap milestones complete

## Testing
- RUSTC_WRAPPER= make lint
- RUSTC_WRAPPER= make test

------
https://chatgpt.com/codex/tasks/task_e_68dc168569d4832285e10b160daf0a69

## Summary by Sourcery

Add a size-aware rotation predicate and strategy to the rotating file handler, integrate it into the worker thread, and enrich the builder API for optional rotation support.

New Features:
- Introduce RotationStrategy trait and BuilderOptions to allow injecting custom rotation logic into FemtoFileHandler.
- Implement FileRotationStrategy for size-based rotation with threshold checks, cascade renames, pruning, and backup management.
- Extend FemtoFileHandler and spawn_worker to accept optional rotation strategies and invoke them before each write.

Enhancements:
- Log rotation errors without blocking record writes to avoid data loss on rotation failures.
- Refactor write_record to operate on pre-formatted messages and streamline worker payload handling.

Documentation:
- Document the size-based rotation predicate and design decisions in the roadmap and design docs, marking related milestones complete.

Tests:
- Add comprehensive Rust unit tests for rotation predicate, FileRotationStrategy behaviour, handler error handling, and idempotency.
- Add pytest-bdd scenarios with snapshot assertions to validate rotating handler size-based rotation across edge cases.