### PR TITLE
Make mutex lock lifetime explicit in logger drop

### DIFF
--- a/rust_extension/src/logger/mod.rs
+++ b/rust_extension/src/logger/mod.rs
@@ -575,7 +575,8 @@ impl Drop for FemtoLogger {
             let _ = shutdown_tx.send(());
         }
         self.tx.take();
-        if let Some(handle) = self.handle.lock().take() {
+        let handle = { self.handle.lock().take() };
+        if let Some(handle) = handle {
             Python::with_gil(|py| py.allow_threads(move || log_join_result(handle)));
         }
     }


### PR DESCRIPTION
## Summary
- Explicitly scope the mutex lock lifetime in FemtoLogger's Drop
- Ensures the lock is released before performing Python GIL operations

## Changes
### Core Functionality
- Refactored Drop for FemtoLogger to capture the result of `self.handle.lock().take()` in a local, scoped variable
- Only proceed to `log_join_result` if `Some(handle)` remains
- This makes the mutex lock lifetime explicit and prevents holding the lock across Python interactions

## Rationale
- Improves safety by ensuring the mutex is not held during potentially long Python operations
- Clarifies lifetime management and reduces risk of deadlocks or unexpected lock holds

## Test plan
- Build succeeds for the crate and workspace
- Simulate logger shutdown to verify no deadlocks occur
- Confirm behavior remains functionally the same aside from the reduced lock lifetime


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6393eef4-0569-40ba-85af-31c11e9a3580

## Summary by Sourcery

Enhancements:
- Scope the mutex handle acquisition in FemtoLogger::Drop so the lock is released before invoking Python GIL-bound logging shutdown.