### PR TITLE
Remove allow attributes from file module

### DIFF
--- a/rust_extension/src/handlers/file/mod.rs
+++ b/rust_extension/src/handlers/file/mod.rs
@@ -12,11 +12,6 @@
 //!
 //! The flush interval must be greater than zero. A value of 1 flushes on every
 //! record.
-#![allow(
-    clippy::too_many_arguments,
-    reason = "PyO3 macro-generated wrappers expand Python-call signatures"
-)]
-
 mod builder_options;
 mod config;
 mod handler_impl;
@@ -67,10 +62,6 @@ pub struct FemtoFileHandler {
     overflow_policy: OverflowPolicy,
 }
 
-#[allow(
-    clippy::too_many_arguments,
-    reason = "PyO3 generates Python-facing wrappers that must preserve constructor parameters"
-)]
 #[pymethods]
 impl FemtoFileHandler {
     /// Create a file handler writing to `path`.


### PR DESCRIPTION
## Summary
- Remove clippy::too_many_arguments allow suppressions in rust_extension/src/handlers/file/mod.rs
- No replacement attributes added in this patch; lint warnings will surface in CI

## Changes
- rust_extension/src/handlers/file/mod.rs
  - Removed the global crate-level `#![allow(
      clippy::too_many_arguments,
      reason = "PyO3 macro-generated wrappers expand Python-call signatures"
  )]` attribute
  - Removed the per-item `#[allow(
      clippy::too_many_arguments,
      reason = "PyO3 generates Python-facing wrappers that must preserve constructor parameters"
  )]` attribute before `impl FemtoFileHandler`

## Rationale
- Avoid silencing lint warnings; surfacing issues earlier helps maintain code quality
- Aligns with standard Clippy expectations and keeps PyO3-related constructor handling visible to the linter

## Test plan
- cargo build
- cargo test
- CI should surface any lint warnings previously silenced by the attributes; ensure no behavioral changes


◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/29e65f2c-d173-49ef-b3ca-cb065749397c

## Summary by Sourcery

Remove Clippy suppression attributes for too_many_arguments in the file handler module to allow lint warnings to surface.

Enhancements:
- Stop globally allowing clippy::too_many_arguments in the file handler module by removing the crate-level attribute.
- Remove the per-impl clippy::too_many_arguments allow on FemtoFileHandler to align with standard linting.