### PR TITLE
Align roadmap with the roadmap grammar

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -206,25 +206,25 @@ where applicable.
   filters. See
   [ADR 003 decision outcome](./adr-003-python-stdlib-filter-parity.md#decision-outcome--proposed-direction)
   and [configuration design §1.1.1](./configuration-design.md#111-filters).
-- [x] 3.2.5.1. Implement and verify producer-path callback filters:
-  execute Python callback filters on the producer path and persist accepted
-  enrichments in Rust-owned metadata. Completion criteria: unit tests confirm
-  accepted enrichment persistence on records that pass filtering. See
-  [ADR 003 phase 1](./adr-003-python-stdlib-filter-parity.md#phase-1-producer-path-callback-filter-support)
-  and [configuration design §1.1.1](./configuration-design.md#111-filters).
-- [x] 3.2.5.2. Implement `dictConfig` filter factory parsing for `"()"` with
-  ADR 003 conflict rejection semantics for mixed declarative/factory forms.
-  Completion criteria: parser tests cover accepted factory declarations and
-  rejected mixed or ambiguous forms. See
-  [ADR 003 phase 2](./adr-003-python-stdlib-filter-parity.md#phase-2-configuration-parity-expansion)
-  and [configuration design §2.2](./configuration-design.md#22-dictconfig).
-- [x] 3.2.5.3. Add integration and concurrency tests for contextvar enrichment
-  propagation and thread/async safety. Completion criteria: CI remains green
-  with reproducible tests that prove propagation under concurrent and async
-  execution paths. See
-  [ADR 003 phase 3](./adr-003-python-stdlib-filter-parity.md#phase-3-conformance-and-hardening)
-  and
-  [configuration design §7](./configuration-design.md#7-testing-and-benchmarking-coverage).
+  - [x] 3.2.5.1. Implement and verify producer-path callback filters:
+    execute Python callback filters on the producer path and persist accepted
+    enrichments in Rust-owned metadata. Completion criteria: unit tests confirm
+    accepted enrichment persistence on records that pass filtering. See
+    [ADR 003 phase 1](./adr-003-python-stdlib-filter-parity.md#phase-1-producer-path-callback-filter-support)
+    and [configuration design §1.1.1](./configuration-design.md#111-filters).
+  - [x] 3.2.5.2. Implement `dictConfig` filter factory parsing for `"()"` with
+    ADR 003 conflict rejection semantics for mixed declarative/factory forms.
+    Completion criteria: parser tests cover accepted factory declarations and
+    rejected mixed or ambiguous forms. See
+    [ADR 003 phase 2](./adr-003-python-stdlib-filter-parity.md#phase-2-configuration-parity-expansion)
+    and [configuration design §2.2](./configuration-design.md#22-dictconfig).
+  - [x] 3.2.5.3. Add integration and concurrency tests for contextvar enrichment
+    propagation and thread/async safety. Completion criteria: CI remains green
+    with reproducible tests that prove propagation under concurrent and async
+    execution paths. See
+    [ADR 003 phase 3](./adr-003-python-stdlib-filter-parity.md#phase-3-conformance-and-hardening)
+    and
+    [configuration design §7](./configuration-design.md#7-testing-and-benchmarking-coverage).
 
 ### 3.3. Rust ecosystem integration
 


### PR DESCRIPTION
## Summary

This branch aligns [docs/roadmap.md](https://github.com/leynos/femtologging/blob/docs/roadmap-syntax/docs/roadmap.md) with the mapsplice roadmap grammar. Tasks 3.2.5.1, 3.2.5.2, and 3.2.5.3 carry four-part addendum numbers but sat at step level, which the grammar checker rejects ("expected a task prefix"); the grammar requires four-part-numbered items to be nested sub-tasks. They are now indented, together with their continuation lines, so they nest under task 3.2.5. Numbering, wording, ordering, and checkbox states are unchanged.

## Review walkthrough

- Start with [docs/roadmap.md](https://github.com/leynos/femtologging/blob/docs/roadmap-syntax/docs/roadmap.md) at step 3.2 — the only change is the two-space indentation of the 3.2.5.x block; the diff is whitespace-only.
- [docs/configuration-roadmap.md](https://github.com/leynos/femtologging/blob/docs/roadmap-syntax/docs/configuration-roadmap.md) is deliberately unchanged — see Notes.

## Validation

- `mapsplice append docs/roadmap.md <dummy-phase>`: exit 0 (grammar-clean)
- `bunx markdownlint-cli2 docs/roadmap.md`: 0 errors

## Notes

- [docs/configuration-roadmap.md](https://github.com/leynos/femtologging/blob/docs/roadmap-syntax/docs/configuration-roadmap.md) fails the checker ("roadmap must contain at least one numbered phase"), but it is a two-sentence pointer stating it has been merged into the consolidated roadmap; it contains no phases, steps, or tasks. Making it parse would mean fabricating roadmap content, so as a superseded tombstone it was left outwith the audit.
- Rebased onto `origin/main`. `main` had normalised the stray leading space on the `and [configuration design …]` continuation lines; that normalisation is preserved, and the branch's diff against `main` is now exactly the two-space nesting of the 3.2.5.x block with clean four-space continuation indents.

## References

- Lody session: https://lody.ai/leynos/sessions/e74eaccf-26d0-45ad-86e9-de5c827c6668
