### PR TITLE
Update Rust extension module documentation comment

### DIFF
--- a/rust_extension/src/lib.rs
+++ b/rust_extension/src/lib.rs
@@ -1,9 +1,7 @@
-//! Python bindings and public re-exports for the femtologging Rust extension.
+//! FemtoLogging Python bindings and public re-exports.
 //!
-//! The [`_femtologging_rs`] module exposes core logging types to Python.
-//! When the `python` feature is enabled, [`add_python_bindings`] registers
-//! builders and errors that are otherwise conditionally compiled. The crate
-//! re-exports these types so they remain usable from Rust.
+//! This module wires up PyO3 classes and functions exposed to Python and
+//! re-exports Rust types used by the Python layer.
 use pyo3::prelude::*;
 
 mod config;


### PR DESCRIPTION
## Summary
- add a module-level doc comment to `rust_extension/src/lib.rs` that describes the Python bindings and re-exports, satisfying the repository guideline
- closes #181

## Testing
- make fmt
- RUSTC_WRAPPER= make lint
- RUSTC_WRAPPER= make test

------
https://chatgpt.com/codex/tasks/task_e_68e7d490ae94832290d150199763a1c6

## Summary by Sourcery

Documentation:
- Add a module-level doc comment explaining how the crate wires up PyO3 classes/functions and re-exports core logging types for Python