### PR TITLE
Document spawn_record_thread parameters

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -91,7 +91,7 @@ with closing(
     try:
         handler.handle("core", "INFO", "second")
     except RuntimeError as exc:
-        assert "queue is full" in str(exc)
+        assert "queue full" in str(exc)
 ```
 
 Advanced use cases can specify an overflow policy when constructing a handler.

--- a/rust_extension/src/handlers/file/tests/test_support.rs
+++ b/rust_extension/src/handlers/file/tests/test_support.rs
@@ -121,7 +121,9 @@ impl RotationStrategy<std::io::Cursor<Vec<u8>>> for FlagRotation {
 /// - `FemtoFileHandler`: configured handler under test
 ///
 /// The handler is configured with capacity 1, immediate flush, and the supplied
-/// overflow policy to trigger overflow scenarios deterministically.
+/// overflow policy to trigger overflow scenarios deterministically. The
+/// `policy` argument selects which overflow behaviour the caller wishes to
+/// exercise, allowing tests to cover drop, block, or error semantics.
 pub(super) fn setup_overflow_test(
     policy: OverflowPolicy,
 ) -> (SharedBuf, Arc<Barrier>, FemtoFileHandler) {
@@ -138,6 +140,16 @@ pub(super) fn setup_overflow_test(
 
 /// Spawn a thread that sends a single record to the handler after barrier
 /// synchronisation.
+///
+/// # Parameters
+///
+/// - `handler`: shared handler instance under test that will receive the
+///   record from the spawned thread. Callers typically wrap their handler in
+///   an `Arc` already, so the fixture simply clones the pointer for the
+///   worker thread.
+/// - `record`: pre-built `FemtoLogRecord` the fixture will submit via
+///   `FemtoFileHandler::handle` once the barrier is released. Craft the record
+///   with the exact payload and metadata the test intends to assert on.
 ///
 /// Returns a tuple of:
 /// - `Arc<Barrier>`: barrier used to release the spawned thread


### PR DESCRIPTION
## Summary
- explain the handler and record parameters accepted by `spawn_record_thread`

## Testing
- make fmt

------
https://chatgpt.com/codex/tasks/task_e_68ef8f062298832292f8e2e0c58dfacb

## Summary by Sourcery

Document parameters for spawn_record_thread, expand test utility documentation for overflow behaviour, and update example assertion text in rust-port docs.

Enhancements:
- Add parameter documentation for spawn_record_thread to clarify handler and record arguments
- Augment setup_overflow_test doc comments to explain overflow policy selection semantics
- Correct example assertion text in formatters-and-handlers-rust-port guide from “queue is full” to “queue full”