### PR TITLE
Refine TLS guard in socket configuration

### DIFF
--- a/femtologging/config.py
+++ b/femtologging/config.py
@@ -322,8 +322,10 @@ def _pop_socket_tls_kwargs(
     tls_value = kwargs.pop("tls", None)
     domain_kw = kwargs.pop("tls_domain", None)
     insecure_kw = kwargs.pop("tls_insecure", None)
-
-    if tls_value is None and domain_kw is None and insecure_kw is None:
+    no_tls_config_provided = (
+        tls_value is None and domain_kw is None and insecure_kw is None
+    )
+    if no_tls_config_provided:
         return None
 
     domain, insecure, enabled = _parse_tls_value(hid, tls_value)


### PR DESCRIPTION
## Summary
- introduce a descriptive `no_tls_config_provided` flag when parsing socket TLS kwargs
- keep the existing early-return behaviour while making the conditional clearer

## Testing
- make test *(fails: interrupted due to long dependency build)*

------
https://chatgpt.com/codex/tasks/task_e_69069c0648888322b7d710fe9727e988

## Summary by Sourcery

Enhancements:
- Add `no_tls_config_provided` flag to improve readability of the TLS guard in `_pop_socket_tls_kwargs` while preserving existing behavior.