### PR TITLE
Align Dependabot coverage with the estate baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,8 +36,16 @@ updates:
     labels:
       - "dependencies"
       - "python"
+      - "pip"
     schedule:
       interval: "daily"
     cooldown:
       default-days: 7
       semver-major-days: 14
+  - package-ecosystem: rust-toolchain
+    directory: /
+    labels:
+      - dependencies
+      - rust-toolchain
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary

This branch applies Wave 1 of the Rust estate baseline remediation
(Operation Parabellum, phase 2). It aligns
[.github/dependabot.yml](https://github.com/leynos/femtologging/blob/parabellum-wave-1/.github/dependabot.yml)
with the canonical Dependabot reference: one update stanza per package
ecosystem the repository uses (`cargo`, `rust-toolchain`, `pip`, `github-actions`), each stanza labelled
`dependencies` plus its channel label, and GitHub Actions updates batched
into a single pull request via a wildcard group.

## Review walkthrough

- Start with
  [.github/dependabot.yml](https://github.com/leynos/femtologging/blob/parabellum-wave-1/.github/dependabot.yml)
  for the ecosystem coverage and labels.

## Validation

- Audited the amended tree with the Concordat rule packages
  `dependabot-baseline` and `rust-dev-fast-baseline`: `dependabot-baseline` compliant, `rust-dev-fast-baseline` indeterminate.

## Notes

- The canonical labels (including the Dependabot channel labels this
  configuration references) were created on the repository ahead of this
  pull request, so no stanza names a missing label.

## Summary by Sourcery

Align Dependabot configuration with the estate baseline by expanding ecosystem coverage and refining labels.

New Features:
- Add Dependabot update configuration for the rust-toolchain ecosystem with a weekly schedule.

Enhancements:
- Tag Python package updates with an explicit pip label to match canonical dependency channel labelling.