### PR TITLE
Add negative flush timeout test for stream handler builders

### DIFF
--- a/tests/test_handler_builders.py
+++ b/tests/test_handler_builders.py
@@ -226,6 +226,15 @@ def test_stream_builder_negative_capacity(ctor) -> None:
         builder.with_capacity(-1)
 
 
+@pytest.mark.parametrize(
+    "ctor", [StreamHandlerBuilder.stdout, StreamHandlerBuilder.stderr]
+)
+def test_stream_builder_negative_flush_timeout(ctor) -> None:
+    builder = ctor()
+    with pytest.raises((OverflowError, HandlerConfigError)):
+        builder.with_flush_timeout_ms(-1)
+
+
 def test_file_builder_timeout_requires_explicit_timeout(tmp_path: Path) -> None:
     """Timeout policy without a timeout raises ``ValueError``."""
 


### PR DESCRIPTION
## Summary
- add a parametrized pytest covering negative flush timeouts for both stdout and stderr stream builders
- closes #159 by ensuring StreamHandlerBuilder flush timeout validation is enforced at the Python boundary

## Testing
- `RUSTC_WRAPPER= make test`


------
https://chatgpt.com/codex/tasks/task_e_68df94d6ce188322a7307046e6c2234d

## Summary by Sourcery

Tests:
- Add test_stream_builder_negative_flush_timeout to validate that negative flush timeouts raise an error for stdout and stderr stream builders