### PR TITLE
Add packaging metadata keywords and classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,18 @@ readme = "README.md"
 requires-python = ">=3.12"
 license = { text = "ISC" }
 authors = [{ name = "Payton McIntosh", email = "pmcintosh@df12.net" }]
+keywords = [
+    "logging",
+    "pyo3",
+    "rust",
+    "async",
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Rust",
+    "License :: OSI Approved :: ISC License (ISCL)",
+    "Operating System :: OS Independent",
+]
 dependencies = []
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
- add project keywords and classifiers to improve packaging metadata
- closes #183

## Testing
- not run (metadata-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e7d53c0f888322ac208c4965ac4210