### PR TITLE
Ensure stream handler drops handle lock before waiting

### DIFF
--- a/rust_extension/src/stream_handler.rs
+++ b/rust_extension/src/stream_handler.rs
@@ -234,7 +234,8 @@ impl FemtoStreamHandler {
     /// Close the handler and wait for the worker thread to exit.
     pub fn close(&mut self) {
         self.tx.take();
-        if let Some(handle) = self.handle.lock().take() {
+        let handle = { self.handle.lock().take() };
+        if let Some(handle) = handle {
             let done_rx = self.done_rx.lock().clone();
             if done_rx.recv_timeout(self.flush_timeout).is_err() {
                 warn!(


### PR DESCRIPTION
## Summary
- drop the stream handler mutex guard before waiting on shutdown notifications and joining the worker thread
- closes #190

## Testing
- make fmt
- RUSTC_WRAPPER= SCCACHE_DISABLE=1 make lint
- RUSTC_WRAPPER= SCCACHE_DISABLE=1 make test

------
https://chatgpt.com/codex/tasks/task_e_68e7d4e313008322bdb6fb9ea50a597c

## Summary by Sourcery

Bug Fixes:
- Drop the stream handler's handle lock guard before blocking on the shutdown signal and thread join to prevent potential deadlocks