### PR TITLE
Add idempotent root logger assignment test case

### DIFF
--- a/tests/test_config_builder.py
+++ b/tests/test_config_builder.py
@@ -297,8 +297,9 @@ def test_disable_existing_loggers_keeps_ancestors(ancestors: list[str]) -> None:
         ("INFO", "ERROR", "ERROR"),
         ("ERROR", "INFO", "INFO"),
         ("DEBUG", "WARN", "WARN"),
+        ("INFO", "INFO", "INFO"),
     ],
-    ids=["INFO→ERROR", "ERROR→INFO", "DEBUG→WARN"],
+    ids=["INFO→ERROR", "ERROR→INFO", "DEBUG→WARN", "INFO→INFO"],
 )
 def test_root_logger_last_assignment_wins(
     first: str, second: str, expected: str


### PR DESCRIPTION
## Summary
- add an INFO→INFO parametrised case to cover idempotent root logger assignments
- closes #156

## Testing
- make test *(fails: sccache unable to reach remote cache service)*

------
https://chatgpt.com/codex/tasks/task_e_68df9501104c83228857d8d9e892485e

## Summary by Sourcery

Tests:
- Add INFO→INFO parametrized case to verify idempotent root logger assignments