### PR TITLE
Enforce Ruff complexity and argument thresholds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,23 @@ dev = [
 [tool.ruff]
 line-length = 88
 
+[tool.ruff.lint]
+extend-select = [
+    "C90",
+    "PLR0913",
+]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 9
+
+[tool.ruff.lint.pylint]
+max-args = 4
+
+[tool.ruff.lint.per-file-ignores]
+"**/test_*.py" = [
+    "PLR0913",
+]
+
 [tool.uv]
 package = true
 


### PR DESCRIPTION
## Summary
- configure Ruff to check McCabe complexity and function argument counts
- cap complexity at 9 and limit functions to 4 arguments while ignoring test files

## Testing
- make check-fmt
- make typecheck
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_690619199b4c83228c11e2074d7fb6ac