### PR TITLE
Add multi-thread exception capture test

### DIFF
--- a/docs/execplans/issue-299-multi-threading-exception-capture-test.md
+++ b/docs/execplans/issue-299-multi-threading-exception-capture-test.md
@@ -224,7 +224,10 @@ Implement `test_multithread_exception_capture` that:
    `handle_record` to receive structured payloads).
 2. Creates barriers for N+1 parties (N threads + main thread waiting).
 3. Spawns N threads (parametrized: 2, 10, 50) each running the worker function.
-4. After all threads complete (via barrier), deletes the logger to flush.
+4. After all threads complete (via barrier), calls `flush_handlers()` on the
+   `FemtoLogger` to ensure payloads are flushed to the
+   `RecordCollectingHandler` (which receives them via `handle_record`), then
+   deletes the logger to ensure worker threads drain completely.
 5. Validates:
    - Exactly N records were captured.
    - Each record's `exc_info["message"]` matches a unique thread index.

--- a/tests/test_multithread_exception_capture.py
+++ b/tests/test_multithread_exception_capture.py
@@ -130,6 +130,12 @@ def _validate_record(record: LogRecordDict, captured_indices: set[int]) -> int:
     )
     thread_idx = int(match.group(1))
 
+    # Verify log message thread index matches exception payload thread index
+    assert int(thread_idx_from_message) == thread_idx, (
+        f"Log message thread index ({thread_idx_from_message}) does not match "
+        f"exception payload thread index ({thread_idx})"
+    )
+
     # Check for duplicates (would indicate cross-thread contamination)
     assert thread_idx not in captured_indices, (
         f"Duplicate thread index {thread_idx} detected - "


### PR DESCRIPTION
## Summary
- Adds a Python-based multi-thread exception capture test to validate thread-safety of exception payload capture in femtologging. 
- Uses barrier-based synchronization to deterministically exercise concurrent exception captures without sleeps. 
- Includes a new ExecPlan documenting the approach and validation steps.

## Changes
- New test file: tests/test_multithread_exception_capture.py
- New ExecPlan: docs/execplans/issue-299-multi-threading-exception-capture-test.md

## Rationale
- Ensures that exceptions raised in multiple threads are captured with clean, isolated payloads per thread and without cross-thread contamination.
- Validates integration paths across Python threading and the Rust extension without modifying production code.
- Uses deterministic synchronization (threading.Barrier) to avoid timing-related flakiness.

## What the test does
- Defines a ThreadSpecificError with a unique per-thread message: "Thread {i} exception".
- Uses a RecordCollectingHandler to capture structured payloads via handle_record for validation.
- Spawns N worker threads (parameterized by thread_count) that each raise a ThreadSpecificError, log with exc_info=True, and synchronize via barriers.
- Validates that:
  - Exactly N records were captured.
  - Each record contains exc_info with type_name == "ThreadSpecificError" and a message containing its thread index.
  - Each payload's frames include the thread_worker function.
  - No cross-thread contamination: each thread index appears exactly once.

## Test plan / How to run
- Run a focused test: pytest tests/test_multithread_exception_capture.py -v
- Or run through the project test suite: make test
- Validate across thread counts: 2, 10, 50 (parametrized in the test)
- Lint and format checks: make lint, make fmt

## Acceptance criteria
- The new test passes for all configured thread counts (2, 10, 50).
- Tests complete without using time.sleep() for synchronization.
- Payloads are isolated per thread with correct messages and frames.
- make test, make lint, and make fmt all succeed.

## Details about the implementation
- ThreadSpecificError: custom exception to clearly identify per-thread data.
- RecordCollectingHandler: collects full structured payloads for validation.
- thread_worker: raises the per-thread exception, logs with exc_info, and participates in barriers.
- test_multithread_exception_capture: parametrized test that exercises 2, 10, and 50 threads.

## Documentation / ExecPlan
- The ExecPlan document (docs/execplans/issue-299-multi-threading-exception-capture-test.md) accompanies this change and is intended to be a living document updated as work progresses.

## Risks and mitigation
- Risk: potential flakiness due to thread scheduling. Mitigation: barrier-based synchronization and validation of payload content rather than timing.
- Risk: Python GIL could influence real concurrency. Mitigation: test focuses on per-thread payload isolation and correct framing within the captured data.

## Related notes
- No production code changes were introduced; the test exercises existing public APIs.
- The test is designed to be deterministic and to complete well within the 30-second pytest timeout.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1d651931-067f-4c14-af6b-b810c0966169

## Summary by Sourcery

Add a deterministic multi-threaded exception capture test and accompanying execution plan documentation to validate thread-safe payload handling in femtologging.

Documentation:
- Document the design, constraints, risks, plan, and outcomes for the multi-threaded exception capture test in a new ExecPlan.

Tests:
- Introduce a parametrized multi-threaded exception capture test that verifies per-thread exception payload isolation, integrity, and absence of cross-thread contamination across varying thread counts.