### PR TITLE
Add missing comma after Internally in docs

### DIFF
--- a/docs/formatters-and-handlers-rust-port.md
+++ b/docs/formatters-and-handlers-rust-port.md
@@ -199,7 +199,7 @@ maximise durability. To batch writes, pass a custom configuration via
 arguments on ``FemtoFileHandler`` (Python). Setting ``flush_interval`` defers
 flushing until the specified number of records have been written. The value
 must be greater than zero, so periodic flushing always occurs. Higher values
-reduce syscall overhead in high-volume scenarios. Internally the handler
+reduce syscall overhead in high-volume scenarios. Internally, the handler
 buffers writes with `BufWriter`, so records only reach the file once a flush
 occurs or the handler shuts down.
 


### PR DESCRIPTION
## Summary
- Corrects punctuation in documentation by adding a comma after the word “Internally” in the Rust-port docs snippet.

## Changes

### Documentation
- docs/formatters-and-handlers-rust-port.md: inserted a comma after "Internally" in the sentence describing buffering with `BufWriter`.

### Rationale
- Improves readability and grammar.

## Test plan
- [x] Review the diff to confirm the comma is present.
- [x] Preview the docs page to ensure the sentence renders correctly and no formatting issues arise.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/aaf272e4-121b-45be-85f7-0b37522fab3c

## Summary by Sourcery

Documentation:
- Fix punctuation in the Rust port formatter/handler documentation by adding a missing comma in the BufWriter buffering description.