### PR TITLE
Expand handler builder boundary tests

### DIFF
--- a/tests/features/handler_builders.feature
+++ b/tests/features/handler_builders.feature
@@ -18,8 +18,7 @@ Feature: Handler builders
 
   Scenario: invalid file handler flush interval
     Given a FileHandlerBuilder for path "test.log"
-    When I set flush record interval 0
-    Then building the file handler fails
+    Then setting flush record interval 0 fails
 
   Scenario: build rotating file handler builder
     Given a RotatingFileHandlerBuilder for path "test.log"

--- a/tests/test_handler_builders.py
+++ b/tests/test_handler_builders.py
@@ -250,7 +250,12 @@ def test_stream_builder_zero_flush_timeout(ctor) -> None:
 def test_stream_builder_large_flush_timeout(ctor) -> None:
     builder = ctor().with_flush_timeout_ms(1_000_000_000)
     data = builder.as_dict()
-    assert data["flush_timeout_ms"] == 1_000_000_000
+    assert data["flush_timeout_ms"] == 1_000_000_000, (
+        "Stream handler builder flush timeout mismatch: "
+        f"ctor={ctor.__name__} builder={builder!r} "
+        f"expected=1_000_000_000 actual={data['flush_timeout_ms']} "
+        f"data={data}"
+    )
 
 
 def test_file_builder_negative_flush_record_interval(tmp_path: Path) -> None:


### PR DESCRIPTION
Strengthens the test suite around flush-related parameters:

- Adds zero-timeout case to ensure builders raise `ValueError`.
- Introduces tests accepting very large timeout/interval values and
  asserts correct serialization.
- Covers negative flush-record-interval for file handlers.
- Drops outdated `HandlerConfigError` expectation; only
  `OverflowError` is produced for negatives.

Improves coverage of limit checks and guards against future
regressions in validation logic.

## Summary by Sourcery

Harden flush-related parameter validations in handler builders by expanding boundary tests for zero, negative, and large values.

Tests:
- Adjust stream builder negative flush timeout test to expect only OverflowError
- Add stream builder tests for zero timeout to raise ValueError
- Add stream builder tests for large timeout to accept and serialize values correctly
- Add file builder test for negative flush-record-interval to raise OverflowError
- Add file builder test for large flush-record-interval to accept and serialize values correctly