### PR TITLE
Document idempotent close() behavior for file and rotating handlers

### DIFF
--- a/rust_extension/src/handlers/file/mod.rs
+++ b/rust_extension/src/handlers/file/mod.rs
@@ -326,6 +326,12 @@ impl FemtoFileHandler {
     ///
     /// This method is idempotent. Calling it multiple times is safe; only the
     /// first call performs shutdown work.
+    ///
+    /// Threading
+    /// ---------
+    /// The method requires `&mut self`, so callers must ensure exclusive access
+    /// when invoking it. Concurrent calls from multiple threads must be
+    /// synchronized externally (for example, with a `Mutex`).
     pub fn close(&mut self) {
         self.tx.take();
         if let Some(handle) = self.handle.take() {

--- a/rust_extension/src/handlers/rotating/mod.rs
+++ b/rust_extension/src/handlers/rotating/mod.rs
@@ -178,7 +178,13 @@ impl FemtoRotatingFileHandler {
             pub fn flush(&self) -> bool;
             /// Close the handler, waiting for the worker thread to shut down.
             ///
-            /// This method is idempotent and safe to call multiple times.
+            /// This method is idempotent. Calling it multiple times is safe;
+            /// only the first call performs shutdown work.
+            ///
+            /// The method requires `&mut self`, so callers must ensure
+            /// exclusive access when invoking it. Concurrent calls from
+            /// multiple threads must be synchronized externally (for example,
+            /// with a `Mutex`).
             pub fn close(&mut self);
         }
     }


### PR DESCRIPTION
## Summary
- Documents idempotent close() behavior for file and rotating handlers
- Updates user guide to mention close() is idempotent and safe to call multiple times

## Changes

### Documentation
- Update docs/users-guide.md to explicitly state that FileHandler.close() is idempotent and safe to call multiple times, and that applications should close the handler on shutdown.

### Code Documentation
- Add doc comments indicating idempotent behavior to:
  - FemtoFileHandler::close
  - FemtoRotatingFileHandler::close

### Rationale
- Improves clarity and safety for users integrating with the Rust extension; prevents assumptions about shutdown semantics.

## Test plan
- [ ] Build the project to ensure compilation succeeds
- [ ] Review generated docs to confirm close() idempotency notes are present
- [ ] (Optional) Run documentation generation if applicable in your workflow

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/4c974492-b0b0-484f-8a0f-67600c1f0818

📝 Closes #219

## Summary by Sourcery

Document idempotent close() behavior for file-based logging handlers and clarify their shutdown semantics.

Enhancements:
- Add Rust doc comments to FemtoFileHandler::close and FemtoRotatingFileHandler::close to describe their idempotent shutdown behavior.

Documentation:
- Clarify in the user guide that file and rotating file handler close() is idempotent, safe to call multiple times, and should be invoked on application shutdown.