### PR TITLE
Document flush return values

### DIFF
--- a/rust_extension/src/handlers/file/mod.rs
+++ b/rust_extension/src/handlers/file/mod.rs
@@ -153,10 +153,11 @@ impl FemtoFileHandler {
     /// Returns
     /// -------
     /// bool
-    ///     ``True`` when the worker acknowledges the flush within 1 second.
-    ///     ``False`` when the handler has already been closed, the flush
-    ///     command cannot be delivered, or acknowledgement is not received
-    ///     within the 1-second timeout.
+    ///     ``True`` when the worker acknowledges the flush command within the
+    ///     1-second timeout.
+    ///     ``False`` when the handler has already been closed, the command
+    ///     cannot be delivered to the worker, or the worker fails to
+    ///     acknowledge before the timeout elapses.
     ///
     /// Examples
     /// --------

--- a/rust_extension/src/handlers/rotating/mod.rs
+++ b/rust_extension/src/handlers/rotating/mod.rs
@@ -332,10 +332,11 @@ impl FemtoRotatingFileHandler {
     /// Returns
     /// -------
     /// bool
-    ///     ``True`` when the worker acknowledges the flush within 1 second.
-    ///     ``False`` when the handler has already been closed, the flush
-    ///     command cannot be delivered, or acknowledgement is not received
-    ///     within the 1-second timeout.
+    ///     ``True`` when the worker acknowledges the flush command within the
+    ///     1-second timeout.
+    ///     ``False`` when the handler has already been closed, the command
+    ///     cannot be delivered to the worker, or the worker fails to
+    ///     acknowledge before the timeout elapses.
     ///
     /// Examples
     /// --------

--- a/rust_extension/src/stream_handler.rs
+++ b/rust_extension/src/stream_handler.rs
@@ -116,10 +116,11 @@ impl FemtoStreamHandler {
     /// Returns
     /// -------
     /// bool
-    ///     ``True`` when the worker acknowledges the flush within the timeout.
-    ///     ``False`` when the handler has already been closed, the flush
-    ///     command cannot be delivered, or acknowledgement is not received
-    ///     within the configured timeout (default: 1 second).
+    ///     ``True`` when the worker acknowledges the flush command within the
+    ///     timeout (default: 1 second).
+    ///     ``False`` when the handler has already been closed, the command
+    ///     cannot be delivered to the worker, or the worker fails to
+    ///     acknowledge before the timeout elapses.
     ///
     /// Examples
     /// --------


### PR DESCRIPTION
## Summary
- clarify the Python-facing docstrings for `flush()` on stream, file, and rotating handlers
- document that the boolean return indicates success versus a closed handler or failed command so users understand the API contract

## Testing
- make fmt
- RUSTC_WRAPPER= cargo clippy --manifest-path rust_extension/Cargo.toml --no-default-features -- -D warnings
- RUSTC_WRAPPER= make test


------
https://chatgpt.com/codex/tasks/task_e_68e7d57f9edc8322831367cf0cbd3805