### PR TITLE
Clarify overflow docs and document helpers

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -75,9 +75,9 @@ down. `block` performs a blocking `send`, which either succeeds or yields
 `Err(HandlerError::Closed)` if the channel is disconnected. `timeout` waits for
 the configured duration using `send_timeout`, returning
 `Err(HandlerError::Timeout(duration))` when the wait expires or
-`Err(HandlerError::Closed)` if the worker stops. All of these errors surface to
-Python as `RuntimeError` (via PyO3's `PyRuntimeError`), allowing Python callers
-to decide whether to retry or fall back.
+`Err(HandlerError::Closed)` if the worker stops. All of these errors propagate
+across the FFI boundary as Python `RuntimeError` (via PyO3's `PyRuntimeError`),
+allowing Python callers to decide whether to retry or fall back.
 
 ```python
 from contextlib import closing
@@ -107,8 +107,10 @@ metrics for monitoring purposes:
   up and dropping the record.
 
 These lowercase names match the literals accepted by the configuration parser
-(`drop`, `block`, or `timeout:N`). The same parser powers `HandlerOptions` and
-the Python builders, so the documentation and implementation stay aligned.
+(`drop`, `block`, or `timeout:N`). They emphasise the policy strings used by
+Python callers and avoid confusing the drop policy with Rust's `Drop` trait.
+The same parser powers `HandlerOptions` and the Python builders, so the
+documentation and implementation stay aligned.
 
 Every handler provides a `flush()` method, so callers can force pending
 messages to be written before shutdown.

--- a/femtologging/_femtologging_rs.pyi
+++ b/femtologging/_femtologging_rs.pyi
@@ -1,4 +1,4 @@
-from typing import Any as _Any, Final, Literal, Self, Union, overload
+from typing import Any as _Any, Final, Literal, Self, Union
 
 FemtoLevel: _Any
 LevelName = Literal["TRACE", "DEBUG", "INFO", "WARN", "WARNING", "ERROR", "CRITICAL"]

--- a/rust_extension/src/handlers/rotating/tests/concurrency.rs
+++ b/rust_extension/src/handlers/rotating/tests/concurrency.rs
@@ -113,7 +113,8 @@ fn rotation_runs_on_worker_thread() -> io::Result<()> {
     Ok(())
 }
 
-/// Poll `started` until it becomes true or `timeout` elapses.
+/// Poll `started` until it becomes true or `timeout` elapses, sleeping for one
+/// millisecond between checks to avoid busy-waiting in tight loops.
 ///
 /// # Panics
 ///
@@ -128,11 +129,13 @@ fn wait_for_rotation_start(started: &AtomicBool, timeout: Duration) {
     }
 }
 
-/// Attempt `count` non-blocking writes to `handler`, returning the elapsed time.
+/// Attempt `count` non-blocking writes to `handler`, returning the elapsed
+/// time.
 ///
 /// Accepts `Ok(())` and `HandlerError::QueueFull` as successful outcomes (the
 /// test exercises non-blocking queueing, so drops are expected). Panics on
-/// other errors.
+/// other errors because they indicate the worker failed while rotation was in
+/// progress.
 fn attempt_non_blocking_writes(handler: &mut FemtoRotatingFileHandler, count: usize) -> Duration {
     let start = Instant::now();
     for idx in 0..count {


### PR DESCRIPTION
## Summary
- clarify the overflow policy documentation to emphasise RuntimeError propagation and lowercase policy names
- document the file handler test helpers, including SharedBuf and the rotation fixtures, to explain their behaviour

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ef7c2569088322abde758efaca1b29

## Summary by Sourcery

Clarify documentation across handlers and tests, emphasizing error propagation and policy naming, and clean up unused imports in the Python stub.

Enhancements:
- Add and refine doc comments for SharedBuf, CountingRotation, FlagRotation, and spawn_record_thread helpers to explain their behavior
- Enhance concurrency test documentation by adding sleep intervals to polling loops and clarifying non-blocking write error handling

Documentation:
- Update overflow policy documentation to emphasize Python RuntimeError propagation across the FFI boundary and clarify lowercase policy names

Chores:
- Remove unused 'overload' import from the Python type stub